### PR TITLE
fix(widget): floating launcher + UX/UI polish

### DIFF
--- a/apps/dashboard/src/app/settings/projects/[id]/EmbedCard.tsx
+++ b/apps/dashboard/src/app/settings/projects/[id]/EmbedCard.tsx
@@ -42,18 +42,19 @@ export function EmbedCard({
 			description="Copy this code and paste it into your website to add the chatbot."
 		>
 			<div className="grid min-w-0 gap-6 lg:grid-cols-2">
-				{/* Embed code */}
+				{/* Embed code — floating bubble is the recommended default */}
 				<div className="flex min-w-0 flex-col gap-3">
 					<div className="space-y-0.5">
 						<h3 className="text-sm font-medium text-foreground">Embed code</h3>
 						<p className="text-sm text-muted-foreground">
-							Paste this iframe into your website HTML where you want the
-							chatbot to appear.
+							Paste this before{" "}
+							<code className="font-mono text-xs">&lt;/body&gt;</code> — a
+							floating chat button appears in the bottom-right of every page.
 						</p>
 					</div>
-					<CodeBlock code={iframeCode} />
+					<CodeBlock code={scriptCode} />
 					<div className="flex flex-wrap items-center gap-2">
-						<CopyButton value={iframeCode}>Copy iframe code</CopyButton>
+						<CopyButton value={scriptCode}>Copy embed code</CopyButton>
 						<Button type="button" variant="outline" size="sm" asChild>
 							<a href={url} target="_blank" rel="noreferrer">
 								Open preview
@@ -63,16 +64,16 @@ export function EmbedCard({
 					</div>
 					<details className="group">
 						<summary className="cursor-pointer text-sm font-medium text-muted-foreground transition-colors hover:text-foreground">
-							Alternative script tag
+							Alternative: inline iframe
 						</summary>
 						<div className="mt-3 flex min-w-0 flex-col gap-3">
 							<p className="text-sm text-muted-foreground">
-								Floating chat bubble on every page — paste before{" "}
-								<code className="font-mono text-xs">&lt;/body&gt;</code>.
+								Renders the chat as a fixed-size panel in the page flow where
+								you place it, instead of a floating button.
 							</p>
-							<CodeBlock code={scriptCode} />
-							<CopyButton value={scriptCode} className="self-start">
-								Copy script tag
+							<CodeBlock code={iframeCode} />
+							<CopyButton value={iframeCode} className="self-start">
+								Copy iframe code
 							</CopyButton>
 						</div>
 					</details>
@@ -104,9 +105,9 @@ export function EmbedCard({
 							<Lightbulb className="size-4" />
 						</span>
 						<p className="text-sm text-indigo-950/80 dark:text-indigo-200/90">
-							<span className="font-semibold">Tip:</span> For most websites,
-							paste this iframe where you want the chatbot to appear. Later, you
-							can replace it with a floating widget script.
+							<span className="font-semibold">Tip:</span> For most websites, use
+							the floating embed code — it adds the chat button site-wide. Use
+							the inline iframe only when you want the chat fixed in one spot.
 						</p>
 					</div>
 				</div>

--- a/packages/widget/src/ShowcaseChat.test.tsx
+++ b/packages/widget/src/ShowcaseChat.test.tsx
@@ -22,7 +22,7 @@ afterEach(() => {
 async function sendMessage(text: string) {
 	const textarea = screen.getByPlaceholderText(/type a message/i);
 	await userEvent.type(textarea, text);
-	await userEvent.click(screen.getByRole("button", { name: "Send" }));
+	await userEvent.click(screen.getByRole("button", { name: "Send message" }));
 }
 
 describe("ShowcaseChat", () => {

--- a/packages/widget/src/components/Composer.test.tsx
+++ b/packages/widget/src/components/Composer.test.tsx
@@ -22,7 +22,7 @@ describe("Composer", () => {
 	it("does not submit whitespace-only input", async () => {
 		const { onSubmit } = setup({ value: "   " });
 		await userEvent.keyboard("{Enter}");
-		expect(screen.getByRole("button", { name: "Send" })).toBeDisabled();
+		expect(screen.getByRole("button", { name: "Send message" })).toBeDisabled();
 		expect(onSubmit).not.toHaveBeenCalled();
 	});
 
@@ -31,7 +31,7 @@ describe("Composer", () => {
 		const textarea = screen.getByPlaceholderText(/type a message/i);
 		await userEvent.type(textarea, "{Enter}");
 		expect(onSubmit).not.toHaveBeenCalled();
-		expect(screen.getByRole("button", { name: "Send" })).toBeDisabled();
+		expect(screen.getByRole("button", { name: "Send message" })).toBeDisabled();
 	});
 
 	it("submits on Enter but not Shift+Enter", async () => {

--- a/packages/widget/src/components/Composer.tsx
+++ b/packages/widget/src/components/Composer.tsx
@@ -1,3 +1,5 @@
+import { SendIcon } from "./icons";
+
 export function Composer({
 	value,
 	disabled,
@@ -28,6 +30,7 @@ export function Composer({
 			<textarea
 				rows={1}
 				value={value}
+				aria-label="Message"
 				onChange={(e) => onChange(e.target.value)}
 				onKeyDown={(e) => {
 					if (e.key === "Enter" && !e.shiftKey) {
@@ -37,8 +40,13 @@ export function Composer({
 				}}
 				placeholder="Type a message…"
 			/>
-			<button type="submit" disabled={!value.trim() || disabled}>
-				Send
+			<button
+				type="submit"
+				className="llmchat-send"
+				disabled={!value.trim() || disabled}
+				aria-label="Send message"
+			>
+				<SendIcon />
 			</button>
 		</form>
 	);

--- a/packages/widget/src/components/EscalationSection.tsx
+++ b/packages/widget/src/components/EscalationSection.tsx
@@ -1,3 +1,5 @@
+import { AgentIcon } from "./icons";
+
 export function EscalationSection({
 	pending,
 	failed,
@@ -10,6 +12,7 @@ export function EscalationSection({
 	return (
 		<div className="llmchat-escalate">
 			<button type="button" onClick={onEscalate} disabled={pending}>
+				<AgentIcon />
 				{pending ? "Sending…" : "Talk to a human"}
 			</button>
 			{failed && (

--- a/packages/widget/src/components/IdentifyForm.tsx
+++ b/packages/widget/src/components/IdentifyForm.tsx
@@ -22,19 +22,31 @@ export function IdentifyForm({
 			}}
 			className="llmchat-identify"
 		>
-			<p>Welcome! Tell us who you are.</p>
-			<input
-				required
-				placeholder="Your name"
-				value={name}
-				onChange={(e) => onNameChange(e.target.value)}
-			/>
-			<input
-				type="email"
-				placeholder="Email (optional)"
-				value={email}
-				onChange={(e) => onEmailChange(e.target.value)}
-			/>
+			<div className="llmchat-identify-intro">
+				<h2 className="llmchat-identify-title">Welcome 👋</h2>
+				<p className="llmchat-identify-sub">
+					Tell us who you are and we'll get the conversation started.
+				</p>
+			</div>
+			<label className="llmchat-field">
+				<span className="llmchat-field-label">Name</span>
+				<input
+					required
+					autoFocus
+					placeholder="Your name"
+					value={name}
+					onChange={(e) => onNameChange(e.target.value)}
+				/>
+			</label>
+			<label className="llmchat-field">
+				<span className="llmchat-field-label">Email (optional)</span>
+				<input
+					type="email"
+					placeholder="you@example.com"
+					value={email}
+					onChange={(e) => onEmailChange(e.target.value)}
+				/>
+			</label>
 			<button type="submit">Start chat</button>
 		</form>
 	);

--- a/packages/widget/src/components/MessageList.tsx
+++ b/packages/widget/src/components/MessageList.tsx
@@ -36,7 +36,16 @@ export function MessageList({
 					</div>
 				) : null,
 			)}
-			{typing && <div className="llmchat-typing">…</div>}
+			{typing && (
+				<div
+					className="llmchat-msg llmchat-msg-assistant llmchat-typing"
+					aria-label="Assistant is typing"
+				>
+					<span className="llmchat-dot" />
+					<span className="llmchat-dot" />
+					<span className="llmchat-dot" />
+				</div>
+			)}
 			{error !== null && (
 				<div className="llmchat-error" role="alert">
 					{error}

--- a/packages/widget/src/components/WidgetFrame.test.tsx
+++ b/packages/widget/src/components/WidgetFrame.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { WidgetFrame } from "./WidgetFrame";
+
+function renderFrame(props: Partial<React.ComponentProps<typeof WidgetFrame>>) {
+	const onOpenChange = vi.fn();
+	render(
+		<WidgetFrame
+			inline={false}
+			brandColor="#4f46e5"
+			open={false}
+			onOpenChange={onOpenChange}
+			{...props}
+		>
+			<p>panel body</p>
+		</WidgetFrame>,
+	);
+	return { onOpenChange };
+}
+
+describe("WidgetFrame — floating bubble layout", () => {
+	it("is collapsed by default: shows only the launcher, hides the panel", () => {
+		renderFrame({ open: false });
+		expect(
+			screen.getByRole("button", { name: /open chat/i }),
+		).toBeInTheDocument();
+		expect(screen.queryByText("panel body")).not.toBeInTheDocument();
+	});
+
+	it("opens the panel when the launcher is clicked", async () => {
+		const { onOpenChange } = renderFrame({ open: false });
+		await userEvent.click(screen.getByRole("button", { name: /open chat/i }));
+		expect(onOpenChange).toHaveBeenCalledWith(true);
+	});
+
+	it("reveals the panel content once open", () => {
+		renderFrame({ open: true });
+		expect(screen.getByText("panel body")).toBeInTheDocument();
+	});
+});
+
+describe("WidgetFrame — inline layout", () => {
+	it("has no launcher and always shows the panel", () => {
+		renderFrame({ inline: true, open: true });
+		expect(
+			screen.queryByRole("button", { name: /open chat/i }),
+		).not.toBeInTheDocument();
+		expect(screen.getByText("panel body")).toBeInTheDocument();
+	});
+});

--- a/packages/widget/src/components/WidgetFrame.tsx
+++ b/packages/widget/src/components/WidgetFrame.tsx
@@ -1,10 +1,23 @@
+import { useEffect, useRef, useState } from "react";
+
+import { ChatIcon, CloseIcon } from "./icons";
+
 import type { ReactNode } from "react";
+
+const EXIT_MS = 180;
+
+function prefersReducedMotion(): boolean {
+	return (
+		typeof window !== "undefined" &&
+		(window.matchMedia?.("(prefers-reduced-motion: reduce)")?.matches ?? false)
+	);
+}
 
 /**
  * Shared chrome for every widget variant: the floating launcher bubble (in
  * bubble layout), the panel, and the branded header. Conversation behavior is
- * composed in via children — live and showcase variants render different
- * children inside the same frame.
+ * composed in via children. Owns the open/close transition, Esc-to-close, and
+ * focus management; conversation logic stays in the variant components.
  */
 export function WidgetFrame({
 	inline,
@@ -22,35 +35,94 @@ export function WidgetFrame({
 	badge?: ReactNode;
 	children: ReactNode;
 }) {
+	const launcherRef = useRef<HTMLButtonElement>(null);
+	const panelRef = useRef<HTMLDivElement>(null);
+	// Keep the panel mounted through its exit animation (bubble layout only).
+	const [mounted, setMounted] = useState(open);
+	const wasOpen = useRef(open);
+
+	useEffect(() => {
+		if (open) {
+			setMounted(true);
+			return;
+		}
+		if (inline || prefersReducedMotion()) {
+			setMounted(false);
+			return;
+		}
+		const t = setTimeout(() => setMounted(false), EXIT_MS);
+		return () => clearTimeout(t);
+	}, [open, inline]);
+
+	// Move focus into the panel when it opens; return it to the launcher when it
+	// closes — but never steal focus on the initial (closed) page load.
+	useEffect(() => {
+		if (inline) {
+			return;
+		}
+		if (open) {
+			panelRef.current?.focus();
+		} else if (wasOpen.current) {
+			launcherRef.current?.focus();
+		}
+		wasOpen.current = open;
+	}, [open, inline]);
+
+	const showPanel = inline || mounted;
+	const closing = !inline && mounted && !open;
+
 	return (
 		<div className="llmchat" style={{ ["--brand" as string]: brandColor }}>
 			{!inline && (
 				<button
+					ref={launcherRef}
 					type="button"
-					className="llmchat-bubble"
+					className={`llmchat-bubble${open ? " llmchat-bubble--open" : ""}`}
 					onClick={() => onOpenChange(!open)}
 					aria-label={open ? "Close chat" : "Open chat"}
+					aria-expanded={open}
 				>
-					{open ? "×" : "💬"}
+					<span className="llmchat-bubble-icon">
+						{open ? <CloseIcon /> : <ChatIcon />}
+					</span>
 				</button>
 			)}
-			{open && (
+			{showPanel && (
 				<div
-					className={
-						inline ? "llmchat-panel llmchat-panel-inline" : "llmchat-panel"
-					}
+					ref={panelRef}
+					tabIndex={-1}
 					role={inline ? undefined : "dialog"}
+					aria-label="Support chat"
+					className={[
+						"llmchat-panel",
+						inline ? "llmchat-panel-inline" : "",
+						closing ? "llmchat-panel--closing" : "",
+					]
+						.filter(Boolean)
+						.join(" ")}
+					onKeyDown={(e) => {
+						if (e.key === "Escape" && !inline) {
+							e.stopPropagation();
+							onOpenChange(false);
+						}
+					}}
 				>
 					<header className="llmchat-header">
-						<span>Support</span>
+						<span className="llmchat-header-id">
+							<span className="llmchat-header-avatar" aria-hidden="true">
+								<ChatIcon />
+							</span>
+							<span className="llmchat-header-text">Support</span>
+						</span>
 						{badge}
 						{!inline && (
 							<button
 								type="button"
+								className="llmchat-icon-btn"
 								onClick={() => onOpenChange(false)}
-								aria-label="Close"
+								aria-label="Close chat"
 							>
-								×
+								<CloseIcon />
 							</button>
 						)}
 					</header>

--- a/packages/widget/src/components/icons.tsx
+++ b/packages/widget/src/components/icons.tsx
@@ -1,0 +1,80 @@
+// Inline SVG icons — kept hand-rolled so the public embed pulls in no icon
+// library. All are decorative; the interactive buttons carry the aria-labels.
+type IconProps = { className?: string };
+
+export function ChatIcon({ className }: IconProps) {
+	return (
+		<svg
+			className={className}
+			width="24"
+			height="24"
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="2"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			aria-hidden="true"
+		>
+			<path d="M21 11.5a8.38 8.38 0 0 1-8.5 8.5 8.5 8.5 0 0 1-3.9-.9L3 21l1.9-5.6a8.5 8.5 0 0 1-.9-3.9A8.38 8.38 0 0 1 12.5 3 8.38 8.38 0 0 1 21 11.5z" />
+		</svg>
+	);
+}
+
+export function CloseIcon({ className }: IconProps) {
+	return (
+		<svg
+			className={className}
+			width="20"
+			height="20"
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="2.2"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			aria-hidden="true"
+		>
+			<path d="M18 6 6 18M6 6l12 12" />
+		</svg>
+	);
+}
+
+export function SendIcon({ className }: IconProps) {
+	return (
+		<svg
+			className={className}
+			width="18"
+			height="18"
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="2"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			aria-hidden="true"
+		>
+			<path d="M22 2 11 13M22 2l-7 20-4-9-9-4 20-7z" />
+		</svg>
+	);
+}
+
+export function AgentIcon({ className }: IconProps) {
+	return (
+		<svg
+			className={className}
+			width="16"
+			height="16"
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="2"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			aria-hidden="true"
+		>
+			<path d="M3 18v-2a4 4 0 0 1 4-4h2M21 18v-2a4 4 0 0 0-4-4h-2" />
+			<circle cx="12" cy="7" r="4" />
+		</svg>
+	);
+}

--- a/packages/widget/src/styles.ts
+++ b/packages/widget/src/styles.ts
@@ -10,6 +10,20 @@ export const widgetStyles = `
 		Segoe UI,
 		sans-serif;
 	color: #111827;
+	/* Pin inherited properties so the host page's typography can't leak across
+	   the shadow boundary and distort the widget. */
+	line-height: 1.5;
+	font-size: 16px;
+	letter-spacing: normal;
+	text-align: left;
+}
+
+/* Reset box model for every widget element so the host page's global styles
+   (e.g. a content-box universal selector) can't change our layout. */
+.llmchat *,
+.llmchat *::before,
+.llmchat *::after {
+	box-sizing: border-box;
 }
 
 .llmchat-bubble {

--- a/packages/widget/src/styles.ts
+++ b/packages/widget/src/styles.ts
@@ -26,126 +26,321 @@ export const widgetStyles = `
 	box-sizing: border-box;
 }
 
+/* ── Floating launcher ─────────────────────────────────────────────── */
 .llmchat-bubble {
 	position: fixed;
-	bottom: 1rem;
-	right: 1rem;
-	width: 3rem;
-	height: 3rem;
+	bottom: 1.25rem;
+	right: 1.25rem;
+	width: 3.5rem;
+	height: 3.5rem;
+	display: flex;
+	align-items: center;
+	justify-content: center;
 	border-radius: 9999px;
 	background: var(--brand);
 	color: #fff;
 	border: none;
 	cursor: pointer;
-	box-shadow: 0 6px 20px rgba(0, 0, 0, 0.18);
-	font-size: 1.25rem;
+	box-shadow:
+		0 8px 24px -6px rgba(0, 0, 0, 0.4),
+		0 2px 6px rgba(0, 0, 0, 0.18);
 	z-index: 2147483646;
+	transition:
+		transform 0.18s cubic-bezier(0.16, 1, 0.3, 1),
+		box-shadow 0.18s ease;
+}
+.llmchat-bubble:hover {
+	transform: translateY(-2px) scale(1.04);
+	box-shadow:
+		0 12px 28px -6px rgba(0, 0, 0, 0.45),
+		0 3px 8px rgba(0, 0, 0, 0.2);
+}
+.llmchat-bubble:active {
+	transform: scale(0.95);
+}
+.llmchat-bubble:focus-visible {
+	outline: none;
+	box-shadow:
+		0 0 0 3px #fff,
+		0 0 0 6px var(--brand);
+}
+.llmchat-bubble-icon {
+	display: flex;
+	animation: llmchat-pop 0.2s ease;
+}
+@keyframes llmchat-pop {
+	from {
+		opacity: 0;
+		transform: scale(0.5) rotate(-12deg);
+	}
+	to {
+		opacity: 1;
+		transform: none;
+	}
 }
 
+/* ── Panel ─────────────────────────────────────────────────────────── */
 .llmchat-panel {
 	position: fixed;
-	bottom: 5rem;
-	right: 1rem;
-	width: 22rem;
-	height: 32rem;
+	bottom: 5.5rem;
+	right: 1.25rem;
+	width: 23rem;
+	max-width: calc(100vw - 2rem);
+	height: 34rem;
+	max-height: calc(100vh - 7rem);
 	background: #fff;
-	border-radius: 0.75rem;
+	border-radius: 1rem;
 	display: flex;
 	flex-direction: column;
-	box-shadow: 0 12px 40px rgba(0, 0, 0, 0.2);
 	overflow: hidden;
+	transform-origin: bottom right;
+	/* Layered shadow + hairline ring so the panel reads on dark host pages. */
+	box-shadow:
+		0 24px 56px -16px rgba(0, 0, 0, 0.45),
+		0 0 0 1px rgba(0, 0, 0, 0.06);
 	z-index: 2147483647;
+	animation: llmchat-panel-in 0.24s cubic-bezier(0.16, 1, 0.3, 1);
+}
+.llmchat-panel--closing {
+	animation: llmchat-panel-out 0.18s ease forwards;
+}
+@keyframes llmchat-panel-in {
+	from {
+		opacity: 0;
+		transform: translateY(14px) scale(0.96);
+	}
+	to {
+		opacity: 1;
+		transform: none;
+	}
+}
+@keyframes llmchat-panel-out {
+	from {
+		opacity: 1;
+		transform: none;
+	}
+	to {
+		opacity: 0;
+		transform: translateY(10px) scale(0.98);
+	}
 }
 
 /* Inline mode: the panel fills its container — the whole viewport on the
-   /embed iframe page (no positioned ancestor), or a position:relative
-   wrapper when mounted in-page (e.g. the showcase demo). */
+   /embed iframe page, or a position:relative wrapper when mounted in-page. */
 .llmchat-panel-inline {
 	position: absolute;
 	inset: 0;
 	width: auto;
+	max-width: none;
 	height: auto;
+	max-height: none;
 	border-radius: 0;
 	box-shadow: none;
+	animation: none;
 }
 
+/* ── Header ────────────────────────────────────────────────────────── */
 .llmchat-header {
 	background: var(--brand);
 	color: #fff;
-	padding: 0.75rem 1rem;
+	padding: 0.875rem 1rem;
 	display: flex;
-	justify-content: space-between;
 	align-items: center;
-	font-weight: 600;
+	gap: 0.5rem;
+	flex-shrink: 0;
 }
-.llmchat-header button {
-	background: none;
+.llmchat-header-id {
+	display: flex;
+	align-items: center;
+	gap: 0.625rem;
+	min-width: 0;
+}
+.llmchat-header-avatar {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 2rem;
+	height: 2rem;
+	border-radius: 9999px;
+	background: rgba(255, 255, 255, 0.22);
+	flex-shrink: 0;
+}
+.llmchat-header-avatar svg {
+	width: 1.05rem;
+	height: 1.05rem;
+}
+.llmchat-header-text {
+	font-weight: 600;
+	font-size: 0.95rem;
+	letter-spacing: 0.01em;
+}
+.llmchat-icon-btn {
+	margin-left: auto;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 2rem;
+	height: 2rem;
+	border-radius: 0.5rem;
+	background: transparent;
 	border: none;
 	color: #fff;
-	font-size: 1.25rem;
 	cursor: pointer;
+	opacity: 0.85;
+	transition:
+		background 0.15s ease,
+		opacity 0.15s ease;
+}
+.llmchat-icon-btn:hover {
+	background: rgba(255, 255, 255, 0.18);
+	opacity: 1;
+}
+.llmchat-icon-btn:focus-visible {
+	outline: none;
+	box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.8);
 }
 
+/* ── Identify form ─────────────────────────────────────────────────── */
 .llmchat-identify {
-	padding: 1.5rem;
+	padding: 1.5rem 1.25rem;
 	display: flex;
 	flex-direction: column;
-	gap: 0.5rem;
+	gap: 1rem;
+}
+.llmchat-identify-intro {
+	display: flex;
+	flex-direction: column;
+	gap: 0.25rem;
+}
+.llmchat-identify-title {
+	margin: 0;
+	font-size: 1.15rem;
+	font-weight: 700;
+}
+.llmchat-identify-sub {
+	margin: 0;
+	font-size: 0.875rem;
+	color: #6b7280;
+}
+.llmchat-field {
+	display: flex;
+	flex-direction: column;
+	gap: 0.3rem;
+}
+.llmchat-field-label {
+	font-size: 0.78rem;
+	font-weight: 600;
+	color: #6b7280;
 }
 .llmchat-identify input,
 .llmchat-input textarea {
+	width: 100%;
 	border: 1px solid #d1d5db;
-	border-radius: 0.5rem;
-	padding: 0.5rem 0.75rem;
+	border-radius: 0.625rem;
+	padding: 0.55rem 0.75rem;
 	font: inherit;
+	font-size: 0.9rem;
+	color: #111827;
+	background: #fff;
 	resize: none;
-	flex: 1;
+	transition:
+		border-color 0.15s ease,
+		box-shadow 0.15s ease;
 }
-.llmchat-identify button,
-.llmchat-input button {
+.llmchat-identify input::placeholder,
+.llmchat-input textarea::placeholder {
+	color: #9ca3af;
+}
+.llmchat-identify input:focus,
+.llmchat-input textarea:focus {
+	outline: none;
+	border-color: var(--brand);
+	box-shadow: 0 0 0 3px color-mix(in srgb, var(--brand) 22%, transparent);
+}
+.llmchat-identify button {
+	margin-top: 0.25rem;
 	background: var(--brand);
 	color: #fff;
 	border: none;
-	border-radius: 0.5rem;
-	padding: 0.5rem 0.75rem;
+	border-radius: 0.625rem;
+	padding: 0.6rem 0.75rem;
 	font: inherit;
+	font-size: 0.9rem;
+	font-weight: 600;
 	cursor: pointer;
+	transition:
+		filter 0.15s ease,
+		transform 0.1s ease;
 }
-.llmchat-identify button:disabled,
-.llmchat-input button:disabled {
+.llmchat-identify button:hover {
+	filter: brightness(1.07);
+}
+.llmchat-identify button:active {
+	transform: translateY(1px);
+}
+.llmchat-identify button:disabled {
 	opacity: 0.5;
+	cursor: default;
 }
 
+/* ── Messages ──────────────────────────────────────────────────────── */
 .llmchat-messages {
 	flex: 1;
 	overflow-y: auto;
-	padding: 0.75rem;
+	padding: 1rem 0.875rem;
 	display: flex;
 	flex-direction: column;
 	gap: 0.5rem;
+	background: #fff;
+	scrollbar-width: thin;
+	scrollbar-color: #d1d5db transparent;
+}
+.llmchat-messages::-webkit-scrollbar {
+	width: 8px;
+}
+.llmchat-messages::-webkit-scrollbar-thumb {
+	background: #d1d5db;
+	border-radius: 9999px;
+	border: 2px solid #fff;
 }
 .llmchat-msg {
 	max-width: 85%;
 	padding: 0.5rem 0.75rem;
 	border-radius: 1rem;
 	font-size: 0.9rem;
-	line-height: 1.4;
+	line-height: 1.45;
 	white-space: pre-wrap;
 	word-break: break-word;
+	animation: llmchat-msg-in 0.18s ease;
+}
+@keyframes llmchat-msg-in {
+	from {
+		opacity: 0;
+		transform: translateY(4px);
+	}
+	to {
+		opacity: 1;
+		transform: none;
+	}
 }
 .llmchat-msg-assistant {
 	background: #f3f4f6;
+	color: #111827;
 	align-self: flex-start;
+	border-bottom-left-radius: 0.25rem;
 }
 .llmchat-msg-user {
 	background: var(--brand);
 	color: #fff;
 	align-self: flex-end;
+	border-bottom-right-radius: 0.25rem;
 }
 .llmchat-msg-admin {
 	background: #ecfdf5;
+	color: #065f46;
 	align-self: flex-start;
 	border: 1px solid #a7f3d0;
+	border-bottom-left-radius: 0.25rem;
 }
 .llmchat-msg-system {
 	align-self: center;
@@ -155,10 +350,43 @@ export const widgetStyles = `
 	border-radius: 9999px;
 	padding: 0.25rem 0.75rem;
 }
+
+/* Typing indicator: three bouncing dots inside an assistant bubble. */
+.llmchat-typing {
+	display: flex;
+	align-items: center;
+	gap: 0.25rem;
+	width: fit-content;
+}
+.llmchat-dot {
+	width: 0.4rem;
+	height: 0.4rem;
+	border-radius: 9999px;
+	background: #9ca3af;
+	animation: llmchat-bounce 1.2s infinite ease-in-out;
+}
+.llmchat-dot:nth-child(2) {
+	animation-delay: 0.15s;
+}
+.llmchat-dot:nth-child(3) {
+	animation-delay: 0.3s;
+}
+@keyframes llmchat-bounce {
+	0%,
+	60%,
+	100% {
+		transform: translateY(0);
+		opacity: 0.5;
+	}
+	30% {
+		transform: translateY(-0.25rem);
+		opacity: 1;
+	}
+}
+
 .llmchat-demo-badge {
 	margin-left: auto;
-	margin-right: 0.5rem;
-	background: rgba(255, 255, 255, 0.25);
+	background: rgba(255, 255, 255, 0.22);
 	color: #fff;
 	font-size: 0.7rem;
 	font-weight: 600;
@@ -167,17 +395,16 @@ export const widgetStyles = `
 	border-radius: 9999px;
 	padding: 0.15rem 0.5rem;
 }
+/* When the demo badge is present the close button shouldn't also push right. */
+.llmchat-demo-badge + .llmchat-icon-btn {
+	margin-left: 0.25rem;
+}
 .llmchat-demo-note {
 	background: #eef2ff;
 	color: #4338ca;
 	font-size: 0.78rem;
-	padding: 0.5rem 0.75rem;
+	padding: 0.5rem 0.875rem;
 	border-bottom: 1px solid #e0e7ff;
-}
-.llmchat-typing {
-	color: #9ca3af;
-	font-size: 0.9rem;
-	padding-left: 0.5rem;
 }
 .llmchat-error {
 	color: #b91c1c;
@@ -186,26 +413,95 @@ export const widgetStyles = `
 	padding: 0.25rem 0.5rem 0;
 }
 
+/* ── Escalation ────────────────────────────────────────────────────── */
 .llmchat-escalate,
 .llmchat-escalated {
-	padding: 0.5rem 0.75rem;
+	padding: 0.625rem 0.875rem;
 	border-top: 1px solid #e5e7eb;
 	font-size: 0.85rem;
+	flex-shrink: 0;
 }
 .llmchat-escalate button {
-	background: var(--brand);
-	color: #fff;
-	border: none;
-	border-radius: 0.375rem;
+	display: inline-flex;
+	align-items: center;
+	gap: 0.4rem;
+	background: transparent;
+	color: var(--brand);
+	border: 1px solid color-mix(in srgb, var(--brand) 35%, transparent);
+	border-radius: 0.5rem;
 	padding: 0.4rem 0.75rem;
+	font: inherit;
+	font-size: 0.85rem;
+	font-weight: 600;
 	cursor: pointer;
+	transition:
+		background 0.15s ease,
+		border-color 0.15s ease;
+}
+.llmchat-escalate button:hover:not(:disabled) {
+	background: color-mix(in srgb, var(--brand) 8%, transparent);
+}
+.llmchat-escalate button:disabled {
+	opacity: 0.55;
+	cursor: default;
+}
+.llmchat-escalated {
+	color: #4b5563;
+	background: #f9fafb;
 }
 
+/* ── Composer ──────────────────────────────────────────────────────── */
 .llmchat-input {
 	border-top: 1px solid #e5e7eb;
-	padding: 0.5rem;
+	padding: 0.625rem 0.75rem;
 	display: flex;
 	gap: 0.5rem;
 	align-items: flex-end;
+	background: #fff;
+	flex-shrink: 0;
+}
+.llmchat-input textarea {
+	max-height: 7rem;
+}
+.llmchat-send {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 2.375rem;
+	height: 2.375rem;
+	flex-shrink: 0;
+	border-radius: 9999px;
+	background: var(--brand);
+	color: #fff;
+	border: none;
+	cursor: pointer;
+	transition:
+		filter 0.15s ease,
+		transform 0.1s ease,
+		opacity 0.15s ease;
+}
+.llmchat-send:hover:not(:disabled) {
+	filter: brightness(1.08);
+}
+.llmchat-send:active:not(:disabled) {
+	transform: scale(0.92);
+}
+.llmchat-send:disabled {
+	opacity: 0.4;
+	cursor: default;
+}
+.llmchat-send:focus-visible,
+.llmchat-escalate button:focus-visible {
+	outline: none;
+	box-shadow: 0 0 0 3px color-mix(in srgb, var(--brand) 30%, transparent);
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.llmchat *,
+	.llmchat *::before,
+	.llmchat *::after {
+		animation: none !important;
+		transition: none !important;
+	}
 }
 `;


### PR DESCRIPTION
## Summary

The embedded widget rendered as a large, always-open panel pinned to the left on third-party sites. This makes the floating bottom-right launcher the default and gives the widget a clean, modern, accessible redesign — all self-contained in the shadow-DOM IIFE (no component library, bundle stays lean).

## Commit 1 — floating launcher, collapsed by default
Root cause: the widget's bubble mode was already a correct floating launcher, but the dashboard EmbedCard recommended the **inline iframe** embed (`/embed/:key` → `data-mode="inline"` → panel fills a 400×600 iframe in page flow) — that's the "always-open left panel."
- Make the floating **script** snippet the recommended "Embed code"; demote the iframe to an "Alternative: inline iframe."
- Harden shadow-DOM isolation: pin inherited typography on `:host` and add a box-sizing reset so the host page's global CSS can't distort layout/position.
- Tests: `WidgetFrame` is collapsed by default (launcher only), opens on click, inline layout has no launcher.

## Commit 2 — UX/UI polish
- Hand-rolled SVG icons (no icon library): launcher chat/close, header avatar, send, agent.
- Launcher: 56px brand bubble with hover lift + focus ring; swaps to a close icon when open.
- Panel: rounded card with a layered shadow + hairline ring so it reads on **dark** host pages; brand header with avatar + close icon button.
- Distinct user/assistant/admin/system bubbles with tail corners, animated three-dot typing indicator, labeled identify form, circular send button, outlined "Talk to a human."
- **Accessibility:** focus moves into the panel on open and back to the launcher on close (no focus-steal on page load), aria-labels on icon buttons, `role="dialog"`, Esc to close, Enter to send, all motion disabled under `prefers-reduced-motion`.
- Subtle open/close transition. No new deps; bundle 387KB → 398KB raw (**+2.4KB gzipped**).

## Constraints honored
- No shadcn / component library imported into the widget — it stays a self-contained Vite IIFE with hand-rolled CSS in `src/styles.ts`.
- The inline iframe mode is kept (separate) for customers who want a fixed in-page panel; floating is the default.

## Test plan
- `pnpm test` (widget 46, 151 total), `pnpm lint`, `pnpm format` — clean.
- Recommend verifying on the dark test site: floating launcher bottom-right, opens a panel above the bubble, Esc/close collapse it, and it stays put regardless of host layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)