### PR TITLE
fix(dashboard): hotfix broken sign-up → onboarding (undefined esbuild helper + 403 cascade)

### DIFF
--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -4,7 +4,7 @@
 	"private": true,
 	"type": "module",
 	"scripts": {
-		"build": "next build",
+		"build": "next build && node scripts/check-bundle.mjs",
 		"dev": "next dev -p 3001",
 		"format": "prettier --write .",
 		"lint": "prettier --check .",

--- a/apps/dashboard/scripts/check-bundle.mjs
+++ b/apps/dashboard/scripts/check-bundle.mjs
@@ -1,0 +1,114 @@
+// Post-build guard: fail the build if the client bundle CALLS an esbuild/tsup
+// runtime helper that is DEFINED NOWHERE in the output.
+//
+// Why: a dependency shipped as esbuild/tsup output expects its helpers (e.g.
+// `__name` from `keepNames`, decorator/private-field helpers) to be defined at
+// its module top. When webpack code-splits and the helper definition is dropped
+// into a chunk that isn't co-loaded, the call site throws `__name is not
+// defined` at runtime and crashes client init — which is exactly what broke the
+// sign-in / onboarding flow. Type-checks and unit tests are blind to it because
+// it only manifests in the minified, split bundle. This converts that silent
+// runtime ReferenceError into a hard build failure.
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// esbuild/tsup helpers that are referenced as bare identifiers (not via a
+// namespace) and therefore throw a ReferenceError if their definition is
+// missing. Webpack's own runtime (`__webpack_require__`, `__webpack_exports__`)
+// is intentionally excluded — it is provided by the webpack runtime chunk.
+export const ESBUILD_HELPERS = [
+	"__name",
+	"__publicField",
+	"__privateGet",
+	"__privateSet",
+	"__privateAdd",
+	"__privateMethod",
+	"__decorateClass",
+	"__decorateParam",
+	"__esDecorate",
+	"__spreadValues",
+	"__spreadProps",
+	"__objRest",
+];
+
+const defPattern = (h) =>
+	new RegExp(`(?:var|let|const|function)\\s+${h}\\b|\\b${h}\\s*=`);
+const callPattern = (h) => new RegExp(`\\b${h}\\s*\\(`);
+
+/**
+ * Given the built chunk sources, return the helpers that are called somewhere
+ * but defined nowhere. Definition and call may live in different chunks (webpack
+ * splits freely), so both sides are evaluated across the whole output set.
+ *
+ * @param {{ name: string, code: string }[]} files
+ * @returns {{ helper: string, calledIn: string[] }[]}
+ */
+export function findUndefinedHelpers(files) {
+	const broken = [];
+	for (const helper of ESBUILD_HELPERS) {
+		const def = defPattern(helper);
+		const call = callPattern(helper);
+		const definedAnywhere = files.some((f) => def.test(f.code));
+		if (definedAnywhere) continue;
+		const calledIn = files.filter((f) => call.test(f.code)).map((f) => f.name);
+		if (calledIn.length > 0) broken.push({ helper, calledIn });
+	}
+	return broken;
+}
+
+function collectJsFiles(dir) {
+	const out = [];
+	const walk = (d) => {
+		for (const entry of readdirSync(d)) {
+			const p = join(d, entry);
+			if (statSync(p).isDirectory()) walk(p);
+			else if (entry.endsWith(".js"))
+				out.push({ name: p, code: readFileSync(p, "utf8") });
+		}
+	};
+	walk(dir);
+	return out;
+}
+
+function main() {
+	const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+	const chunksDir = join(root, ".next", "static", "chunks");
+	let files;
+	try {
+		files = collectJsFiles(chunksDir);
+	} catch {
+		console.error(
+			`bundle check: no built chunks at ${chunksDir}. Run \`next build\` first.`,
+		);
+		process.exit(1);
+	}
+
+	const broken = findUndefinedHelpers(files);
+	if (broken.length > 0) {
+		console.error(
+			"bundle check FAILED — client chunks call esbuild helpers that are defined nowhere:",
+		);
+		for (const { helper, calledIn } of broken) {
+			console.error(`  • ${helper} — called in ${calledIn.length} chunk(s)`);
+			for (const name of calledIn.slice(0, 5)) console.error(`      ${name}`);
+		}
+		console.error(
+			"This crashes client init at runtime (e.g. `__name is not defined`). " +
+				"Add the offending dependency to next.config `transpilePackages` so Next re-transpiles it.",
+		);
+		process.exit(1);
+	}
+
+	console.log(
+		`bundle check OK — ${files.length} chunk(s), no undefined esbuild helpers.`,
+	);
+}
+
+if (
+	process.argv[1] &&
+	resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+	main();
+}

--- a/apps/dashboard/src/app/onboarding/page.test.tsx
+++ b/apps/dashboard/src/app/onboarding/page.test.tsx
@@ -3,7 +3,7 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { api } from "@/lib/api";
+import { api, ApiError } from "@/lib/api";
 import { useSession } from "@/lib/auth-client";
 import { useOnboardingState } from "@/lib/use-onboarding";
 
@@ -12,7 +12,12 @@ import OnboardingPage from "./page";
 vi.mock("next/navigation", () => ({ useRouter: () => ({ replace: vi.fn() }) }));
 vi.mock("@/lib/auth-client", () => ({ useSession: vi.fn() }));
 vi.mock("@/lib/use-onboarding", () => ({ useOnboardingState: vi.fn() }));
-vi.mock("@/lib/api", () => ({ api: vi.fn() }));
+// Mock only the transport; keep ApiError / isWorkspaceAuthError real so the
+// self-heal branch is exercised exactly as in production.
+vi.mock("@/lib/api", async (orig) => ({
+	...(await orig<typeof import("@/lib/api")>()),
+	api: vi.fn(),
+}));
 
 function renderPage() {
 	const client = new QueryClient({
@@ -26,6 +31,7 @@ function renderPage() {
 }
 
 beforeEach(() => {
+	vi.clearAllMocks();
 	vi.mocked(useSession).mockReturnValue({
 		data: { user: { id: "u1", email: "a@b.com" } },
 		isPending: false,
@@ -107,5 +113,63 @@ describe("OnboardingPage", () => {
 			expect.objectContaining({ workspaceId: "ws-new" }),
 		);
 		expect(await screen.findByText(/acme is ready/i)).toBeInTheDocument();
+	});
+
+	it("self-heals a stale/foreign workspace: 403 on project create → provision fresh → retry → finish", async () => {
+		// The active workspace is one the user isn't a member of (stale localStorage
+		// or a broken client-init context — the cascade behind the prod 403).
+		vi.mocked(useOnboardingState).mockReturnValue({
+			state: "needs-onboarding",
+			workspaceId: "ws-foreign",
+		});
+		const projectCalls: string[] = [];
+		vi.mocked(api).mockImplementation(async (path: string, opts?: unknown) => {
+			if (path === "/api/projects") {
+				const wsId = (opts as { workspaceId?: string } | undefined)
+					?.workspaceId;
+				projectCalls.push(wsId ?? "");
+				// First attempt against the foreign workspace is rejected by the guard.
+				if (wsId === "ws-foreign")
+					throw new ApiError(403, '{"error":"forbidden"}');
+				return {
+					project: { publicKey: "pk_ok", brandColor: "#000000", name: "Acme" },
+				};
+			}
+			if (path === "/api/workspaces") return { workspace: { id: "ws-fresh" } };
+			return {};
+		});
+
+		const user = userEvent.setup();
+		renderPage();
+
+		await user.type(screen.getByLabelText(/business or chatbot name/i), "Acme");
+		await user.click(screen.getByRole("button", { name: /create chatbot/i }));
+
+		// Recovered: provisioned a fresh workspace and retried the project there.
+		expect(api).toHaveBeenCalledWith(
+			"/api/workspaces",
+			expect.objectContaining({ method: "POST", body: { name: "Acme" } }),
+		);
+		expect(projectCalls).toEqual(["ws-foreign", "ws-fresh"]);
+		expect(await screen.findByText(/acme is ready/i)).toBeInTheDocument();
+		const snippet = document.querySelector("pre")?.textContent ?? "";
+		expect(snippet).toContain("pk_ok");
+	});
+
+	it("does not retry on a non-workspace error (e.g. validation 422)", async () => {
+		vi.mocked(api).mockImplementation(async (path: string) => {
+			if (path === "/api/projects")
+				throw new ApiError(422, '{"error":"bad input"}');
+			return {};
+		});
+		const user = userEvent.setup();
+		renderPage();
+
+		await user.type(screen.getByLabelText(/business or chatbot name/i), "Acme");
+		await user.click(screen.getByRole("button", { name: /create chatbot/i }));
+
+		// No workspace provisioning — the error isn't a workspace-auth failure.
+		await screen.findByRole("button", { name: /create chatbot/i });
+		expect(api).not.toHaveBeenCalledWith("/api/workspaces", expect.anything());
 	});
 });

--- a/apps/dashboard/src/app/onboarding/page.tsx
+++ b/apps/dashboard/src/app/onboarding/page.tsx
@@ -6,10 +6,11 @@ import { useEffect, useState } from "react";
 import { toast } from "sonner";
 
 import { useSession } from "@/lib/auth-client";
-import { api } from "@/lib/api";
+import { api, isWorkspaceAuthError } from "@/lib/api";
 import { track, ANALYTICS_EVENTS } from "@/lib/analytics";
 import { defaultSystemPrompt, defaultWelcomeMessage } from "@/lib/onboarding";
 import { useOnboardingState } from "@/lib/use-onboarding";
+import { useWorkspace } from "@/lib/workspace";
 
 import { OnboardingFinish } from "./_components/OnboardingFinish";
 import { OnboardingNameStep } from "./_components/OnboardingNameStep";
@@ -26,6 +27,7 @@ export default function OnboardingPage() {
 	const qc = useQueryClient();
 	const { data: session, isPending: sessionPending } = useSession();
 	const { state, workspaceId } = useOnboardingState();
+	const { setWorkspaceId } = useWorkspace();
 	const [pending, setPending] = useState(false);
 	const [created, setCreated] = useState<CreatedProject | null>(null);
 
@@ -46,34 +48,51 @@ export default function OnboardingPage() {
 			router.replace("/inbox");
 	}, [created, session, state, router]);
 
+	// Provision a fresh free-plan workspace and make it the active selection.
+	async function provisionWorkspace(name: string): Promise<string> {
+		const { workspace } = await api<{ workspace: { id: string } }>(
+			"/api/workspaces",
+			{ method: "POST", body: { name } },
+		);
+		setWorkspaceId(workspace.id);
+		await qc.invalidateQueries({ queryKey: ["workspaces"] });
+		return workspace.id;
+	}
+
+	async function createProject(wsId: string, name: string) {
+		const { project } = await api<{ project: CreatedProject }>(
+			"/api/projects",
+			{
+				method: "POST",
+				workspaceId: wsId,
+				body: {
+					name,
+					systemPrompt: defaultSystemPrompt(name),
+					welcomeMessage: defaultWelcomeMessage(name),
+				},
+			},
+		);
+		await qc.invalidateQueries({ queryKey: ["projects", wsId] });
+		return project;
+	}
+
 	async function handleCreate(name: string) {
 		setPending(true);
 		try {
-			// Backstop: provisioning normally happens at sign-up, but get-or-create
-			// covers accounts that somehow have no workspace.
-			let wsId = workspaceId;
-			if (!wsId) {
-				const { workspace } = await api<{ workspace: { id: string } }>(
-					"/api/workspaces",
-					{ method: "POST", body: { name } },
-				);
-				wsId = workspace.id;
-				await qc.invalidateQueries({ queryKey: ["workspaces"] });
+			// Sign-up provisions a workspace, but the active selection can be absent
+			// (provisioning still settling) or stale/foreign (e.g. a prior account's
+			// id left in localStorage, or a client-init failure). Create-on-demand,
+			// then if the workspace assertion is rejected, provision a fresh one and
+			// retry once so a broken context can't strand the user on a 403.
+			let project: CreatedProject;
+			try {
+				const wsId = workspaceId ?? (await provisionWorkspace(name));
+				project = await createProject(wsId, name);
+			} catch (e) {
+				if (!isWorkspaceAuthError(e)) throw e;
+				project = await createProject(await provisionWorkspace(name), name);
 			}
 
-			const { project } = await api<{ project: CreatedProject }>(
-				"/api/projects",
-				{
-					method: "POST",
-					workspaceId: wsId,
-					body: {
-						name,
-						systemPrompt: defaultSystemPrompt(name),
-						welcomeMessage: defaultWelcomeMessage(name),
-					},
-				},
-			);
-			await qc.invalidateQueries({ queryKey: ["projects", wsId] });
 			setCreated({
 				name,
 				publicKey: project.publicKey,

--- a/apps/dashboard/src/lib/api.test.ts
+++ b/apps/dashboard/src/lib/api.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { ApiError, isWorkspaceAuthError } from "./api";
+
+describe("isWorkspaceAuthError", () => {
+	it("is true for the workspace-assertion failures (400 missing, 403 not a member)", () => {
+		expect(isWorkspaceAuthError(new ApiError(400, "workspace required"))).toBe(
+			true,
+		);
+		expect(isWorkspaceAuthError(new ApiError(403, "forbidden"))).toBe(true);
+	});
+
+	it("is false for other statuses and non-ApiError throwables", () => {
+		expect(isWorkspaceAuthError(new ApiError(401, "unauthorized"))).toBe(false);
+		expect(isWorkspaceAuthError(new ApiError(422, "bad input"))).toBe(false);
+		expect(isWorkspaceAuthError(new ApiError(500, "boom"))).toBe(false);
+		expect(isWorkspaceAuthError(new Error("API 403: forbidden"))).toBe(false);
+		expect(isWorkspaceAuthError("nope")).toBe(false);
+	});
+
+	it("ApiError exposes status + body and a readable message", () => {
+		const e = new ApiError(403, '{"error":"forbidden"}');
+		expect(e.status).toBe(403);
+		expect(e.body).toBe('{"error":"forbidden"}');
+		expect(e.message).toContain("403");
+	});
+});

--- a/apps/dashboard/src/lib/api.ts
+++ b/apps/dashboard/src/lib/api.ts
@@ -6,6 +6,27 @@ export interface ApiOptions {
 	workspaceId?: string;
 }
 
+/** Carries the HTTP status so callers can branch (e.g. recover from a stale
+ * workspace) instead of string-matching the message. */
+export class ApiError extends Error {
+	constructor(
+		readonly status: number,
+		readonly body: string,
+	) {
+		super(`API ${status}: ${body}`);
+		this.name = "ApiError";
+	}
+}
+
+/** A failed `x-workspace-id` assertion: the active workspace is missing (400)
+ * or the user isn't a member of it (403). Onboarding uses this to self-heal a
+ * stale/broken workspace context by provisioning a fresh workspace. */
+export function isWorkspaceAuthError(error: unknown): boolean {
+	return (
+		error instanceof ApiError && (error.status === 400 || error.status === 403)
+	);
+}
+
 export async function api<T>(
 	path: string,
 	{ method = "GET", body, workspaceId }: ApiOptions = {},
@@ -20,7 +41,7 @@ export async function api<T>(
 		body: body ? JSON.stringify(body) : undefined,
 	});
 	if (!res.ok) {
-		throw new Error(`API ${res.status}: ${await res.text()}`);
+		throw new ApiError(res.status, await res.text());
 	}
 	return (await res.json()) as T;
 }

--- a/apps/dashboard/src/lib/bundle-check.test.ts
+++ b/apps/dashboard/src/lib/bundle-check.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+import { findUndefinedHelpers } from "../../scripts/check-bundle.mjs";
+
+describe("findUndefinedHelpers", () => {
+	it("flags a helper that is called but defined nowhere (the prod break)", () => {
+		const files = [
+			{ name: "sign-in.js", code: "foo();__name(Bar,'Bar');baz();" },
+		];
+		const broken = findUndefinedHelpers(files);
+		expect(broken).toEqual([{ helper: "__name", calledIn: ["sign-in.js"] }]);
+	});
+
+	it("passes when the helper is defined in any chunk, even a different one", () => {
+		const files = [
+			{ name: "runtime.js", code: "var __name=(t,n)=>t;" },
+			{ name: "sign-in.js", code: "__name(Bar,'Bar');" },
+		];
+		expect(findUndefinedHelpers(files)).toEqual([]);
+	});
+
+	it("recognizes a `function` definition form", () => {
+		const files = [
+			{ name: "a.js", code: "function __publicField(o,k,v){return v}" },
+			{ name: "b.js", code: "__publicField(this,'x',1);" },
+		];
+		expect(findUndefinedHelpers(files)).toEqual([]);
+	});
+
+	it("ignores webpack's own runtime identifiers", () => {
+		const files = [
+			{
+				name: "a.js",
+				code: "__webpack_require__(123);__webpack_exports__={};",
+			},
+		];
+		expect(findUndefinedHelpers(files)).toEqual([]);
+	});
+
+	it("returns clean for helper-free chunks", () => {
+		expect(
+			findUndefinedHelpers([{ name: "a.js", code: "console.log('hi')" }]),
+		).toEqual([]);
+	});
+
+	it("flags multiple distinct undefined helpers", () => {
+		const files = [
+			{ name: "a.js", code: "__spreadValues({},x);__objRest(y,[]);" },
+		];
+		const helpers = findUndefinedHelpers(files).map((b) => b.helper);
+		expect(helpers).toContain("__spreadValues");
+		expect(helpers).toContain("__objRest");
+	});
+});


### PR DESCRIPTION
## Symptoms (prod, llmchat-dashboard.meetploy.app)

- `Uncaught ReferenceError: __name is not defined` in the dashboard client bundle (sign-in chunk).
- `POST /api/projects → 403` repeated; new account stuck on `/onboarding`.

## Root cause (investigated, not assumed)

**`__name` was the primary bug; the 403 was a cascade.**

- `__name` is esbuild's `keepNames` helper. A dependency shipped as esbuild/tsup output expects the helper defined at its module top; when webpack code-split the prod bundle, the definition landed in a chunk that wasn't co-loaded with a call site, so client init threw `__name is not defined` and the auth/session/workspace context never hydrated.
- It is **not reproducible from current source**: no dependency in the tree ships `__name(` calls, a local `next build` is clean, and the **current live bundle has zero `__name`** (live chunk hashes match the clean local build). So it was a transient broken build from one deploy (the analytics/posthog merge window) — same builder-nondeterminism class as the prior `pnpm`/corepack deploy flakes.
- The **403 is a cascade**, not an API bug. I ran the **real prod signup flow**: sign-up → the provisioning hook **does** create a free-plan workspace + owner member → `GET /api/workspaces` returns it → `POST /api/projects` returns **200**. Unauthenticated requests get **401**, so the observed **403** only happens when a *valid session* sends an `x-workspace-id` it isn't a member of — i.e. the workspace context was broken/stale because client init had crashed.

## Fix

**1. Build-time bundle-integrity gate** (`apps/dashboard/scripts/check-bundle.mjs`, wired into `build`)
Scans built client chunks and **fails the build** if any esbuild/tsup helper (`__name`, `__publicField`, decorator/private-field/spread helpers) is *called but defined nowhere*. Converts the silent runtime ReferenceError into a hard build failure — this **would have caught the broken deploy**. Unit-tested (`bundle-check.test.ts`).

**2. Onboarding self-heal on workspace-auth failure**
`api()` now throws a typed `ApiError(status, body)`; new `isWorkspaceAuthError` (400/403). Onboarding creates-on-demand and, on a workspace-auth rejection, **provisions a fresh workspace and retries the project once** (and sets it active) so a broken/stale workspace context can no longer strand the user on a 403. Non-auth errors still surface.

## Tests (the gap: unit tests were green but nobody ran the browser/bundle)

- `bundle-check.test.ts` — undefined-helper detection (catches the bundling break).
- `onboarding/page.test.tsx` — real flow with the **real** `ApiError`/`isWorkspaceAuthError`: `403 on project create → provision fresh workspace → retry → finish`; and `422 → no retry` (catches/handles the 403).
- `api.test.ts` — `ApiError`/`isWorkspaceAuthError` contract.

`pnpm test` (all 4 packages), `pnpm lint`, `pnpm format` green. Full `next build` runs the gate (`bundle check OK — 38 chunks`).

## Verify on preview before merge

1. Open the preview `/sign-up`, create a new account → land on `/onboarding` with **no console `__name`/ReferenceError**.
2. Enter a chatbot name → project is created (no 403), finish screen shows the embed snippet.
3. Confirm the preview build log shows `bundle check OK`.

> Note: a throwaway account `hotfix-test-…@example.com` was created against prod during investigation — safe to delete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)