### PR TITLE
fix(showcase): repoint production widget to the operator's project key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,10 @@ dist/
 .env.*
 !.env.example
 !**/.env.example
+# Showcase production env holds ONLY a public NEXT_PUBLIC_WIDGET_KEY (the
+# operator's public project key) so the prod build is reproducible from the
+# repo. Public by design — never put secrets here.
+!apps/showcase/.env.production
 .dev.vars
 .DS_Store
 .idea/

--- a/apps/showcase/.env.example
+++ b/apps/showcase/.env.example
@@ -8,5 +8,6 @@ NEXT_PUBLIC_API_URL=http://localhost:8787
 # Canonical dashboard origin linked from the showcase copy.
 NEXT_PUBLIC_DASHBOARD_URL=http://localhost:3001
 # Public project/embed key the floating widget uses. Defaults to the seeded
-# local-dev-key; point at a real LLMChat project key in production.
+# local-dev-key for local dev. Production is set in the committed
+# apps/showcase/.env.production (loaded only by `next build`).
 NEXT_PUBLIC_WIDGET_KEY=local-dev-key

--- a/apps/showcase/.env.production
+++ b/apps/showcase/.env.production
@@ -1,0 +1,14 @@
+# Production-only env for the showcase build.
+#
+# Next.js loads this file ONLY for production builds (`next build`, which Ploy
+# runs on deploy) and NEVER for `next dev` — so local dev keeps falling back to
+# the code default `local-dev-key` in src/lib/api-url.ts.
+#
+# Repoints the live floating widget to the operator's real project. This is a
+# PUBLIC project/embed key (safe to commit); it carries no secret.
+#
+# Precedence note: a real `NEXT_PUBLIC_WIDGET_KEY` set in the Ploy dashboard env
+# would override this file at build time. As of this change the prod build uses
+# the code fallback (the live showcase serves `local-dev-key`), so no dashboard
+# override is set and this value takes effect on the next deploy.
+NEXT_PUBLIC_WIDGET_KEY=pk_be2dddeff3f7720be1709253f3fbe6bfbd6c0a2f82947e60


### PR DESCRIPTION
## Why

The operator has **no Ploy-dashboard access**, so the showcase's `NEXT_PUBLIC_WIDGET_KEY` can't be set there. Repoint it via the **repo** so it ships on the next deploy.

## Audit — how prod resolves the key today

- `apps/showcase/src/lib/api-url.ts`: `WIDGET_PROJECT_KEY = process.env.NEXT_PUBLIC_WIDGET_KEY ?? "local-dev-key"`.
- No `.env.production` existed; `apps/showcase/ploy.yaml` `env:` sets `NEXT_PUBLIC_API_URL`/`NEXT_PUBLIC_DASHBOARD_URL` but **not** the widget key.
- **Observed live:** the prod showcase bundle bakes **`local-dev-key`** — i.e. the code fallback, with **no Ploy-dashboard override set**. Since the dev seed was removed from prod, `local-dev-key` no longer resolves → the widget can't chat.

## Change (minimal, dev-safe)

Add committed **`apps/showcase/.env.production`** with:
```
NEXT_PUBLIC_WIDGET_KEY=pk_be2dddeff3f7720be1709253f3fbe6bfbd6c0a2f82947e60
```
Next.js loads `.env.production` **only** for `next build` (deploy), never `next dev` — so local dev keeps the `local-dev-key` fallback. A narrow `.gitignore` allow-list tracks the file (public `NEXT_PUBLIC_*` only; no secret). No code change.

### Verified locally
- `next build` bakes `pk_be2ddd…` (1×), `local-dev-key` gone (0×) from prod static.
- Next's own `@next/env` loader: `development → key unset (→ local-dev-key fallback)`, `production → pk_be2ddd…`.

## Could a Ploy-dashboard env var still override this?

Yes — **if** `NEXT_PUBLIC_WIDGET_KEY` is set as a real env var in the Ploy dashboard, it takes precedence over `.env.production` at build time (Next.js does not override existing `process.env`). **But it isn't set today** — the live bundle serves `local-dev-key` (the code fallback), proving no dashboard override is active. So this repo change is **sufficient on its own**. If a teammate ever sets that var, they'd need to clear/update it for this to take effect.

## Verify on preview
Load the preview showcase, open the floating bubble, confirm it chats against `pk_be2ddd…` (Network: `/v1/chat` 200). Prod confirmation after merge/deploy is the operator's to do on the live site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)