### PR TITLE
fix(api): always allow all origins on public /v1 endpoints

### DIFF
--- a/apps/api/src/cors.test.ts
+++ b/apps/api/src/cors.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import app from "./index";
+
+const env = {
+	vars: { DASHBOARD_URL: "https://dash.example.com" },
+} as unknown as Parameters<typeof app.request>[2];
+
+function preflight(path: string, origin: string) {
+	return app.request(
+		path,
+		{
+			method: "OPTIONS",
+			headers: {
+				Origin: origin,
+				"Access-Control-Request-Method": "POST",
+				"Access-Control-Request-Headers": "content-type",
+			},
+		},
+		env,
+	);
+}
+
+describe("/v1/* public widget CORS", () => {
+	it("allows arbitrary origins unconditionally (ACAO: *)", async () => {
+		for (const origin of [
+			"https://some-random-customer.com",
+			"http://localhost:5500",
+			"https://evil.example",
+			"https://llmchat-showcase---preview.meetploy.app",
+		]) {
+			const res = await preflight("/v1/chat", origin);
+			expect(res.headers.get("access-control-allow-origin")).toBe("*");
+		}
+	});
+
+	it("is non-credentialed (so ACAO: * is valid)", async () => {
+		const res = await preflight("/v1/messages", "https://anything.example");
+		expect(res.headers.get("access-control-allow-credentials")).toBeNull();
+	});
+});
+
+describe("/api/* dashboard CORS stays pinned", () => {
+	it("allows only DASHBOARD_URL, with credentials", async () => {
+		const ok = await preflight("/api/projects", "https://dash.example.com");
+		expect(ok.headers.get("access-control-allow-origin")).toBe(
+			"https://dash.example.com",
+		);
+		expect(ok.headers.get("access-control-allow-credentials")).toBe("true");
+	});
+
+	it("rejects other origins", async () => {
+		const bad = await preflight("/api/projects", "https://evil.com");
+		expect(bad.headers.get("access-control-allow-origin")).toBeNull();
+	});
+});

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -2,7 +2,7 @@ import { Hono } from "hono";
 import { cors } from "hono/cors";
 
 import { createAuth } from "@/auth";
-import { allowWidgetOrigin, isAllowedOrigin } from "@/lib/origins";
+import { isAllowedOrigin } from "@/lib/origins";
 import { billing } from "@/routes/billing";
 import { chat } from "@/routes/chat";
 import { conversations } from "@/routes/conversations";
@@ -28,11 +28,16 @@ app.use(
 	}),
 );
 
+// Public widget endpoints: allow ALL origins, unconditionally. The widget is a
+// public embed that must load on any customer site, and these routes are
+// non-credentialed, so `Access-Control-Allow-Origin: *` is valid. This does NOT
+// read WIDGET_ALLOWED_ORIGINS — the env-based gate is gone for /v1/*.
+// Per-PROJECT domain restriction (future) is enforced separately server-side
+// (against the request's project), not via this global CORS gate.
 app.use(
 	"/v1/*",
 	cors({
-		origin: (origin, c) =>
-			allowWidgetOrigin(origin, c.env.vars.WIDGET_ALLOWED_ORIGINS),
+		origin: "*",
 		credentials: false,
 	}),
 );

--- a/apps/api/src/lib/origins.test.ts
+++ b/apps/api/src/lib/origins.test.ts
@@ -1,9 +1,8 @@
 import { describe, expect, it } from "vitest";
 
-import { allowWidgetOrigin, isAllowedOrigin } from "./origins";
+import { isAllowedOrigin } from "./origins";
 
 const DASH = "https://llmchat-dashboard.meetploy.app";
-const SHOWCASE = "https://llmchat-showcase.meetploy.app";
 
 describe("isAllowedOrigin", () => {
 	it("allows the canonical dashboard origin", () => {
@@ -81,81 +80,8 @@ describe("isAllowedOrigin", () => {
 	});
 });
 
-describe("allowWidgetOrigin", () => {
-	it('treats "*" as allow-all, returning a literal * for any origin', () => {
-		expect(allowWidgetOrigin("https://customer.com", "*")).toBe("*");
-		expect(allowWidgetOrigin("https://anything.example", "*")).toBe("*");
-		expect(allowWidgetOrigin(undefined, "*")).toBe("*");
-		// "*" anywhere in the list still allows all
-		expect(allowWidgetOrigin("https://x.com", "https://a.com, *")).toBe("*");
-	});
-
-	it("falls open (reflects the origin) when the list is empty or unset", () => {
-		expect(allowWidgetOrigin("https://customer.com", "")).toBe(
-			"https://customer.com",
-		);
-		expect(allowWidgetOrigin("https://customer.com", undefined)).toBe(
-			"https://customer.com",
-		);
-		expect(allowWidgetOrigin(undefined, "")).toBe("*");
-	});
-
-	it("allows listed origins and their Ploy previews", () => {
-		const csv = `${SHOWCASE}, https://customer.com`;
-		expect(allowWidgetOrigin(SHOWCASE, csv)).toBe(SHOWCASE);
-		expect(allowWidgetOrigin("https://customer.com", csv)).toBe(
-			"https://customer.com",
-		);
-		expect(
-			allowWidgetOrigin("https://llmchat-showcase---iframe.meetploy.app", csv),
-		).toBe("https://llmchat-showcase---iframe.meetploy.app");
-		expect(
-			allowWidgetOrigin("https://llmchat-showcase--b9a8691.meetploy.app", csv),
-		).toBe("https://llmchat-showcase--b9a8691.meetploy.app");
-	});
-
-	it("rejects origins not in the list", () => {
-		const csv = `${SHOWCASE}, https://customer.com`;
-		expect(allowWidgetOrigin("https://evil.com", csv)).toBe(null);
-		expect(allowWidgetOrigin("https://other.meetploy.app", csv)).toBe(null);
-		expect(allowWidgetOrigin(undefined, csv)).toBe(null);
-	});
-});
-
 describe("configured value normalization", () => {
 	it("tolerates trailing slashes in configured origins", () => {
 		expect(isAllowedOrigin(DASH, `${DASH}/`)).toBe(true);
-		expect(allowWidgetOrigin(SHOWCASE, `${SHOWCASE}/`)).toBe(SHOWCASE);
-		expect(
-			allowWidgetOrigin(
-				"https://llmchat-showcase---iframe.meetploy.app",
-				`${SHOWCASE}/`,
-			),
-		).toBe("https://llmchat-showcase---iframe.meetploy.app");
-	});
-});
-
-describe("allowWidgetOrigin with unusable config", () => {
-	it("ignores unsubstituted env references and falls back to open", () => {
-		expect(
-			allowWidgetOrigin("https://customer.com", "$WIDGET_ALLOWED_ORIGINS"),
-		).toBe("https://customer.com");
-	});
-
-	it("ignores junk entries but keeps valid ones restrictive", () => {
-		const csv = "$WIDGET_ALLOWED_ORIGINS, https://customer.com";
-		expect(allowWidgetOrigin("https://customer.com", csv)).toBe(
-			"https://customer.com",
-		);
-		expect(allowWidgetOrigin("https://evil.com", csv)).toBe(null);
-	});
-
-	it("rejects non-http(s) schemes as entries", () => {
-		expect(allowWidgetOrigin("https://x.com", "javascript:alert(1)")).toBe(
-			"https://x.com",
-		);
-		expect(allowWidgetOrigin("file:///etc/passwd", "file://")).toBe(
-			"file:///etc/passwd",
-		);
 	});
 });

--- a/apps/api/src/lib/origins.ts
+++ b/apps/api/src/lib/origins.ts
@@ -45,47 +45,7 @@ export function isAllowedOrigin(
 	);
 }
 
-function isUsableOriginEntry(entry: string): boolean {
-	try {
-		const url = new URL(entry);
-		return url.protocol === "http:" || url.protocol === "https:";
-	} catch {
-		return false;
-	}
-}
-
-/**
- * The /v1 widget CORS policy. `allowedCsv` is the WIDGET_ALLOWED_ORIGINS env
- * value. An explicit "*" allows ALL sites and returns a literal `*` (a single
- * cacheable `Access-Control-Allow-Origin: *`, valid because /v1/* is
- * non-credentialed). A comma-separated list restricts to those origins and
- * their Ploy previews, reflecting the matched origin. Returns the value to
- * echo in access-control-allow-origin, or null to reject.
- *
- * Entries that aren't parseable http(s) urls are ignored — e.g. an
- * unsubstituted `$WIDGET_ALLOWED_ORIGINS` reference when the deployment
- * secret was never created. A list with no usable entries falls open
- * (reflects the origin): this endpoint is credential-less and public by
- * design, so a broken allowlist must not silently brick every embed.
- */
-export function allowWidgetOrigin(
-	origin: string | undefined,
-	allowedCsv: string | undefined,
-): string | null {
-	const entries = (allowedCsv ?? "")
-		.split(",")
-		.map((s) => s.trim())
-		.filter(Boolean);
-	// Explicit allow-all: one cacheable `ACAO: *` for every site rather than
-	// reflecting each origin.
-	if (entries.includes("*")) {
-		return "*";
-	}
-	const list = entries.filter(isUsableOriginEntry);
-	if (list.length === 0) {
-		return origin ?? "*";
-	}
-	return list.some((entry) => isAllowedOrigin(origin, entry))
-		? (origin ?? null)
-		: null;
-}
+// NOTE: the public /v1/* widget endpoints intentionally have NO origin
+// allowlist — they allow all origins unconditionally (see the CORS wiring in
+// src/index.ts). `isAllowedOrigin` above is only for the credentialed /api/*
+// dashboard routes and Better Auth CSRF trust.


### PR DESCRIPTION
## Summary

Makes the public `/v1/*` widget endpoints allow **all** origins unconditionally, independent of any env var — so the deployed app no longer depends on the stale dashboard-set `WIDGET_ALLOWED_ORIGINS` value that was CORS-blocking the live widget.

- `/v1/*` CORS now returns `Access-Control-Allow-Origin: *` for every origin (non-credentialed, so `*` is valid). It no longer reads `WIDGET_ALLOWED_ORIGINS`.
- `/api/*` dashboard CORS is **unchanged** — still pinned to `DASHBOARD_URL` with credentials.
- Removed the now-dead `allowWidgetOrigin` gate; kept `isAllowedOrigin` for `/api/*` + Better Auth CSRF trust.
- Per-PROJECT domain restriction (future) is to be enforced separately server-side against the request's project, not via this global CORS gate (noted in code).

## Why

The widget is a public embed that must load on arbitrary customer sites. On Ploy, deployed env comes from the dashboard, not the `ploy.yaml` literal, so the committed `WIDGET_ALLOWED_ORIGINS: "*"` only affected local dev — the deployed value stayed restrictive and blocked every origin. Dropping the gate removes that operational dependency entirely.

## Test plan

- New `apps/api/src/cors.test.ts` (app-level via `app.request`): `/v1/chat` + `/v1/messages` preflights from arbitrary origins (random customer, localhost, evil, preview) all return `ACAO: *` and are non-credentialed; `/api/projects` allows only `DASHBOARD_URL` with credentials and rejects others.
- `pnpm test` (api 36), `pnpm lint`, `pnpm format`, api typecheck — all clean on top of latest `main`.
- **Verified live** on the branch preview: `/v1/*` preflight + POST + GET return `ACAO: *` for arbitrary origins; `/api/*` still rejects `evil.com` and allows the canonical dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)