### PR TITLE
feat(dashboard): make floating widget the recommended embed

### DIFF
--- a/apps/dashboard/src/app/settings/projects/[id]/EmbedCard.test.tsx
+++ b/apps/dashboard/src/app/settings/projects/[id]/EmbedCard.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+
+import { EmbedCard } from "./EmbedCard";
+
+/** The single visible code block's text (only the selected snippet renders). */
+function snippetText(): string {
+	const blocks = document.querySelectorAll("pre");
+	expect(blocks).toHaveLength(1); // never show both snippets at once
+	return blocks[0]?.textContent ?? "";
+}
+
+function setup() {
+	render(<EmbedCard publicKey="pk_test123" brandColor="#4f46e5" />);
+}
+
+describe("EmbedCard", () => {
+	it("defaults to the floating script embed, marked Recommended", () => {
+		setup();
+		expect(screen.getByText("Recommended")).toBeInTheDocument();
+		const code = snippetText();
+		expect(code).toContain("<script");
+		expect(code).toContain("/widget.js");
+		expect(code).not.toContain("<iframe");
+		expect(
+			screen.getByRole("button", { name: /copy script/i }),
+		).toBeInTheDocument();
+		expect(
+			screen.queryByRole("button", { name: /copy iframe/i }),
+		).not.toBeInTheDocument();
+	});
+
+	it("switches to the inline iframe snippet and copy label when selected", async () => {
+		setup();
+		await userEvent.click(screen.getByText("Inline embed"));
+
+		const code = snippetText();
+		expect(code).toContain("<iframe");
+		expect(code).toContain("/embed/pk_test123");
+		expect(code).not.toContain("<script");
+		expect(
+			screen.getByRole("button", { name: /copy iframe/i }),
+		).toBeInTheDocument();
+		expect(
+			screen.queryByRole("button", { name: /copy script/i }),
+		).not.toBeInTheDocument();
+	});
+
+	it("switches back to the floating snippet", async () => {
+		setup();
+		await userEvent.click(screen.getByText("Inline embed"));
+		await userEvent.click(screen.getByText("Floating bubble"));
+		expect(snippetText()).toContain("<script");
+	});
+
+	it("exposes the embed URL with its own copy control and a matching preview link", () => {
+		setup();
+		const urlField = screen.getByLabelText("Embed URL") as HTMLInputElement;
+		expect(urlField.value).toContain("/embed/pk_test123");
+		expect(
+			screen.getByRole("button", { name: /copy url/i }),
+		).toBeInTheDocument();
+		expect(screen.getByRole("link", { name: /open preview/i })).toHaveAttribute(
+			"href",
+			urlField.value,
+		);
+	});
+});

--- a/apps/dashboard/src/app/settings/projects/[id]/EmbedCard.tsx
+++ b/apps/dashboard/src/app/settings/projects/[id]/EmbedCard.tsx
@@ -1,10 +1,13 @@
 "use client";
 
 import { ExternalLink, Lightbulb } from "lucide-react";
+import { useState } from "react";
 
 import { CopyButton } from "@/components/copy-button";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { apiBaseUrl } from "@/lib/api-base";
 import {
 	embedUrl,
@@ -22,6 +25,8 @@ function CodeBlock({ code }: { code: string }) {
 	);
 }
 
+type EmbedMode = "floating" | "inline";
+
 export function EmbedCard({
 	publicKey,
 	brandColor,
@@ -29,86 +34,119 @@ export function EmbedCard({
 	publicKey: string;
 	brandColor: string;
 }) {
+	const [mode, setMode] = useState<EmbedMode>("floating");
 	const config = { apiUrl: apiBaseUrl(), publicKey, brandColor };
 	const url = embedUrl(config);
-	const iframeCode = widgetIframeSnippet(config);
-	const scriptCode = widgetScriptSnippet(config);
+
+	const options: Record<
+		EmbedMode,
+		{ code: string; copyLabel: string; when: React.ReactNode }
+	> = {
+		floating: {
+			code: widgetScriptSnippet(config),
+			copyLabel: "Copy script",
+			when: (
+				<>
+					Adds a chat button in the bottom-right of every page — best for
+					site-wide support. Paste before{" "}
+					<code className="rounded bg-muted px-1 py-0.5 font-mono text-xs">
+						&lt;/body&gt;
+					</code>
+					.
+				</>
+			),
+		},
+		inline: {
+			code: widgetIframeSnippet(config),
+			copyLabel: "Copy iframe",
+			when: "Drops the chat into a specific spot on a page (e.g. a contact page).",
+		},
+	};
+	const selected = options[mode];
 
 	return (
 		<SectionCard
 			id="install"
 			step={5}
 			title="Install widget"
-			description="Copy this code and paste it into your website to add the chatbot."
+			description="Choose how the chatbot appears, then copy the code into your site."
 		>
-			<div className="grid min-w-0 gap-6 lg:grid-cols-2">
-				{/* Embed code — floating bubble is the recommended default */}
-				<div className="flex min-w-0 flex-col gap-3">
-					<div className="space-y-0.5">
-						<h3 className="text-sm font-medium text-foreground">Embed code</h3>
-						<p className="text-sm text-muted-foreground">
-							Paste this before{" "}
-							<code className="font-mono text-xs">&lt;/body&gt;</code> — a
-							floating chat button appears in the bottom-right of every page.
-						</p>
+			<div className="flex min-w-0 flex-col gap-5">
+				<ToggleGroup
+					type="single"
+					value={mode}
+					onValueChange={(value) => value && setMode(value as EmbedMode)}
+					className="w-full max-w-md"
+					aria-label="Embed type"
+				>
+					<ToggleGroupItem
+						value="floating"
+						aria-label="Floating bubble (recommended)"
+						className="flex-1 gap-2"
+					>
+						Floating bubble
+						<Badge
+							variant="secondary"
+							className="border-emerald-500/20 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400"
+						>
+							Recommended
+						</Badge>
+					</ToggleGroupItem>
+					<ToggleGroupItem value="inline" className="flex-1">
+						Inline embed
+					</ToggleGroupItem>
+				</ToggleGroup>
+
+				<div className="grid min-w-0 gap-6 lg:grid-cols-2">
+					{/* Selected embed snippet */}
+					<div className="flex min-w-0 flex-col gap-3">
+						<p className="text-sm text-muted-foreground">{selected.when}</p>
+						<CodeBlock code={selected.code} />
+						<div className="flex flex-wrap items-center gap-2">
+							<CopyButton value={selected.code}>
+								{selected.copyLabel}
+							</CopyButton>
+							<Button type="button" variant="outline" size="sm" asChild>
+								<a href={url} target="_blank" rel="noreferrer">
+									Open preview
+									<ExternalLink />
+								</a>
+							</Button>
+						</div>
 					</div>
-					<CodeBlock code={scriptCode} />
-					<div className="flex flex-wrap items-center gap-2">
-						<CopyButton value={scriptCode}>Copy embed code</CopyButton>
-						<Button type="button" variant="outline" size="sm" asChild>
-							<a href={url} target="_blank" rel="noreferrer">
-								Open preview
-								<ExternalLink />
-							</a>
-						</Button>
-					</div>
-					<details className="group">
-						<summary className="cursor-pointer text-sm font-medium text-muted-foreground transition-colors hover:text-foreground">
-							Alternative: inline iframe
-						</summary>
-						<div className="mt-3 flex min-w-0 flex-col gap-3">
+
+					{/* Embed URL */}
+					<div className="flex min-w-0 flex-col gap-3">
+						<div className="space-y-0.5">
+							<h3 className="text-sm font-medium text-foreground">Embed URL</h3>
 							<p className="text-sm text-muted-foreground">
-								Renders the chat as a fixed-size panel in the page flow where
-								you place it, instead of a floating button.
+								Use this link to preview your chatbot or for advanced
+								integrations.
 							</p>
-							<CodeBlock code={iframeCode} />
-							<CopyButton value={iframeCode} className="self-start">
-								Copy iframe code
+						</div>
+						<div className="flex min-w-0 items-center gap-2">
+							<Input
+								readOnly
+								value={url}
+								aria-label="Embed URL"
+								className="min-w-0 truncate font-mono text-xs"
+								onFocus={(e) => e.currentTarget.select()}
+							/>
+							<CopyButton value={url} size="default" className="shrink-0">
+								Copy URL
 							</CopyButton>
 						</div>
-					</details>
-				</div>
-
-				{/* Embed URL */}
-				<div className="flex min-w-0 flex-col gap-3">
-					<div className="space-y-0.5">
-						<h3 className="text-sm font-medium text-foreground">Embed URL</h3>
-						<p className="text-sm text-muted-foreground">
-							Use this link to preview your chatbot or for advanced
-							integrations.
-						</p>
-					</div>
-					<div className="flex min-w-0 items-center gap-2">
-						<Input
-							readOnly
-							value={url}
-							aria-label="Embed URL"
-							className="min-w-0 truncate font-mono text-xs"
-							onFocus={(e) => e.currentTarget.select()}
-						/>
-						<CopyButton value={url} size="default" className="shrink-0">
-							Copy URL
-						</CopyButton>
-					</div>
-					<div className="flex items-start gap-3 rounded-xl border border-indigo-500/20 bg-indigo-500/5 p-4 dark:bg-indigo-500/10">
-						<span className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-indigo-500/10 text-indigo-600 dark:text-indigo-400">
-							<Lightbulb className="size-4" />
-						</span>
-						<p className="text-sm text-indigo-950/80 dark:text-indigo-200/90">
-							<span className="font-semibold">Tip:</span> For most websites, use
-							the floating embed code — it adds the chat button site-wide. Use
-							the inline iframe only when you want the chat fixed in one spot.
-						</p>
+						<div className="flex items-start gap-3 rounded-xl border border-indigo-500/20 bg-indigo-500/5 p-4 dark:bg-indigo-500/10">
+							<span className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-indigo-500/10 text-indigo-600 dark:text-indigo-400">
+								<Lightbulb className="size-4" />
+							</span>
+							<p className="text-sm text-indigo-950/80 dark:text-indigo-200/90">
+								<span className="font-semibold">Tip:</span> The floating bubble
+								is recommended for most sites — one paste adds support to every
+								page. Use the inline embed only when you want the chat fixed in
+								a specific spot.
+							</p>
+						</div>
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
## Summary

Polishes the "Install widget" card so the **floating bubble** is the primary, recommended embed and the inline iframe is secondary, presented as a chooser.

- **Segmented chooser** (shadcn `ToggleGroup`): **Floating bubble** with an emerald **Recommended** badge (selected by default) vs **Inline embed**. Only the selected option's snippet + copy button is shown at a time.
- **"When to use" one-liners**: floating → a chat button bottom-right on every page, best for site-wide support, paste before `</body>`; inline → drops the chat into a specific spot on a page (e.g. a contact page).
- **Clear copy labels**: "Copy script" / "Copy iframe" (track the selection). Kept the **Embed URL** field + "Copy URL" and **Open preview**.
- **Fixed misleading Tip**: now recommends the floating bubble for most sites; inline only when you want the chat fixed in one spot.
- Uses dashboard-appropriate shadcn components (`ToggleGroup`, `Badge`); clean hierarchy (full-width chooser → snippet | URL+tip grid).

## Test plan
- `pnpm test` (dashboard 62, 151 total), `pnpm lint`, `pnpm format`, dashboard build/typecheck — all clean on top of latest `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)