### PR TITLE
fix(api): get the dev seed out of prod

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,7 @@ Local env: `cp apps/api/.env.example apps/api/.env` and fill in keys. `ploy dev`
 
 ### Zero-setup local dev
 
-`apps/api/migrations/0001_dev_seed.sql` is an idempotent (`INSERT OR IGNORE`) seed applied automatically by `ploy dev`. It creates:
+The dev seed is **`apps/api/seed/dev-seed.sql`**, applied **only** by `pnpm seed` (the runner is `apps/api/scripts/seed.mjs`). It is deliberately **not** in `apps/api/migrations/`: Ploy auto-applies every migration on `ploy dev` _and_ on deploy, so a seed there would create the admin in production too. Keeping it out means **production deploys never create or re-assert `admin@example.com`**. The seed is idempotent (`INSERT OR IGNORE`) and creates:
 
 - **Admin user:** `admin@example.com` / `admin@example.com` (Better Auth scrypt hash with a fixed salt — only matches that literal password, safe to commit).
 - **Dev workspace + owner member** for the user.
@@ -58,12 +58,13 @@ Local env: `cp apps/api/.env.example apps/api/.env` and fill in keys. `ploy dev`
 
 To exercise the full loop locally:
 
-1. `pnpm dev` — boots api, dashboard, marketing, showcase; migrations apply the seed.
-2. Open `http://localhost:3003` — the **showcase** (`apps/showcase`) is a fake "Acme Tools" landing page that embeds the widget via `WidgetMount.tsx`, pinned to `local-dev-key` and `http://localhost:8787`.
-3. Chat with the bubble; send 3+ messages to trigger "Talk to a human".
-4. Sign in at `http://localhost:3001` with the admin credentials to see the conversation in the dashboard inbox.
+1. `pnpm dev` — boots api, dashboard, marketing, showcase; Ploy applies the real schema migrations and creates the local DB at `.ploy/db/llmchat_db.db`.
+2. `pnpm seed` — once, in another terminal, to insert the admin/workspace/demo project (re-runnable; resolves the local DB, or `PLOY_DB_PATH=<file>` to override). Refuses to run under `NODE_ENV=production`.
+3. Open `http://localhost:3003` — the **showcase** (`apps/showcase`) is a fake "Acme Tools" landing page that embeds the widget via `WidgetMount.tsx`, pinned to `local-dev-key` and `http://localhost:8787`.
+4. Chat with the bubble; send 3+ messages to trigger "Talk to a human".
+5. Sign in at `http://localhost:3001` with the admin credentials to see the conversation in the dashboard inbox.
 
-The seed hash is computed for scrypt `{ N: 16384, r: 16, p: 1, dkLen: 64 }` — Better Auth's defaults via `@better-auth/utils/password`. If they ever change those params, regenerate the hash and update `0001_dev_seed.sql`.
+`apps/api/src/seed.test.ts` enforces the contract: the committed migrations never create the admin/demo project, and the dev seed does (idempotently). The seed hash is computed for scrypt `{ N: 16384, r: 16, p: 1, dkLen: 64 }` — Better Auth's defaults via `@better-auth/utils/password`. If they ever change those params, regenerate the hash and update `apps/api/seed/dev-seed.sql`.
 
 ## Architecture
 

--- a/apps/api/migrations/0002_dev_seed_notify_email.sql
+++ b/apps/api/migrations/0002_dev_seed_notify_email.sql
@@ -1,7 +1,0 @@
--- Backfill notify_email on the dev seed project for DBs that applied the
--- original 0001 seed before notify_email was added. No-op on fresh DBs
--- (those get notify_email directly from 0001).
-
-UPDATE `project`
-SET `notify_email` = 'admin@example.com'
-WHERE `id` = 'dev-project' AND `notify_email` IS NULL;

--- a/apps/api/scripts/seed.d.mts
+++ b/apps/api/scripts/seed.d.mts
@@ -1,0 +1,10 @@
+// Type surface for the dev-seed runner (seed.mjs stays plain JS so `node`
+// can run it directly; this lets the vitest suite import its guards typed).
+
+type Env = Record<string, string | undefined>;
+
+/** Throws if `env.NODE_ENV === "production"`. */
+export function assertDevOnly(env?: Env): void;
+
+/** Local Ploy DB path; honors `env.PLOY_DB_PATH`, else the default under .ploy. */
+export function resolveDbPath(env?: Env): string;

--- a/apps/api/scripts/seed.mjs
+++ b/apps/api/scripts/seed.mjs
@@ -1,0 +1,72 @@
+// Dev-only seed runner.
+//
+// Applies apps/api/seed/dev-seed.sql to the LOCAL Ploy SQLite database so the
+// dashboard/showcase work out-of-the-box (admin@example.com / local-dev-key).
+//
+// This is deliberately separate from apps/api/migrations/: Ploy auto-applies
+// every migration on `ploy dev` AND on deploy, so anything in there would also
+// run in production. The seed must never touch prod, hence this opt-in script.
+//
+// Usage:  pnpm seed            (after `pnpm dev` has created the local DB)
+//         PLOY_DB_PATH=/path pnpm seed   (override DB location)
+
+import { DatabaseSync } from "node:sqlite";
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(here, "../../..");
+const SEED_SQL = resolve(here, "../seed/dev-seed.sql");
+const DEFAULT_DB = resolve(REPO_ROOT, ".ploy/db/llmchat_db.db");
+
+/**
+ * The seed creates a known admin with a committed password hash. Refuse to run
+ * anywhere that looks like production, so it can never be wired into a deploy.
+ */
+export function assertDevOnly(env = process.env) {
+	if (env.NODE_ENV === "production") {
+		throw new Error(
+			"refusing to seed: NODE_ENV=production. The dev seed must never run in production.",
+		);
+	}
+}
+
+/** Local Ploy DB path, overridable via PLOY_DB_PATH for non-default setups. */
+export function resolveDbPath(env = process.env) {
+	return env.PLOY_DB_PATH ? resolve(env.PLOY_DB_PATH) : DEFAULT_DB;
+}
+
+function main() {
+	assertDevOnly();
+
+	const dbPath = resolveDbPath();
+	if (!existsSync(dbPath)) {
+		console.error(
+			`No local DB at ${dbPath}.\nStart the dev server once (\`pnpm dev\`) so Ploy creates and migrates it, then re-run \`pnpm seed\`.`,
+		);
+		process.exit(1);
+	}
+
+	const sql = readFileSync(SEED_SQL, "utf8");
+	const db = new DatabaseSync(dbPath);
+	try {
+		// Coexist with the running Ploy emulator holding the same file.
+		db.exec("PRAGMA busy_timeout = 5000;");
+		db.exec(sql);
+	} finally {
+		db.close();
+	}
+
+	console.log(
+		"✔ dev seed applied — sign in at the dashboard with admin@example.com / admin@example.com (widget key: local-dev-key)",
+	);
+}
+
+// Only run when invoked directly, so tests can import the guards without seeding.
+if (
+	process.argv[1] &&
+	resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+	main();
+}

--- a/apps/api/seed/dev-seed.sql
+++ b/apps/api/seed/dev-seed.sql
@@ -1,5 +1,12 @@
--- Dev seed: a default admin user, workspace, and project so the showcase
--- and dashboard work out-of-the-box without manual signup.
+-- Dev seed (NOT an auto-applied migration).
+--
+-- This file is applied ONLY by `pnpm seed`, against the local Ploy SQLite DB
+-- (.ploy/db/llmchat_db.db). It is intentionally NOT in apps/api/migrations/,
+-- so production deploys never create or re-assert this admin user. See
+-- apps/api/scripts/seed.mjs and the "Zero-setup local dev" section of AGENTS.md.
+--
+-- Creates a default admin user, workspace, and demo project so the dashboard
+-- and showcase work out-of-the-box locally without manual signup.
 --
 -- Sign in:   admin@example.com  /  admin@example.com
 -- Widget key: local-dev-key
@@ -7,6 +14,8 @@
 -- The password hash is scrypt(N=16384,r=16,p=1,dkLen=64) in better-auth's
 -- "<saltHex>:<keyHex>" format. Salt is fixed so this seed is reproducible.
 -- Safe to ship because it only matches the literal password "admin@example.com".
+--
+-- All statements are INSERT OR IGNORE: applying repeatedly is a no-op.
 
 INSERT OR IGNORE INTO `user` (`id`, `name`, `email`, `email_verified`)
 VALUES ('dev-admin', 'Local Admin', 'admin@example.com', 1);

--- a/apps/api/src/seed.test.ts
+++ b/apps/api/src/seed.test.ts
@@ -1,0 +1,129 @@
+import { DatabaseSync } from "node:sqlite";
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import { assertDevOnly, resolveDbPath } from "../scripts/seed.mjs";
+
+const API_DIR = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const MIGRATIONS_DIR = resolve(API_DIR, "migrations");
+const SEED_SQL = resolve(API_DIR, "seed/dev-seed.sql");
+
+/** Apply every committed migration (the exact set Ploy deploys) to a fresh DB. */
+function migratedDb() {
+	const db = new DatabaseSync(":memory:");
+	// Sort a copy in filename order (api targets es2022, so `toSorted` isn't in
+	// lib here; sorting a fresh copy never mutates the readdir result).
+	const files = [...readdirSync(MIGRATIONS_DIR)].filter((f) =>
+		f.endsWith(".sql"),
+	);
+	// oxlint-disable-next-line unicorn/no-array-sort
+	files.sort((a, b) => (a < b ? -1 : 1));
+	for (const f of files) {
+		db.exec(readFileSync(resolve(MIGRATIONS_DIR, f), "utf8"));
+	}
+	return db;
+}
+
+const ADMIN = "admin@example.com";
+const WIDGET_KEY = "local-dev-key";
+
+describe("production migrations", () => {
+	it("never create the dev admin or demo project", () => {
+		const db = migratedDb();
+		const admin = db
+			.prepare("SELECT count(*) AS c FROM user WHERE email = ?")
+			.get(ADMIN) as { c: number };
+		const project = db
+			.prepare("SELECT count(*) AS c FROM project WHERE public_key = ?")
+			.get(WIDGET_KEY) as { c: number };
+		expect(admin.c).toBe(0);
+		expect(project.c).toBe(0);
+		db.close();
+	});
+
+	it("contain no seed file (the dev seed lives outside migrations/)", () => {
+		const offending = readdirSync(MIGRATIONS_DIR)
+			.filter((f) => f.endsWith(".sql"))
+			.filter((f) => {
+				const sql = readFileSync(resolve(MIGRATIONS_DIR, f), "utf8");
+				return sql.includes(ADMIN) || sql.includes(WIDGET_KEY);
+			});
+		expect(offending).toEqual([]);
+	});
+});
+
+describe("dev seed", () => {
+	it("creates the admin, owner-membership, and demo project on a migrated DB", () => {
+		const db = migratedDb();
+		db.exec(readFileSync(SEED_SQL, "utf8"));
+
+		const user = db
+			.prepare("SELECT id, email FROM user WHERE email = ?")
+			.get(ADMIN) as { id: string; email: string };
+		expect(user).toMatchObject({ id: "dev-admin", email: ADMIN });
+
+		const member = db
+			.prepare("SELECT role FROM member WHERE user_id = ? AND workspace_id = ?")
+			.get("dev-admin", "dev-workspace") as { role: string };
+		expect(member.role).toBe("owner");
+
+		const project = db
+			.prepare(
+				"SELECT public_key, model, notify_email FROM project WHERE id = ?",
+			)
+			.get("dev-project") as {
+			public_key: string;
+			model: string;
+			notify_email: string;
+		};
+		expect(project).toMatchObject({
+			public_key: WIDGET_KEY,
+			model: "gpt-5.4-mini",
+			notify_email: ADMIN,
+		});
+		db.close();
+	});
+
+	it("is idempotent — applying twice leaves a single row each", () => {
+		const db = migratedDb();
+		const sql = readFileSync(SEED_SQL, "utf8");
+		db.exec(sql);
+		db.exec(sql);
+
+		for (const [table, where] of [
+			["user", "email = 'admin@example.com'"],
+			["workspace", "id = 'dev-workspace'"],
+			["member", "id = 'dev-member'"],
+			["project", "id = 'dev-project'"],
+		] as const) {
+			const row = db
+				.prepare(`SELECT count(*) AS c FROM ${table} WHERE ${where}`)
+				.get() as { c: number };
+			expect(row.c, table).toBe(1);
+		}
+		db.close();
+	});
+});
+
+describe("seed runner guards", () => {
+	it("refuses to run under NODE_ENV=production", () => {
+		expect(() => assertDevOnly({ NODE_ENV: "production" })).toThrow(
+			/production/,
+		);
+	});
+
+	it("allows dev/test and other environments", () => {
+		expect(() => assertDevOnly({ NODE_ENV: "development" })).not.toThrow();
+		expect(() => assertDevOnly({})).not.toThrow();
+	});
+
+	it("honors PLOY_DB_PATH override, else defaults under .ploy", () => {
+		expect(resolveDbPath({ PLOY_DB_PATH: "/tmp/custom.db" })).toBe(
+			"/tmp/custom.db",
+		);
+		expect(resolveDbPath({})).toMatch(/\.ploy\/db\/llmchat_db\.db$/);
+	});
+});

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
 		"lint": "turbo run lint && oxlint .",
 		"migrate": "pnpm --filter @llmchat/db migrate",
 		"migrations": "pnpm --filter @llmchat/db migrations",
+		"seed": "node apps/api/scripts/seed.mjs",
 		"test": "turbo run test"
 	},
 	"devDependencies": {


### PR DESCRIPTION
## Summary

Repo-only, **not prod-destructive**: stops future deploys from creating/re-asserting the dev-seed admin (`admin@example.com`). The live-DB deletion of the seed admin is handled separately by the operator/teammate per the runbook below.

Ploy applies **every** `apps/api/migrations/*.sql` on both `ploy dev` and deploy — there's no env gate — so the dev seed was reaching production. This moves it out of the auto-applied set into a DEV-gated `pnpm seed` path.

## Changes

- **Move** `apps/api/migrations/0001_dev_seed.sql` → `apps/api/seed/dev-seed.sql` (out of the auto-applied migration set).
- **Delete** `0002_dev_seed_notify_email.sql` (dev-seed-only backfill; only ever touched `dev-project`).
- **New runner** `apps/api/scripts/seed.mjs` (+ `seed.d.mts` types) applies the seed via `node:sqlite` to the local Ploy DB. Run with **`pnpm seed`**; refuses `NODE_ENV=production`; never wired into a deploy.
- **Keep** real schema/data migrations (`0000`, `0003`–`0008`) untouched. The `0001/0002` numbering gap is intentional — renumbering would look like changed/un-applied migrations to Ploy on existing DBs.
- **Docs:** AGENTS.md "Zero-setup local dev" now documents `pnpm dev` + `pnpm seed`.

## Tests

`apps/api/src/seed.test.ts` (real, via `node:sqlite`):
- the committed migration set never creates the admin/demo project (prod-safe),
- the dev seed does create them (admin + owner member + `local-dev-key` project),
- applying the seed twice is idempotent (`INSERT OR IGNORE`),
- the runner refuses under `NODE_ENV=production` and honors `PLOY_DB_PATH`.

`pnpm test` / `pnpm lint` / `pnpm format` all green.

## Net effect

Future deploys no longer create or re-assert `admin@example.com`. Local zero-setup becomes `pnpm dev` then `pnpm seed`.

---

## RUNBOOK — removing the public demo

**Two traps (why order matters):**

- **Trap 1 — seed is `INSERT OR IGNORE`:** before this PR ships, every deploy re-creates the admin if it's missing. Deleting the admin while the old seed still deploys → it comes back on the next deploy. **This PR must be merged + deployed BEFORE the teammate deletes the admin.**
- **Trap 2 — showcase lives in the seed admin's workspace:** prod showcase's `NEXT_PUBLIC_WIDGET_KEY` (dashboard-managed) points at a project under the seed-admin account. Deleting that workspace kills the showcase widget. **Repoint the showcase to a project under the operator's real account first.**

**Ordered cutover:**

1. **Operator:** real account + workspace → fresh demo project → set prod showcase `NEXT_PUBLIC_WIDGET_KEY` to that project's key → redeploy showcase → verify the live widget chats. *(Closes Trap 2.)*
2. **Merge + deploy this PR** to `main`; confirm all 4 Ploy projects deploy green. *(Closes Trap 1 — no future redeploy can resurrect the admin.)*
3. **Teammate:** delete `admin@example.com` (user + account/credential) and the old `dev-workspace` from the live DB. With 1–2 done, nothing re-creates them and the showcase is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)