### PR TITLE
feat: message rating — visitor thumbs up/down per assistant reply

### DIFF
--- a/apps/api/migrations/0009_message_rating.sql
+++ b/apps/api/migrations/0009_message_rating.sql
@@ -1,0 +1,5 @@
+-- Per-message visitor rating (thumbs up/down) for assistant replies.
+-- Nullable: NULL = unrated. Only assistant messages are rateable, enforced in
+-- the /v1/rating route rather than by a DB constraint. Additive ADD COLUMN,
+-- matching the 0005 pattern; Ploy's migration ledger applies each file once.
+ALTER TABLE `message` ADD COLUMN `rating` text;

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -13,6 +13,7 @@ import { sources } from "@/routes/sources";
 import { systemPrompts } from "@/routes/system-prompts";
 import { widgetAsset } from "@/routes/widget-asset";
 import { widgetMessages } from "@/routes/widget-messages";
+import { widgetRating } from "@/routes/widget-rating";
 import { workspaces } from "@/routes/workspaces";
 
 import type { AppContext } from "@/env";
@@ -75,6 +76,7 @@ app.on(["GET", "POST"], "/api/auth/*", (c) => {
 
 app.route("/v1", chat);
 app.route("/v1", widgetMessages);
+app.route("/v1", widgetRating);
 app.route("/api", workspaces);
 app.route("/api", projects);
 app.route("/api", systemPrompts);

--- a/apps/api/src/routes/widget-messages.ts
+++ b/apps/api/src/routes/widget-messages.ts
@@ -50,7 +50,7 @@ export const widgetMessages = new Hono<AppContext>().get(
 				a(e(ct.projectId, project.id), e(ct.clientId, clientId)),
 		});
 		if (!conv) {
-			return c.json({ messages: [] });
+			return c.json({ conversationId: null, messages: [] });
 		}
 
 		const rows = await db(c.env).query.message.findMany({
@@ -59,14 +59,18 @@ export const widgetMessages = new Hono<AppContext>().get(
 		});
 		// Conversation content: never cacheable by intermediaries.
 		c.header("cache-control", "no-store");
+		// The conversation id lets the widget address its own messages for
+		// rating; it's the caller's own id, not another tenant's.
 		// Only the fields the widget needs — no email ids, author ids, etc.
 		return c.json({
+			conversationId: conv.id,
 			messages: rows.map((m) => ({
 				id: m.id,
 				role: m.role,
 				content: m.content,
 				sequence: m.sequence,
 				createdAt: m.createdAt,
+				rating: m.rating,
 			})),
 		});
 	},

--- a/apps/api/src/routes/widget-rating.test.ts
+++ b/apps/api/src/routes/widget-rating.test.ts
@@ -1,0 +1,189 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { db } from "@/lib/db";
+
+import { widgetRating } from "./widget-rating";
+
+// A faithful in-memory fake: relational findFirst evaluates the route's real
+// where-callbacks against seeded rows, so cross-tenant rejections are actually
+// exercised (not stubbed). The single rating update is matched by message id.
+vi.mock("@/lib/db", () => ({ db: vi.fn() }));
+vi.mock("@/lib/kv", () => ({ rateLimit: vi.fn(async () => ({ ok: true })) }));
+vi.mock("@llmchat/db", async (orig) => ({
+	...(await orig<typeof import("@llmchat/db")>()),
+	// Capture the target id so the fake update can locate the row.
+	eq: (_col: unknown, val: unknown) => ({ eqVal: val }),
+}));
+
+type Row = Record<string, unknown>;
+
+function fakeDb(data: {
+	projects: Row[];
+	conversations: Row[];
+	messages: Row[];
+}) {
+	const ops = {
+		eq: (col: string, val: unknown) => (row: Row) => row[col] === val,
+		and:
+			(...preds: ((r: Row) => boolean)[]) =>
+			(row: Row) =>
+				preds.every((p) => p(row)),
+		or:
+			(...preds: ((r: Row) => boolean)[]) =>
+			(row: Row) =>
+				preds.some((p) => p(row)),
+	};
+	const tableProxy = new Proxy(
+		{},
+		{ get: (_t, prop) => prop },
+	) as unknown as Row;
+	const findFirst =
+		(rows: Row[]) =>
+		async ({
+			where,
+		}: {
+			where?: (t: Row, o: typeof ops) => (r: Row) => boolean;
+		}) =>
+			where ? rows.find(where(tableProxy, ops)) : rows[0];
+	return {
+		query: {
+			project: { findFirst: findFirst(data.projects) },
+			conversation: { findFirst: findFirst(data.conversations) },
+			message: { findFirst: findFirst(data.messages) },
+		},
+		update: () => ({
+			set: (vals: Row) => ({
+				where: async (cond: { eqVal?: unknown }) => {
+					const target = data.messages.find((m) => m.id === cond.eqVal);
+					if (target) Object.assign(target, vals);
+					return [];
+				},
+			}),
+		}),
+	};
+}
+
+/** Two tenants: project p1/client1 owns conversation c1 (assistant ma, user
+ * mu); project p2/client2 owns conversation c2 (assistant mb). */
+function seed() {
+	const data = {
+		projects: [
+			{ id: "p1", publicKey: "pk1" },
+			{ id: "p2", publicKey: "pk2" },
+		],
+		conversations: [
+			{ id: "c1", projectId: "p1", clientId: "client1" },
+			{ id: "c2", projectId: "p2", clientId: "client2" },
+		],
+		messages: [
+			{ id: "mu", conversationId: "c1", role: "user", rating: null },
+			{ id: "ma", conversationId: "c1", role: "assistant", rating: null },
+			{ id: "mb", conversationId: "c2", role: "assistant", rating: null },
+		],
+	};
+	vi.mocked(db).mockReturnValue(
+		fakeDb(data) as unknown as ReturnType<typeof db>,
+	);
+	return data;
+}
+
+const ENV = { vars: {}, DB: {} } as never;
+
+function rate(body: unknown) {
+	return widgetRating.request(
+		"/rating",
+		{
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify(body),
+		},
+		ENV,
+	);
+}
+
+const own = {
+	projectKey: "pk1",
+	clientId: "client1",
+	conversationId: "c1",
+	messageId: "ma",
+};
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("POST /v1/rating", () => {
+	it("persists a rating on the caller's own assistant message", async () => {
+		const data = seed();
+		const res = await rate({ ...own, rating: "up" });
+		expect(res.status).toBe(200);
+		expect(await res.json()).toEqual({ ok: true });
+		expect(data.messages.find((m) => m.id === "ma")?.rating).toBe("up");
+	});
+
+	it("toggles up → down → clear (last-write-wins)", async () => {
+		const data = seed();
+		const ma = () => data.messages.find((m) => m.id === "ma");
+		expect((await rate({ ...own, rating: "up" })).status).toBe(200);
+		expect(ma()?.rating).toBe("up");
+		expect((await rate({ ...own, rating: "down" })).status).toBe(200);
+		expect(ma()?.rating).toBe("down");
+		expect((await rate({ ...own, rating: null })).status).toBe(200);
+		expect(ma()?.rating).toBeNull();
+	});
+
+	it("rejects rating another project's message (wrong clientId)", async () => {
+		const data = seed();
+		// Caller from project 1 trying to rate project 2's conversation/message.
+		const res = await rate({
+			projectKey: "pk1",
+			clientId: "client1",
+			conversationId: "c2",
+			messageId: "mb",
+			rating: "up",
+		});
+		expect(res.status).toBe(404);
+		expect(data.messages.find((m) => m.id === "mb")?.rating).toBeNull();
+	});
+
+	it("rejects a clientId that doesn't own the conversation", async () => {
+		seed();
+		const res = await rate({ ...own, clientId: "intruder", rating: "up" });
+		expect(res.status).toBe(404);
+	});
+
+	it("rejects a message that isn't in the named conversation", async () => {
+		seed();
+		// mb belongs to c2, not c1 — message lookup must fail.
+		const res = await rate({ ...own, messageId: "mb", rating: "up" });
+		expect(res.status).toBe(404);
+	});
+
+	it("rejects rating a non-assistant message", async () => {
+		const data = seed();
+		const res = await rate({ ...own, messageId: "mu", rating: "up" });
+		expect(res.status).toBe(400);
+		expect(data.messages.find((m) => m.id === "mu")?.rating).toBeNull();
+	});
+
+	it("rejects an invalid project key", async () => {
+		seed();
+		const res = await rate({ ...own, projectKey: "nope", rating: "up" });
+		expect(res.status).toBe(404);
+	});
+
+	it("rejects a malformed body (missing rating)", async () => {
+		seed();
+		const res = await rate({
+			projectKey: "pk1",
+			clientId: "client1",
+			conversationId: "c1",
+			messageId: "ma",
+		});
+		expect(res.status).toBe(400);
+	});
+
+	it("rejects an out-of-range rating value", async () => {
+		seed();
+		const res = await rate({ ...own, rating: "sideways" });
+		expect(res.status).toBe(400);
+	});
+});

--- a/apps/api/src/routes/widget-rating.ts
+++ b/apps/api/src/routes/widget-rating.ts
@@ -1,0 +1,92 @@
+import { zValidator } from "@hono/zod-validator";
+import { Hono } from "hono";
+import { z } from "zod";
+
+import { db } from "@/lib/db";
+import { rateLimit } from "@/lib/kv";
+import { clientIp } from "@/lib/request";
+
+import { eq, message as messageTable } from "@llmchat/db";
+
+import type { AppContext } from "@/env";
+
+// `null` clears the rating; "up"/"down" set it. Last-write-wins on one column.
+const ratingBody = z.object({
+	projectKey: z.string().max(128),
+	clientId: z.string().max(128),
+	conversationId: z.string().max(128),
+	messageId: z.string().max(128),
+	rating: z.union([z.literal("up"), z.literal("down"), z.null()]),
+});
+
+// Visitors toggle freely; keep a generous budget that still caps abuse.
+const RATING_RATE_LIMIT_MAX = 240;
+const RATING_RATE_LIMIT_WINDOW = 60 * 60;
+
+/**
+ * Public per-message rating for the embedded widget. Same posture as
+ * /v1/chat and /v1/messages: anonymous, CORS-open, scoped by the (public)
+ * project key plus the visitor's own client id.
+ *
+ * Before writing, the full ownership chain is validated so a visitor can only
+ * ever rate an assistant message in their OWN conversation:
+ *   project(publicKey) → conversation(id, projectId, clientId) → message(id, conversationId, assistant)
+ * Any broken link is rejected (404), and non-assistant messages aren't rateable (400).
+ */
+export const widgetRating = new Hono<AppContext>().post(
+	"/rating",
+	zValidator("json", ratingBody),
+	async (c) => {
+		const { projectKey, clientId, conversationId, messageId, rating } =
+			c.req.valid("json");
+
+		const project = await db(c.env).query.project.findFirst({
+			where: (pt, { eq: e }) => e(pt.publicKey, projectKey),
+		});
+		if (!project) {
+			return c.json({ error: "invalid project key" }, 404);
+		}
+
+		const rl = await rateLimit(
+			c.env,
+			`rating:${project.id}:${clientIp(c)}`,
+			RATING_RATE_LIMIT_MAX,
+			RATING_RATE_LIMIT_WINDOW,
+		);
+		if (!rl.ok) {
+			return c.json({ error: "rate limit exceeded" }, 429);
+		}
+
+		// The conversation must belong to this project AND this caller's clientId.
+		const conv = await db(c.env).query.conversation.findFirst({
+			where: (ct, { and: a, eq: e }) =>
+				a(
+					e(ct.id, conversationId),
+					e(ct.projectId, project.id),
+					e(ct.clientId, clientId),
+				),
+		});
+		if (!conv) {
+			return c.json({ error: "not found" }, 404);
+		}
+
+		// The message must belong to that conversation.
+		const msg = await db(c.env).query.message.findFirst({
+			where: (mt, { and: a, eq: e }) =>
+				a(e(mt.id, messageId), e(mt.conversationId, conv.id)),
+		});
+		if (!msg) {
+			return c.json({ error: "not found" }, 404);
+		}
+		if (msg.role !== "assistant") {
+			return c.json({ error: "only assistant messages are rateable" }, 400);
+		}
+
+		await db(c.env)
+			.update(messageTable)
+			.set({ rating })
+			.where(eq(messageTable.id, msg.id));
+
+		return c.json({ ok: true });
+	},
+);

--- a/apps/dashboard/src/app/inbox/_components/DetailPanel.tsx
+++ b/apps/dashboard/src/app/inbox/_components/DetailPanel.tsx
@@ -167,15 +167,17 @@ export function DetailPanel({
 					/>
 				</Section>
 
-				<Section title="Rating">
-					{/* Placeholder: LLMChat has no rating/resolve data yet (TODO). */}
+				<Section title="Satisfaction">
+					{/* Disabled placeholder for the upcoming per-conversation CSAT
+					    feature — distinct from the per-message thumbs shown in the
+					    thread. Never show a fabricated number. */}
 					<div className="flex items-center gap-3 opacity-60">
 						<span className="text-muted-foreground/50">
 							<Star className="size-4" />
 						</span>
 						<div>
 							<p className="text-xs font-medium text-muted-foreground">
-								Visitor rating
+								Overall conversation rating
 							</p>
 							<p className="text-sm text-muted-foreground">Not collected yet</p>
 						</div>

--- a/apps/dashboard/src/app/inbox/_components/InboxStats.tsx
+++ b/apps/dashboard/src/app/inbox/_components/InboxStats.tsx
@@ -40,9 +40,10 @@ function StatItem({
 }
 
 /**
- * At-a-glance counts derived from the loaded conversation set. Ratings are a
- * disabled placeholder — LLMChat has no rating data yet (TODO: wire up once a
- * resolve/rate flow exists), so we never show a fabricated number.
+ * At-a-glance counts derived from the loaded conversation set. The avg rating
+ * is a disabled placeholder for the upcoming per-conversation CSAT feature
+ * (distinct from the per-message thumbs in the thread), so we never show a
+ * fabricated number.
  */
 export function InboxStats({
 	conversations,

--- a/apps/dashboard/src/app/inbox/_components/MessageThread.test.tsx
+++ b/apps/dashboard/src/app/inbox/_components/MessageThread.test.tsx
@@ -68,4 +68,34 @@ describe("MessageThread", () => {
 			screen.getByText(/no messages in this conversation/i),
 		).toBeInTheDocument();
 	});
+
+	it("surfaces the per-message rating on assistant replies", () => {
+		render(
+			<MessageThread
+				messages={[
+					msg({ role: "assistant", content: "up reply", rating: "up" }),
+					msg({ role: "assistant", content: "down reply", rating: "down" }),
+					msg({ role: "assistant", content: "neutral reply", rating: null }),
+				]}
+			/>,
+		);
+		expect(screen.getByText("Helpful")).toBeInTheDocument();
+		expect(screen.getByText("Not helpful")).toBeInTheDocument();
+		expect(screen.getByText("Not rated")).toBeInTheDocument();
+	});
+
+	it("does not show a rating indicator on visitor or admin messages", () => {
+		render(
+			<MessageThread
+				messages={[
+					msg({ role: "user", content: "hi", rating: "up" }),
+					msg({ role: "admin", content: "hello", rating: "down" }),
+				]}
+			/>,
+		);
+		// No rating chips render for non-assistant roles, even if data carried one.
+		expect(screen.queryByText("Helpful")).not.toBeInTheDocument();
+		expect(screen.queryByText("Not helpful")).not.toBeInTheDocument();
+		expect(screen.queryByText("Not rated")).not.toBeInTheDocument();
+	});
 });

--- a/apps/dashboard/src/app/inbox/_components/MessageThread.tsx
+++ b/apps/dashboard/src/app/inbox/_components/MessageThread.tsx
@@ -1,11 +1,40 @@
 "use client";
 
+import { ThumbsDown, ThumbsUp } from "lucide-react";
 import { useEffect, useRef } from "react";
 
 import { cn } from "@/lib/utils";
 
 import { formatMessageTime } from "./format";
 import type { Message } from "./types";
+
+/**
+ * Visitor's per-message thumbs (answer quality) on an assistant reply. Shows
+ * up / down / neutral clearly; read-only here. This is NOT the per-conversation
+ * CSAT placeholder in DetailPanel/InboxStats — those are a separate feature.
+ */
+function RatingIndicator({ rating }: { rating: Message["rating"] }) {
+	const base = "flex items-center gap-1 px-1 text-[11px] font-medium";
+	if (rating === "up") {
+		return (
+			<span className={cn(base, "text-emerald-600 dark:text-emerald-400")}>
+				<ThumbsUp className="size-3" />
+				Helpful
+			</span>
+		);
+	}
+	if (rating === "down") {
+		return (
+			<span className={cn(base, "text-rose-600 dark:text-rose-400")}>
+				<ThumbsDown className="size-3" />
+				Not helpful
+			</span>
+		);
+	}
+	return (
+		<span className={cn(base, "text-muted-foreground/60")}>Not rated</span>
+	);
+}
 
 const ROLE = {
 	user: { side: "left", label: "Visitor", labelClass: "text-muted-foreground" },
@@ -44,6 +73,9 @@ function MessageBubble({ message }: { message: Message }) {
 			<span className="px-1 text-[11px] text-muted-foreground">
 				{formatMessageTime(message.createdAt)}
 			</span>
+			{message.role === "assistant" && (
+				<RatingIndicator rating={message.rating} />
+			)}
 		</div>
 	);
 }

--- a/apps/dashboard/src/app/inbox/_components/types.ts
+++ b/apps/dashboard/src/app/inbox/_components/types.ts
@@ -22,4 +22,7 @@ export interface Message {
 	content: string;
 	sequence: number;
 	createdAt: string;
+	/** Visitor thumbs rating on an assistant reply (answer quality); null/absent
+	 * = unrated. Distinct from per-conversation CSAT. */
+	rating?: "up" | "down" | null;
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -234,6 +234,9 @@ export const message = sqliteTable(
 		role: text({ enum: ["user", "assistant", "admin", "system"] }).notNull(),
 		content: text().notNull(),
 		sequence: integer().notNull(),
+		// Visitor thumbs rating on an assistant reply; null = unrated. Only
+		// assistant messages are rateable (enforced in the /v1/rating route).
+		rating: text({ enum: ["up", "down"] }),
 		// Author for admin messages; null for user/assistant.
 		authorUserId: text().references(() => user.id),
 		// RFC 5322 Message-ID for outbound email threading + inbound matching.

--- a/packages/widget/src/components/MessageList.test.tsx
+++ b/packages/widget/src/components/MessageList.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { MessageList } from "./MessageList";
+import type { DisplayMessage } from "./MessageList";
+
+const assistant = (over: Partial<DisplayMessage> = {}): DisplayMessage => ({
+	id: "a1",
+	role: "assistant",
+	content: "Hello",
+	rateable: true,
+	rating: null,
+	...over,
+});
+
+describe("MessageList rating", () => {
+	it("shows thumbs on a rateable assistant message reflecting current state", () => {
+		render(
+			<MessageList
+				greeting="hi"
+				messages={[assistant({ rating: "up" })]}
+				typing={false}
+				error={null}
+				onRate={vi.fn()}
+			/>,
+		);
+		expect(screen.getByLabelText("Helpful")).toHaveAttribute(
+			"aria-pressed",
+			"true",
+		);
+		expect(screen.getByLabelText("Not helpful")).toHaveAttribute(
+			"aria-pressed",
+			"false",
+		);
+	});
+
+	it("calls onRate with the message id, current rating, and intent", async () => {
+		const onRate = vi.fn();
+		render(
+			<MessageList
+				greeting="hi"
+				messages={[assistant({ rating: "up" })]}
+				typing={false}
+				error={null}
+				onRate={onRate}
+			/>,
+		);
+		await userEvent.click(screen.getByLabelText("Not helpful"));
+		expect(onRate).toHaveBeenCalledWith("a1", "up", "down");
+	});
+
+	it("renders no thumbs for user messages", () => {
+		render(
+			<MessageList
+				greeting="hi"
+				messages={[{ id: "u1", role: "user", content: "hey" }]}
+				typing={false}
+				error={null}
+				onRate={vi.fn()}
+			/>,
+		);
+		expect(screen.queryByLabelText("Helpful")).not.toBeInTheDocument();
+	});
+
+	it("renders no thumbs when onRate is not provided", () => {
+		render(
+			<MessageList
+				greeting="hi"
+				messages={[assistant()]}
+				typing={false}
+				error={null}
+			/>,
+		);
+		expect(screen.queryByLabelText("Helpful")).not.toBeInTheDocument();
+	});
+});

--- a/packages/widget/src/components/MessageList.tsx
+++ b/packages/widget/src/components/MessageList.tsx
@@ -1,9 +1,46 @@
 import { useEffect, useRef } from "react";
 
+import type { Rating } from "../rating";
+import { ThumbDownIcon, ThumbUpIcon } from "./icons";
+
 export interface DisplayMessage {
 	id: string;
 	role: string;
 	content: string;
+	rating?: Rating;
+	/** True for persisted assistant messages the visitor can rate. */
+	rateable?: boolean;
+}
+
+function RateButtons({
+	rating,
+	onRate,
+}: {
+	rating: Rating;
+	onRate: (intent: "up" | "down") => void;
+}) {
+	return (
+		<div className="llmchat-rate">
+			<button
+				type="button"
+				className="llmchat-rate-btn"
+				aria-label="Helpful"
+				aria-pressed={rating === "up"}
+				onClick={() => onRate("up")}
+			>
+				<ThumbUpIcon />
+			</button>
+			<button
+				type="button"
+				className="llmchat-rate-btn"
+				aria-label="Not helpful"
+				aria-pressed={rating === "down"}
+				onClick={() => onRate("down")}
+			>
+				<ThumbDownIcon />
+			</button>
+		</div>
+	);
 }
 
 export function MessageList({
@@ -11,12 +48,16 @@ export function MessageList({
 	messages,
 	typing,
 	error,
+	onRate,
 }: {
 	greeting: string;
 	messages: DisplayMessage[];
 	typing: boolean;
 	/** Friendly error line rendered under the messages, or null. */
 	error: string | null;
+	/** Rate an assistant message; omit to hide the thumbs (e.g. before a
+	 * conversation exists). */
+	onRate?: (messageId: string, current: Rating, intent: "up" | "down") => void;
 }) {
 	const endRef = useRef<HTMLDivElement>(null);
 
@@ -29,13 +70,31 @@ export function MessageList({
 			{messages.length === 0 && (
 				<div className="llmchat-msg llmchat-msg-assistant">{greeting}</div>
 			)}
-			{messages.map((m) =>
-				m.content ? (
+			{messages.map((m) => {
+				if (!m.content) {
+					return null;
+				}
+				const bubble = (
+					<div className={`llmchat-msg llmchat-msg-${m.role}`}>{m.content}</div>
+				);
+				if (m.role === "assistant" && m.rateable && onRate) {
+					const rating = m.rating ?? null;
+					return (
+						<div key={m.id} className="llmchat-msg-group">
+							{bubble}
+							<RateButtons
+								rating={rating}
+								onRate={(intent) => onRate(m.id, rating, intent)}
+							/>
+						</div>
+					);
+				}
+				return (
 					<div key={m.id} className={`llmchat-msg llmchat-msg-${m.role}`}>
 						{m.content}
 					</div>
-				) : null,
-			)}
+				);
+			})}
 			{typing && (
 				<div
 					className="llmchat-msg llmchat-msg-assistant llmchat-typing"

--- a/packages/widget/src/components/icons.tsx
+++ b/packages/widget/src/components/icons.tsx
@@ -59,6 +59,46 @@ export function SendIcon({ className }: IconProps) {
 	);
 }
 
+export function ThumbUpIcon({ className }: IconProps) {
+	return (
+		<svg
+			className={className}
+			width="16"
+			height="16"
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="2"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			aria-hidden="true"
+		>
+			<path d="M7 10v12" />
+			<path d="M15 5.88 14 10h5.83a2 2 0 0 1 1.92 2.56l-2.33 8A2 2 0 0 1 17.5 22H4a2 2 0 0 1-2-2v-8a2 2 0 0 1 2-2h2.76a2 2 0 0 0 1.79-1.11L12 2a3.13 3.13 0 0 1 3 3.88Z" />
+		</svg>
+	);
+}
+
+export function ThumbDownIcon({ className }: IconProps) {
+	return (
+		<svg
+			className={className}
+			width="16"
+			height="16"
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="2"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			aria-hidden="true"
+		>
+			<path d="M17 14V2" />
+			<path d="M9 18.12 10 14H4.17a2 2 0 0 1-1.92-2.56l2.33-8A2 2 0 0 1 6.5 2H20a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2h-2.76a2 2 0 0 0-1.79 1.11L12 22a3.13 3.13 0 0 1-3-3.88Z" />
+		</svg>
+	);
+}
+
 export function AgentIcon({ className }: IconProps) {
 	return (
 		<svg

--- a/packages/widget/src/messages-sync.ts
+++ b/packages/widget/src/messages-sync.ts
@@ -1,4 +1,5 @@
 import type { DisplayMessage } from "./components/MessageList";
+import type { Rating } from "./rating";
 
 export interface ServerMessage {
 	id: string;
@@ -6,22 +7,33 @@ export interface ServerMessage {
 	content: string;
 	sequence: number;
 	createdAt: number;
+	rating?: Rating;
 }
 
-/** GET the persisted conversation feed; [] when none exists yet. */
+export interface MessageFeed {
+	/** The visitor's own conversation id (null until one exists), used to
+	 * address messages for rating. */
+	conversationId: string | null;
+	messages: ServerMessage[];
+}
+
+/** GET the persisted conversation feed; empty when none exists yet. */
 export async function fetchMessages(
 	apiUrl: string,
 	projectKey: string,
 	clientId: string,
 	signal?: AbortSignal,
-): Promise<ServerMessage[]> {
+): Promise<MessageFeed> {
 	const params = new URLSearchParams({ projectKey, clientId });
 	const res = await fetch(`${apiUrl}/v1/messages?${params}`, { signal });
 	if (!res.ok) {
 		throw new Error(`messages failed: ${res.status}`);
 	}
-	const data = (await res.json()) as { messages: ServerMessage[] };
-	return data.messages;
+	const data = (await res.json()) as Partial<MessageFeed>;
+	return {
+		conversationId: data.conversationId ?? null,
+		messages: data.messages ?? [],
+	};
 }
 
 /**
@@ -51,7 +63,15 @@ export function mergeMessages(
 		}
 	}
 	return [
-		...server.map((s) => ({ id: s.id, role: s.role, content: s.content })),
+		...server.map((s) => ({
+			id: s.id,
+			role: s.role,
+			content: s.content,
+			rating: s.rating ?? null,
+			// Only persisted assistant messages can be rated (they have a stable
+			// DB id); in-flight local messages can't until the feed catches up.
+			rateable: s.role === "assistant",
+		})),
 		...tail,
 	];
 }

--- a/packages/widget/src/rating.test.ts
+++ b/packages/widget/src/rating.test.ts
@@ -1,0 +1,93 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { rateMessage, useMessageRatings } from "./rating";
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("rateMessage", () => {
+	it("POSTs the rating to /v1/rating", async () => {
+		const fetchMock = vi
+			.fn()
+			.mockResolvedValue(new Response(JSON.stringify({ ok: true })));
+		vi.stubGlobal("fetch", fetchMock);
+
+		await rateMessage("http://x", {
+			projectKey: "pk",
+			clientId: "c",
+			conversationId: "cv",
+			messageId: "m1",
+			rating: "up",
+		});
+
+		expect(fetchMock).toHaveBeenCalledWith(
+			"http://x/v1/rating",
+			expect.objectContaining({ method: "POST" }),
+		);
+		const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+		expect(body).toMatchObject({ messageId: "m1", rating: "up" });
+	});
+
+	it("throws on a non-OK response", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValue(new Response("no", { status: 500 })),
+		);
+		await expect(
+			rateMessage("http://x", {
+				projectKey: "pk",
+				clientId: "c",
+				conversationId: "cv",
+				messageId: "m1",
+				rating: "down",
+			}),
+		).rejects.toThrow(/rating failed/);
+	});
+});
+
+describe("useMessageRatings", () => {
+	it("optimistically applies a rating", async () => {
+		const send = vi.fn().mockResolvedValue(undefined);
+		const { result } = renderHook(() => useMessageRatings(send));
+		await act(async () => {
+			await result.current.rate("m1", null, "up");
+		});
+		expect(result.current.effective("m1", null)).toBe("up");
+		expect(send).toHaveBeenCalledWith("m1", "up");
+	});
+
+	it("clears when the active thumb is clicked again", async () => {
+		const send = vi.fn().mockResolvedValue(undefined);
+		const { result } = renderHook(() => useMessageRatings(send));
+		await act(async () => {
+			await result.current.rate("m1", "up", "up");
+		});
+		expect(result.current.effective("m1", "up")).toBeNull();
+		expect(send).toHaveBeenCalledWith("m1", null);
+	});
+
+	it("switches up → down", async () => {
+		const send = vi.fn().mockResolvedValue(undefined);
+		const { result } = renderHook(() => useMessageRatings(send));
+		await act(async () => {
+			await result.current.rate("m1", "up", "down");
+		});
+		expect(result.current.effective("m1", "up")).toBe("down");
+	});
+
+	it("rolls back to the value shown before the click on failure", async () => {
+		const send = vi.fn().mockRejectedValue(new Error("boom"));
+		const { result } = renderHook(() => useMessageRatings(send));
+		await act(async () => {
+			await result.current.rate("m1", "up", "down");
+		});
+		// Override is restored to "up" (not the optimistic "down", not cleared):
+		// effective beats even a differing server value.
+		expect(result.current.effective("m1", null)).toBe("up");
+	});
+
+	it("falls back to the server value for untouched messages", () => {
+		const { result } = renderHook(() => useMessageRatings(vi.fn()));
+		expect(result.current.effective("mX", "down")).toBe("down");
+	});
+});

--- a/packages/widget/src/rating.ts
+++ b/packages/widget/src/rating.ts
@@ -1,0 +1,59 @@
+import { useCallback, useState } from "react";
+
+export type Rating = "up" | "down" | null;
+
+/** POST a per-message rating to the public widget API. `null` clears it. */
+export async function rateMessage(
+	apiUrl: string,
+	body: {
+		projectKey: string;
+		clientId: string;
+		conversationId: string;
+		messageId: string;
+		rating: Rating;
+	},
+): Promise<void> {
+	const res = await fetch(`${apiUrl}/v1/rating`, {
+		method: "POST",
+		headers: { "content-type": "application/json" },
+		body: JSON.stringify(body),
+	});
+	if (!res.ok) {
+		throw new Error(`rating failed: ${res.status}`);
+	}
+}
+
+/**
+ * Optimistic per-message rating overrides layered on top of the polled server
+ * feed. `rate` applies the new value immediately and rolls back to exactly what
+ * was shown if the request fails. Clicking the active thumb clears it; up↔down
+ * switches.
+ */
+export function useMessageRatings(
+	send: (messageId: string, rating: Rating) => Promise<void>,
+) {
+	const [overrides, setOverrides] = useState<Record<string, Rating>>({});
+
+	const rate = useCallback(
+		async (messageId: string, current: Rating, intent: "up" | "down") => {
+			const next: Rating = current === intent ? null : intent;
+			setOverrides((o) => ({ ...o, [messageId]: next }));
+			try {
+				await send(messageId, next);
+			} catch {
+				// Roll back to exactly what was displayed before the click.
+				setOverrides((o) => ({ ...o, [messageId]: current }));
+			}
+		},
+		[send],
+	);
+
+	/** The visitor's override if they've acted on this message, else the server value. */
+	const effective = useCallback(
+		(messageId: string, serverRating: Rating): Rating =>
+			messageId in overrides ? overrides[messageId] : serverRating,
+		[overrides],
+	);
+
+	return { rate, effective };
+}

--- a/packages/widget/src/styles.ts
+++ b/packages/widget/src/styles.ts
@@ -351,6 +351,56 @@ export const widgetStyles = `
 	padding: 0.25rem 0.75rem;
 }
 
+/* ── Per-message rating (assistant thumbs) ─────────────────────────── */
+/* Group an assistant bubble with its rating controls so they read as one
+   left-aligned unit. */
+.llmchat-msg-group {
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+	align-self: flex-start;
+	gap: 0.25rem;
+	max-width: 85%;
+}
+.llmchat-msg-group .llmchat-msg {
+	max-width: 100%;
+}
+.llmchat-rate {
+	display: flex;
+	gap: 0.125rem;
+	padding-left: 0.125rem;
+}
+.llmchat-rate-btn {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 1.625rem;
+	height: 1.625rem;
+	border-radius: 0.375rem;
+	background: transparent;
+	border: none;
+	color: #9ca3af;
+	cursor: pointer;
+	transition:
+		background 0.15s ease,
+		color 0.15s ease;
+}
+.llmchat-rate-btn:hover {
+	background: #f3f4f6;
+	color: #4b5563;
+}
+.llmchat-rate-btn[aria-pressed="true"] {
+	color: var(--brand);
+}
+.llmchat-rate-btn:focus-visible {
+	outline: none;
+	box-shadow: 0 0 0 2px color-mix(in srgb, var(--brand) 30%, transparent);
+}
+.llmchat-rate-btn svg {
+	width: 0.875rem;
+	height: 0.875rem;
+}
+
 /* Typing indicator: three bouncing dots inside an assistant bubble. */
 .llmchat-typing {
 	display: flex;

--- a/packages/widget/src/useServerMessages.ts
+++ b/packages/widget/src/useServerMessages.ts
@@ -15,8 +15,13 @@ export function useServerMessages(
 	projectKey: string,
 	clientId: string,
 	enabled: boolean,
-): { serverMessages: ServerMessage[]; refresh: () => void } {
+): {
+	serverMessages: ServerMessage[];
+	conversationId: string | null;
+	refresh: () => void;
+} {
 	const [serverMessages, setServerMessages] = useState<ServerMessage[]>([]);
+	const [conversationId, setConversationId] = useState<string | null>(null);
 	const abortRef = useRef<AbortController | null>(null);
 
 	const load = useCallback(async () => {
@@ -24,13 +29,14 @@ export function useServerMessages(
 		const controller = new AbortController();
 		abortRef.current = controller;
 		try {
-			const messages = await fetchMessages(
+			const feed = await fetchMessages(
 				apiUrl,
 				projectKey,
 				clientId,
 				controller.signal,
 			);
-			setServerMessages(messages);
+			setServerMessages(feed.messages);
+			setConversationId(feed.conversationId);
 		} catch {
 			// Transient poll failure — keep showing the last good feed.
 		}
@@ -52,5 +58,5 @@ export function useServerMessages(
 		void load();
 	}, [load]);
 
-	return { serverMessages, refresh };
+	return { serverMessages, conversationId, refresh };
 }

--- a/packages/widget/src/widget.tsx
+++ b/packages/widget/src/widget.tsx
@@ -1,6 +1,6 @@
 import { Chat, useChat } from "@ai-sdk/react";
 import { DefaultChatTransport } from "ai";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { Composer } from "./components/Composer";
 import { EscalationSection } from "./components/EscalationSection";
@@ -10,8 +10,11 @@ import { WidgetFrame } from "./components/WidgetFrame";
 import { requestEscalation } from "./escalation";
 import { getOrCreateClientId, getText } from "./lib";
 import { mergeMessages } from "./messages-sync";
+import { rateMessage, useMessageRatings } from "./rating";
 import { ShowcaseChat } from "./ShowcaseChat";
 import { useServerMessages } from "./useServerMessages";
+
+import type { Rating } from "./rating";
 
 /**
  * "live" (default) talks to the real API: conversations are created and
@@ -125,12 +128,30 @@ function LiveWidget({
 
 	// Poll the persisted feed while chatting so admin replies from the
 	// dashboard appear without a refresh.
-	const { serverMessages, refresh } = useServerMessages(
+	const { serverMessages, conversationId, refresh } = useServerMessages(
 		apiUrl,
 		projectKey,
 		clientId,
 		open && identified,
 	);
+
+	// Per-message thumbs: optimistic, rolling back if the request fails.
+	const sendRating = useCallback(
+		async (messageId: string, rating: Rating) => {
+			if (!conversationId) {
+				return;
+			}
+			await rateMessage(apiUrl, {
+				projectKey,
+				clientId,
+				conversationId,
+				messageId,
+				rating,
+			});
+		},
+		[apiUrl, projectKey, clientId, conversationId],
+	);
+	const { rate, effective } = useMessageRatings(sendRating);
 
 	// Refetch as soon as a send settles (stream finished or failed) so the
 	// just-persisted exchange replaces the local copy immediately.
@@ -147,8 +168,10 @@ function LiveWidget({
 			mergeMessages(
 				serverMessages,
 				messages.map((m) => ({ id: m.id, role: m.role, content: getText(m) })),
+			).map((m) =>
+				m.rateable ? { ...m, rating: effective(m.id, m.rating ?? null) } : m,
 			),
-		[serverMessages, messages],
+		[serverMessages, messages, effective],
 	);
 	const userMessageCount = displayMessages.filter(
 		(m) => m.role === "user",
@@ -209,6 +232,7 @@ function LiveWidget({
 						messages={displayMessages}
 						typing={loading}
 						error={sendFailed ? SEND_ERROR : null}
+						onRate={conversationId ? rate : undefined}
 					/>
 					{showEscalation && (
 						<EscalationSection


### PR DESCRIPTION
## What & why

Adds **per-assistant-message** thumbs up/down (answer quality). Visitors rate individual bot replies in the widget; the rating persists on the message and surfaces in the dashboard inbox thread.

### Step 0 alignment (per decision)
The inbox's existing rating placeholders (DetailPanel ⭐ "Visitor rating", InboxStats "avg rating") are **per-conversation CSAT**, a separate upcoming feature — not per-message. As agreed (Option 3):
- New **per-message 👍/👎** lives in the thread (`MessageThread`).
- The per-conversation **CSAT placeholders are left disabled**, not removed/repurposed; copy clarified so they read as "overall conversation rating" rather than implying the new thumbs are missing.
- The two systems are kept distinct; thumbs are **not** aggregated into the star fields.

## Changes
- **DB** — nullable `message.rating` (`'up'|'down'`); additive `0009_message_rating.sql` (`ADD COLUMN`, matching the 0005 pattern; Ploy applies each migration once).
- **API** — `POST /v1/rating` (public, CORS-open like `/v1/chat`). Validates the full ownership chain `project(publicKey) → conversation(id, projectId, clientId) → message(id, conversationId, assistant)` before writing; broken links → 404, non-assistant → 400, toggle/clear idempotent (single column, last-write-wins). `/v1/messages` now also returns `conversationId` + per-message `rating` so the widget can address its own messages.
- **Widget** — thumbs on each persisted assistant bubble in the shadow DOM; optimistic with rollback to the prior value on failure; clicking the active thumb clears, up↔down switches. Only server-persisted assistant messages are rateable.
- **Inbox** — read-only per-message indicator (helpful / not helpful / not rated) on assistant bubbles, fed server-side from `message.rating` via the existing conversation-detail endpoint.

## Security
A visitor can only rate an assistant message in **their own** conversation: the route asserts the conversation belongs to both the project (by public key) and the caller's `clientId`, and that the message belongs to that conversation. No secrets; the endpoint returns only `{ ok: true }`.

## Tests (offline, key-free)
- **api** (81): ownership-chain rejections (wrong clientId / cross-tenant / message not in conversation), non-assistant rejection, toggle up→down→clear, invalid key/body — via a predicate-evaluating fake `db` that runs the route's real where-clauses.
- **widget** (57): rating client, optimistic/toggle/rollback hook, `MessageList` thumb rendering + callback.
- **dashboard** (152): inbox indicator renders up/down/neutral; none on visitor/admin rows.

## Operator notes
- **Migration** auto-applies on deploy via Ploy's filesystem scan — no manual step.
- **Widget bundle** (`apps/api/src/generated/widget-bundle.ts`) is gitignored and regenerated by the widget build; rebuilt and verified locally to include the rating UI. No env/config changes.

Not merged — feature branch + PR per the task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)