### PR TITLE
fix: route production cross-app links to deployed URLs (not localhost)

### DIFF
--- a/apps/marketing/ploy.yaml
+++ b/apps/marketing/ploy.yaml
@@ -2,5 +2,10 @@ kind: nextjs
 build: pnpm --filter @llmchat/marketing build
 out: .next
 
+env:
+  NEXT_PUBLIC_API_URL: https://llmchat-api.meetploy.app
+  NEXT_PUBLIC_DASHBOARD_URL: https://llmchat-dashboard--2105411.meetploy.app
+  NEXT_PUBLIC_SHOWCASE_URL: https://llmchat-showcase--2105411.meetploy.app
+
 dev:
   port: 3002

--- a/apps/showcase/ploy.yaml
+++ b/apps/showcase/ploy.yaml
@@ -4,7 +4,8 @@ out: .next
 
 env:
   NEXT_PUBLIC_API_URL: https://llmchat-api.meetploy.app
-  NEXT_PUBLIC_DASHBOARD_URL: https://llmchat-dashboard.meetploy.app
+  NEXT_PUBLIC_DASHBOARD_URL: https://llmchat-dashboard--2105411.meetploy.app
+  NEXT_PUBLIC_MARKETING_URL: https://llmchat-marketing--2105411.meetploy.app
 
 dev:
   port: 3003


### PR DESCRIPTION
## Problem

After deploying, clicking **Sign in** or **Dashboard** in the marketing site (and cross-app links in showcase) redirected to `localhost`.

The `NEXT_PUBLIC_*` URLs are baked into the Next.js bundle at build time. `apps/marketing/ploy.yaml` had no `env:` block, so production fell back to the `?? "http://localhost:3001"` defaults in the source. `apps/showcase/ploy.yaml` pointed at a non-suffixed dashboard URL and was missing the marketing URL entirely.

## Changes

**apps/marketing/ploy.yaml** — added the missing `env:` block:
- `NEXT_PUBLIC_DASHBOARD_URL` → `https://llmchat-dashboard--2105411.meetploy.app` (fixes Sign in / Dashboard buttons)
- `NEXT_PUBLIC_SHOWCASE_URL` → `https://llmchat-showcase--2105411.meetploy.app`
- `NEXT_PUBLIC_API_URL` → `https://llmchat-api.meetploy.app` (auth session check)

**apps/showcase/ploy.yaml**:
- `NEXT_PUBLIC_DASHBOARD_URL` → repointed to the commit-pinned URL
- `NEXT_PUBLIC_MARKETING_URL` → `https://llmchat-marketing--2105411.meetploy.app` (was missing)

## Notes

- These vars are compiled in at build time — **marketing and showcase must be redeployed** for the change to take effect.
- The API CORS/auth allowlist reads `MARKETING_URL` / `SHOWCASE_URL` / `DASHBOARD_URL` from deployment secrets (`$VAR` in `apps/api/ploy.yaml`). For cross-app sign-in to work, those deployment env vars must be set to the matching suffixed URLs — that's a meetploy config change, outside this repo.
- URLs are commit-pinned (`--2105411`) per request; they will need updating on the next deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)