### PR TITLE
feat: end-of-conversation CSAT — 1–5 star rating on widget close

### DIFF
--- a/apps/api/migrations/0010_conversation_csat.sql
+++ b/apps/api/migrations/0010_conversation_csat.sql
@@ -1,0 +1,5 @@
+-- End-of-conversation CSAT (1–5 star) rating, prompted on widget close.
+-- Nullable: NULL = unrated. Distinct from per-message thumbs (message.rating).
+-- Range is enforced in the /v1/csat route, not by a DB constraint. Additive
+-- ADD COLUMN matching the 0005/0009 pattern; Ploy's ledger applies each file once.
+ALTER TABLE `conversation` ADD COLUMN `csat_rating` integer;

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -12,6 +12,7 @@ import { projects } from "@/routes/projects";
 import { sources } from "@/routes/sources";
 import { systemPrompts } from "@/routes/system-prompts";
 import { widgetAsset } from "@/routes/widget-asset";
+import { widgetCsat } from "@/routes/widget-csat";
 import { widgetMessages } from "@/routes/widget-messages";
 import { widgetRating } from "@/routes/widget-rating";
 import { workspaces } from "@/routes/workspaces";
@@ -77,6 +78,7 @@ app.on(["GET", "POST"], "/api/auth/*", (c) => {
 app.route("/v1", chat);
 app.route("/v1", widgetMessages);
 app.route("/v1", widgetRating);
+app.route("/v1", widgetCsat);
 app.route("/api", workspaces);
 app.route("/api", projects);
 app.route("/api", systemPrompts);

--- a/apps/api/src/routes/widget-csat.test.ts
+++ b/apps/api/src/routes/widget-csat.test.ts
@@ -1,0 +1,165 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { db } from "@/lib/db";
+
+import { widgetCsat } from "./widget-csat";
+
+// Faithful in-memory fake: findFirst evaluates the route's real where-callbacks
+// against seeded rows, so cross-tenant rejections are actually exercised. The
+// single conversation update is matched by id.
+vi.mock("@/lib/db", () => ({ db: vi.fn() }));
+vi.mock("@/lib/kv", () => ({ rateLimit: vi.fn(async () => ({ ok: true })) }));
+vi.mock("@llmchat/db", async (orig) => ({
+	...(await orig<typeof import("@llmchat/db")>()),
+	eq: (_col: unknown, val: unknown) => ({ eqVal: val }),
+}));
+
+type Row = Record<string, unknown>;
+
+function fakeDb(data: { projects: Row[]; conversations: Row[] }) {
+	const ops = {
+		eq: (col: string, val: unknown) => (row: Row) => row[col] === val,
+		and:
+			(...preds: ((r: Row) => boolean)[]) =>
+			(row: Row) =>
+				preds.every((p) => p(row)),
+	};
+	const tableProxy = new Proxy(
+		{},
+		{ get: (_t, prop) => prop },
+	) as unknown as Row;
+	const findFirst =
+		(rows: Row[]) =>
+		async ({
+			where,
+		}: {
+			where?: (t: Row, o: typeof ops) => (r: Row) => boolean;
+		}) =>
+			where ? rows.find(where(tableProxy, ops)) : rows[0];
+	return {
+		query: {
+			project: { findFirst: findFirst(data.projects) },
+			conversation: { findFirst: findFirst(data.conversations) },
+		},
+		update: () => ({
+			set: (vals: Row) => ({
+				where: async (cond: { eqVal?: unknown }) => {
+					const target = data.conversations.find((cv) => cv.id === cond.eqVal);
+					if (target) Object.assign(target, vals);
+					return [];
+				},
+			}),
+		}),
+	};
+}
+
+/** Two tenants: project p1/client1 owns conversation c1; p2/client2 owns c2. */
+function seed() {
+	const data: { projects: Row[]; conversations: Row[] } = {
+		projects: [
+			{ id: "p1", publicKey: "pk1" },
+			{ id: "p2", publicKey: "pk2" },
+		],
+		conversations: [
+			{ id: "c1", projectId: "p1", clientId: "client1", csatRating: null },
+			{ id: "c2", projectId: "p2", clientId: "client2", csatRating: null },
+		],
+	};
+	vi.mocked(db).mockReturnValue(
+		fakeDb(data) as unknown as ReturnType<typeof db>,
+	);
+	return data;
+}
+
+const ENV = { vars: {}, DB: {} } as never;
+
+function csat(body: unknown) {
+	return widgetCsat.request(
+		"/csat",
+		{
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify(body),
+		},
+		ENV,
+	);
+}
+
+const own = { projectKey: "pk1", clientId: "client1", conversationId: "c1" };
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("POST /v1/csat", () => {
+	it("persists a 1–5 rating on the caller's own conversation", async () => {
+		const data = seed();
+		const res = await csat({ ...own, rating: 4 });
+		expect(res.status).toBe(200);
+		expect(await res.json()).toEqual({ ok: true });
+		expect(data.conversations.find((c) => c.id === "c1")?.csatRating).toBe(4);
+	});
+
+	it("accepts the boundary values 1 and 5", async () => {
+		const data = seed();
+		expect((await csat({ ...own, rating: 1 })).status).toBe(200);
+		expect(data.conversations[0].csatRating).toBe(1);
+		expect((await csat({ ...own, rating: 5 })).status).toBe(200);
+		expect(data.conversations[0].csatRating).toBe(5);
+	});
+
+	it("clears the rating with null", async () => {
+		const data = seed();
+		data.conversations[0].csatRating = 3;
+		const res = await csat({ ...own, rating: null });
+		expect(res.status).toBe(200);
+		expect(data.conversations[0].csatRating).toBeNull();
+	});
+
+	it("rejects rating another tenant's conversation", async () => {
+		const data = seed();
+		// project 1 caller targeting project 2's conversation
+		const res = await csat({
+			projectKey: "pk1",
+			clientId: "client1",
+			conversationId: "c2",
+			rating: 5,
+		});
+		expect(res.status).toBe(404);
+		expect(
+			data.conversations.find((c) => c.id === "c2")?.csatRating,
+		).toBeNull();
+	});
+
+	it("rejects a clientId that doesn't own the conversation", async () => {
+		seed();
+		const res = await csat({ ...own, clientId: "intruder", rating: 3 });
+		expect(res.status).toBe(404);
+	});
+
+	it("rejects an invalid project key", async () => {
+		seed();
+		expect((await csat({ ...own, projectKey: "nope", rating: 3 })).status).toBe(
+			404,
+		);
+	});
+
+	it("rejects out-of-range ratings (0 and 6)", async () => {
+		seed();
+		expect((await csat({ ...own, rating: 0 })).status).toBe(400);
+		expect((await csat({ ...own, rating: 6 })).status).toBe(400);
+	});
+
+	it("rejects a non-integer rating", async () => {
+		seed();
+		expect((await csat({ ...own, rating: 3.5 })).status).toBe(400);
+	});
+
+	it("rejects a missing rating field", async () => {
+		seed();
+		const res = await csat({
+			projectKey: "pk1",
+			clientId: "client1",
+			conversationId: "c1",
+		});
+		expect(res.status).toBe(400);
+	});
+});

--- a/apps/api/src/routes/widget-csat.ts
+++ b/apps/api/src/routes/widget-csat.ts
@@ -1,0 +1,78 @@
+import { zValidator } from "@hono/zod-validator";
+import { Hono } from "hono";
+import { z } from "zod";
+
+import { db } from "@/lib/db";
+import { rateLimit } from "@/lib/kv";
+import { clientIp } from "@/lib/request";
+
+import { conversation, eq } from "@llmchat/db";
+
+import type { AppContext } from "@/env";
+
+// `null` clears; 1–5 sets the star rating. Out-of-range / non-integer → 400.
+const csatBody = z.object({
+	projectKey: z.string().max(128),
+	clientId: z.string().max(128),
+	conversationId: z.string().max(128),
+	rating: z.union([z.number().int().min(1).max(5), z.null()]),
+});
+
+const CSAT_RATE_LIMIT_MAX = 60;
+const CSAT_RATE_LIMIT_WINDOW = 60 * 60;
+
+/**
+ * Public end-of-conversation CSAT for the embedded widget. Same posture as
+ * /v1/chat and /v1/rating: anonymous, CORS-open, scoped by the (public) project
+ * key plus the visitor's own client id.
+ *
+ * Validates the ownership chain before writing so a visitor can only rate their
+ * OWN conversation: project(publicKey) → conversation(id, projectId, clientId).
+ * A broken link is rejected (404); the rating is conversation-level (distinct
+ * from per-message thumbs).
+ */
+export const widgetCsat = new Hono<AppContext>().post(
+	"/csat",
+	zValidator("json", csatBody),
+	async (c) => {
+		const { projectKey, clientId, conversationId, rating } =
+			c.req.valid("json");
+
+		const project = await db(c.env).query.project.findFirst({
+			where: (pt, { eq: e }) => e(pt.publicKey, projectKey),
+		});
+		if (!project) {
+			return c.json({ error: "invalid project key" }, 404);
+		}
+
+		const rl = await rateLimit(
+			c.env,
+			`csat:${project.id}:${clientIp(c)}`,
+			CSAT_RATE_LIMIT_MAX,
+			CSAT_RATE_LIMIT_WINDOW,
+		);
+		if (!rl.ok) {
+			return c.json({ error: "rate limit exceeded" }, 429);
+		}
+
+		// The conversation must belong to this project AND this caller's clientId.
+		const conv = await db(c.env).query.conversation.findFirst({
+			where: (ct, { and: a, eq: e }) =>
+				a(
+					e(ct.id, conversationId),
+					e(ct.projectId, project.id),
+					e(ct.clientId, clientId),
+				),
+		});
+		if (!conv) {
+			return c.json({ error: "not found" }, 404);
+		}
+
+		await db(c.env)
+			.update(conversation)
+			.set({ csatRating: rating })
+			.where(eq(conversation.id, conv.id));
+
+		return c.json({ ok: true });
+	},
+);

--- a/apps/api/src/routes/widget-messages.ts
+++ b/apps/api/src/routes/widget-messages.ts
@@ -50,7 +50,7 @@ export const widgetMessages = new Hono<AppContext>().get(
 				a(e(ct.projectId, project.id), e(ct.clientId, clientId)),
 		});
 		if (!conv) {
-			return c.json({ conversationId: null, messages: [] });
+			return c.json({ conversationId: null, csatRating: null, messages: [] });
 		}
 
 		const rows = await db(c.env).query.message.findMany({
@@ -64,6 +64,8 @@ export const widgetMessages = new Hono<AppContext>().get(
 		// Only the fields the widget needs — no email ids, author ids, etc.
 		return c.json({
 			conversationId: conv.id,
+			// Conversation-level CSAT so the widget never re-prompts a rated visitor.
+			csatRating: conv.csatRating,
 			messages: rows.map((m) => ({
 				id: m.id,
 				role: m.role,

--- a/apps/dashboard/src/app/inbox/_components/ConversationList.test.tsx
+++ b/apps/dashboard/src/app/inbox/_components/ConversationList.test.tsx
@@ -19,6 +19,7 @@ function conv(overrides: Partial<Conversation>): Conversation {
 		archivedAt: null,
 		createdAt: "2026-06-16T05:00:00.000Z",
 		updatedAt: "2026-06-16T05:00:00.000Z",
+		csatRating: null,
 		firstMessage: "How do I reset my device?",
 		...overrides,
 	};

--- a/apps/dashboard/src/app/inbox/_components/DetailPanel.test.tsx
+++ b/apps/dashboard/src/app/inbox/_components/DetailPanel.test.tsx
@@ -20,6 +20,7 @@ function conv(overrides: Partial<Conversation> = {}): Conversation {
 		archivedAt: null,
 		createdAt: "2026-06-16T05:00:00.000Z",
 		updatedAt: "2026-06-16T05:00:00.000Z",
+		csatRating: null,
 		...overrides,
 	};
 }
@@ -65,9 +66,15 @@ describe("DetailPanel", () => {
 		expect(screen.getByText(/escalated to a human/i)).toBeInTheDocument();
 	});
 
-	it("renders ratings as a disabled placeholder, not a number", () => {
-		setup();
-		expect(screen.getByText(/not collected yet/i)).toBeInTheDocument();
+	it("shows 'Not rated' when the conversation has no CSAT", () => {
+		setup({ csatRating: null });
+		expect(screen.getByText(/not rated/i)).toBeInTheDocument();
+	});
+
+	it("shows the CSAT score when the conversation is rated", () => {
+		setup({ csatRating: 4 });
+		expect(screen.getByText(/4 \/ 5/)).toBeInTheDocument();
+		expect(screen.queryByText(/not rated/i)).not.toBeInTheDocument();
 	});
 
 	it("archives directly but confirms before deleting", async () => {

--- a/apps/dashboard/src/app/inbox/_components/DetailPanel.tsx
+++ b/apps/dashboard/src/app/inbox/_components/DetailPanel.tsx
@@ -168,18 +168,30 @@ export function DetailPanel({
 				</Section>
 
 				<Section title="Satisfaction">
-					{/* Disabled placeholder for the upcoming per-conversation CSAT
-					    feature — distinct from the per-message thumbs shown in the
-					    thread. Never show a fabricated number. */}
-					<div className="flex items-center gap-3 opacity-60">
-						<span className="text-muted-foreground/50">
-							<Star className="size-4" />
+					{/* Conversation-level CSAT (1–5), prompted on widget close — distinct
+					    from the per-message thumbs shown in the thread. */}
+					<div className="flex items-center gap-3">
+						<span
+							className={
+								conversation.csatRating != null
+									? "text-amber-500"
+									: "text-muted-foreground/50"
+							}
+						>
+							<Star
+								className="size-4"
+								fill={conversation.csatRating != null ? "currentColor" : "none"}
+							/>
 						</span>
 						<div>
 							<p className="text-xs font-medium text-muted-foreground">
 								Overall conversation rating
 							</p>
-							<p className="text-sm text-muted-foreground">Not collected yet</p>
+							<p className="text-sm text-foreground">
+								{conversation.csatRating != null
+									? `${conversation.csatRating} / 5 ★`
+									: "Not rated"}
+							</p>
 						</div>
 					</div>
 				</Section>

--- a/apps/dashboard/src/app/inbox/_components/InboxStats.test.tsx
+++ b/apps/dashboard/src/app/inbox/_components/InboxStats.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { InboxStats } from "./InboxStats";
+
+import type { Conversation } from "./types";
+
+function conv(overrides: Partial<Conversation> = {}): Conversation {
+	return {
+		id: crypto.randomUUID(),
+		clientId: "c",
+		name: null,
+		email: null,
+		ipAddress: null,
+		userAgent: null,
+		messageCount: 2,
+		escalatedAt: null,
+		archivedAt: null,
+		createdAt: "2026-06-16T05:00:00.000Z",
+		updatedAt: "2026-06-16T05:00:00.000Z",
+		csatRating: null,
+		...overrides,
+	};
+}
+
+/** The avg rating chip is the only stat labelled "avg rating". */
+function avgValue(): string | null {
+	const label = screen.getByText("avg rating");
+	// StatItem renders [value][label] as siblings; value is the previous span.
+	return label.previousElementSibling?.textContent ?? null;
+}
+
+describe("InboxStats avg rating", () => {
+	it("averages only the rated conversations", () => {
+		render(
+			<InboxStats
+				conversations={[
+					conv({ csatRating: 5 }),
+					conv({ csatRating: 3 }),
+					conv({ csatRating: null }), // unrated: excluded from the average
+				]}
+			/>,
+		);
+		expect(avgValue()).toBe("4.0");
+	});
+
+	it("shows a dash (no NaN) when nothing is rated", () => {
+		render(<InboxStats conversations={[conv({ csatRating: null }), conv()]} />);
+		expect(avgValue()).toBe("—");
+	});
+
+	it("is safe with an empty conversation set", () => {
+		render(<InboxStats conversations={[]} />);
+		expect(avgValue()).toBe("—");
+	});
+
+	it("rounds the average to one decimal", () => {
+		render(
+			<InboxStats
+				conversations={[
+					conv({ csatRating: 5 }),
+					conv({ csatRating: 4 }),
+					conv({ csatRating: 4 }),
+				]}
+			/>,
+		);
+		expect(avgValue()).toBe("4.3");
+	});
+});

--- a/apps/dashboard/src/app/inbox/_components/InboxStats.tsx
+++ b/apps/dashboard/src/app/inbox/_components/InboxStats.tsx
@@ -55,6 +55,14 @@ export function InboxStats({
 	const escalated = conversations.filter((c) => c.escalatedAt).length;
 	const archived = conversations.filter((c) => c.archivedAt).length;
 
+	// Average CSAT across rated conversations only. Null when none are rated —
+	// shown as "—" rather than a fabricated number or NaN.
+	const rated = conversations.filter((c) => c.csatRating != null);
+	const avgRating =
+		rated.length > 0
+			? rated.reduce((sum, c) => sum + (c.csatRating ?? 0), 0) / rated.length
+			: null;
+
 	return (
 		<div className="flex flex-wrap items-center gap-x-6 gap-y-2 border-b bg-card px-4 py-2.5">
 			<StatItem
@@ -81,15 +89,12 @@ export function InboxStats({
 				label="archived"
 			/>
 
-			<div
-				className="ml-auto cursor-default select-none opacity-60"
-				title="Ratings aren't collected yet"
-			>
+			<div className="ml-auto">
 				<StatItem
 					icon={<Star className="size-4" />}
-					value="—"
+					value={avgRating != null ? avgRating.toFixed(1) : "—"}
 					label="avg rating"
-					tone="muted"
+					tone={avgRating != null ? undefined : "muted"}
 				/>
 			</div>
 		</div>

--- a/apps/dashboard/src/app/inbox/_components/types.ts
+++ b/apps/dashboard/src/app/inbox/_components/types.ts
@@ -10,6 +10,9 @@ export interface Conversation {
 	archivedAt: string | null;
 	createdAt: string;
 	updatedAt: string;
+	/** End-of-conversation CSAT (1–5 stars); null when the visitor didn't rate.
+	 * Distinct from per-message thumbs (Message.rating). */
+	csatRating: number | null;
 	/** First visitor message, used as the list preview (added by the list API). */
 	firstMessage?: string | null;
 	/** True when the current user hasn't seen the latest messages. */

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -174,6 +174,10 @@ export const conversation = sqliteTable(
 		messageCount: integer().notNull().default(0),
 		escalatedAt: timestamp(),
 		archivedAt: timestamp(),
+		// End-of-conversation CSAT (1–5 stars), prompted on widget close; null =
+		// unrated. Distinct from per-message thumbs (message.rating). Range is
+		// enforced in the /v1/csat route, not by a DB constraint.
+		csatRating: integer(),
 		createdAt: createdAt(),
 		updatedAt: timestamp()
 			.notNull()

--- a/packages/widget/src/components/CsatStep.test.tsx
+++ b/packages/widget/src/components/CsatStep.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { CsatStep } from "./CsatStep";
+
+describe("CsatStep", () => {
+	it("renders the prompt with five star buttons", () => {
+		render(<CsatStep step="prompt" onRate={vi.fn()} onSkip={vi.fn()} />);
+		expect(screen.getByText(/how was your experience/i)).toBeInTheDocument();
+		expect(screen.getAllByRole("button", { name: /star/i })).toHaveLength(5);
+		expect(
+			screen.getByRole("button", { name: /^3 stars$/i }),
+		).toBeInTheDocument();
+	});
+
+	it("submits the tapped star value", async () => {
+		const onRate = vi.fn();
+		render(<CsatStep step="prompt" onRate={onRate} onSkip={vi.fn()} />);
+		await userEvent.click(screen.getByRole("button", { name: /^4 stars$/i }));
+		expect(onRate).toHaveBeenCalledWith(4);
+	});
+
+	it("skips without rating", async () => {
+		const onRate = vi.fn();
+		const onSkip = vi.fn();
+		render(<CsatStep step="prompt" onRate={onRate} onSkip={onSkip} />);
+		await userEvent.click(screen.getByRole("button", { name: /skip/i }));
+		expect(onSkip).toHaveBeenCalledTimes(1);
+		expect(onRate).not.toHaveBeenCalled();
+	});
+
+	it("shows a thank-you on the thanks step (no stars)", () => {
+		render(<CsatStep step="thanks" onRate={vi.fn()} onSkip={vi.fn()} />);
+		expect(screen.getByText(/thanks for your feedback/i)).toBeInTheDocument();
+		expect(
+			screen.queryByRole("button", { name: /star/i }),
+		).not.toBeInTheDocument();
+	});
+});

--- a/packages/widget/src/components/CsatStep.tsx
+++ b/packages/widget/src/components/CsatStep.tsx
@@ -1,0 +1,57 @@
+import { useState } from "react";
+
+import { StarIcon } from "./icons";
+
+/**
+ * Closing screen: a 1–5 star "How was your experience?" prompt, or a brief
+ * thank-you after a rating is submitted. Tapping a star submits; "Skip" (and the
+ * frame's close button) always dismiss — the visitor is never trapped.
+ */
+export function CsatStep({
+	step,
+	onRate,
+	onSkip,
+}: {
+	step: "prompt" | "thanks";
+	onRate: (rating: number) => void;
+	onSkip: () => void;
+}) {
+	const [hover, setHover] = useState(0);
+
+	if (step === "thanks") {
+		return (
+			<div className="llmchat-csat" role="status">
+				<p className="llmchat-csat-title">Thanks for your feedback!</p>
+			</div>
+		);
+	}
+
+	return (
+		<div className="llmchat-csat">
+			<p className="llmchat-csat-title">How was your experience?</p>
+			<div
+				className="llmchat-csat-stars"
+				role="group"
+				aria-label="Rate from 1 to 5 stars"
+				onMouseLeave={() => setHover(0)}
+			>
+				{[1, 2, 3, 4, 5].map((n) => (
+					<button
+						key={n}
+						type="button"
+						className="llmchat-csat-star"
+						aria-label={`${n} star${n > 1 ? "s" : ""}`}
+						aria-pressed={false}
+						onMouseEnter={() => setHover(n)}
+						onClick={() => onRate(n)}
+					>
+						<StarIcon filled={n <= hover} />
+					</button>
+				))}
+			</div>
+			<button type="button" className="llmchat-csat-skip" onClick={onSkip}>
+				Skip
+			</button>
+		</div>
+	);
+}

--- a/packages/widget/src/components/icons.tsx
+++ b/packages/widget/src/components/icons.tsx
@@ -99,6 +99,28 @@ export function ThumbDownIcon({ className }: IconProps) {
 	);
 }
 
+export function StarIcon({
+	className,
+	filled,
+}: IconProps & { filled?: boolean }) {
+	return (
+		<svg
+			className={className}
+			width="28"
+			height="28"
+			viewBox="0 0 24 24"
+			fill={filled ? "currentColor" : "none"}
+			stroke="currentColor"
+			strokeWidth="2"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			aria-hidden="true"
+		>
+			<path d="M11.525 2.295a.53.53 0 0 1 .95 0l2.31 4.679a2.123 2.123 0 0 0 1.595 1.16l5.166.756a.53.53 0 0 1 .294.904l-3.736 3.638a2.123 2.123 0 0 0-.611 1.878l.882 5.14a.53.53 0 0 1-.771.56l-4.618-2.428a2.122 2.122 0 0 0-1.973 0L6.396 21.01a.53.53 0 0 1-.77-.56l.881-5.139a2.122 2.122 0 0 0-.611-1.879L2.16 9.795a.53.53 0 0 1 .294-.906l5.165-.755a2.122 2.122 0 0 0 1.597-1.16z" />
+		</svg>
+	);
+}
+
 export function AgentIcon({ className }: IconProps) {
 	return (
 		<svg

--- a/packages/widget/src/csat.test.ts
+++ b/packages/widget/src/csat.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { rateConversation, shouldPromptCsat } from "./csat";
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("rateConversation", () => {
+	it("POSTs the rating to /v1/csat", async () => {
+		const fetchMock = vi
+			.fn()
+			.mockResolvedValue(new Response(JSON.stringify({ ok: true })));
+		vi.stubGlobal("fetch", fetchMock);
+
+		await rateConversation("http://x", {
+			projectKey: "pk",
+			clientId: "c",
+			conversationId: "cv",
+			rating: 4,
+		});
+
+		expect(fetchMock).toHaveBeenCalledWith(
+			"http://x/v1/csat",
+			expect.objectContaining({ method: "POST" }),
+		);
+		expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toMatchObject({
+			conversationId: "cv",
+			rating: 4,
+		});
+	});
+
+	it("throws on a non-OK response (so callers can swallow it)", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValue(new Response("no", { status: 500 })),
+		);
+		await expect(
+			rateConversation("http://x", {
+				projectKey: "pk",
+				clientId: "c",
+				conversationId: "cv",
+				rating: 3,
+			}),
+		).rejects.toThrow(/csat failed/);
+	});
+});
+
+describe("shouldPromptCsat", () => {
+	it("prompts only on a real, unrated exchange", () => {
+		expect(
+			shouldPromptCsat({ hasRealExchange: true, alreadyRated: false }),
+		).toBe(true);
+	});
+
+	it("does not prompt an empty conversation", () => {
+		expect(
+			shouldPromptCsat({ hasRealExchange: false, alreadyRated: false }),
+		).toBe(false);
+	});
+
+	it("does not re-prompt an already-rated conversation", () => {
+		expect(
+			shouldPromptCsat({ hasRealExchange: true, alreadyRated: true }),
+		).toBe(false);
+	});
+});

--- a/packages/widget/src/csat.ts
+++ b/packages/widget/src/csat.ts
@@ -1,0 +1,31 @@
+/** POST an end-of-conversation CSAT (1–5) to the public widget API. */
+export async function rateConversation(
+	apiUrl: string,
+	body: {
+		projectKey: string;
+		clientId: string;
+		conversationId: string;
+		rating: number;
+	},
+): Promise<void> {
+	const res = await fetch(`${apiUrl}/v1/csat`, {
+		method: "POST",
+		headers: { "content-type": "application/json" },
+		body: JSON.stringify(body),
+	});
+	if (!res.ok) {
+		throw new Error(`csat failed: ${res.status}`);
+	}
+}
+
+/**
+ * Whether to show the CSAT step on close. Only prompt when there was a real
+ * exchange and the conversation isn't already rated — never nag an empty
+ * conversation, never re-prompt.
+ */
+export function shouldPromptCsat(opts: {
+	hasRealExchange: boolean;
+	alreadyRated: boolean;
+}): boolean {
+	return opts.hasRealExchange && !opts.alreadyRated;
+}

--- a/packages/widget/src/messages-sync.ts
+++ b/packages/widget/src/messages-sync.ts
@@ -14,6 +14,9 @@ export interface MessageFeed {
 	/** The visitor's own conversation id (null until one exists), used to
 	 * address messages for rating. */
 	conversationId: string | null;
+	/** Conversation-level CSAT (1–5), null until rated. Lets the widget avoid
+	 * re-prompting an already-rated visitor. */
+	csatRating: number | null;
 	messages: ServerMessage[];
 }
 
@@ -32,6 +35,7 @@ export async function fetchMessages(
 	const data = (await res.json()) as Partial<MessageFeed>;
 	return {
 		conversationId: data.conversationId ?? null,
+		csatRating: data.csatRating ?? null,
 		messages: data.messages ?? [],
 	};
 }

--- a/packages/widget/src/styles.ts
+++ b/packages/widget/src/styles.ts
@@ -401,6 +401,68 @@ export const widgetStyles = `
 	height: 0.875rem;
 }
 
+/* ── CSAT closing screen ───────────────────────────────────────────── */
+.llmchat-csat {
+	flex: 1;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	gap: 1rem;
+	padding: 2rem 1.5rem;
+	text-align: center;
+}
+.llmchat-csat-title {
+	margin: 0;
+	font-size: 1.05rem;
+	font-weight: 600;
+	color: #111827;
+}
+.llmchat-csat-stars {
+	display: flex;
+	gap: 0.25rem;
+}
+.llmchat-csat-star {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	padding: 0.25rem;
+	background: transparent;
+	border: none;
+	color: #f59e0b;
+	cursor: pointer;
+	border-radius: 0.5rem;
+	transition: transform 0.1s ease;
+}
+.llmchat-csat-star:hover {
+	transform: scale(1.12);
+}
+.llmchat-csat-star:active {
+	transform: scale(0.95);
+}
+.llmchat-csat-star:focus-visible {
+	outline: none;
+	box-shadow: 0 0 0 2px color-mix(in srgb, var(--brand) 30%, transparent);
+}
+.llmchat-csat-skip {
+	background: transparent;
+	border: none;
+	color: #6b7280;
+	font: inherit;
+	font-size: 0.85rem;
+	cursor: pointer;
+	padding: 0.25rem 0.5rem;
+	border-radius: 0.375rem;
+}
+.llmchat-csat-skip:hover {
+	color: #111827;
+	text-decoration: underline;
+}
+.llmchat-csat-skip:focus-visible {
+	outline: none;
+	box-shadow: 0 0 0 2px color-mix(in srgb, var(--brand) 30%, transparent);
+}
+
 /* Typing indicator: three bouncing dots inside an assistant bubble. */
 .llmchat-typing {
 	display: flex;

--- a/packages/widget/src/useServerMessages.ts
+++ b/packages/widget/src/useServerMessages.ts
@@ -18,10 +18,12 @@ export function useServerMessages(
 ): {
 	serverMessages: ServerMessage[];
 	conversationId: string | null;
+	csatRating: number | null;
 	refresh: () => void;
 } {
 	const [serverMessages, setServerMessages] = useState<ServerMessage[]>([]);
 	const [conversationId, setConversationId] = useState<string | null>(null);
+	const [csatRating, setCsatRating] = useState<number | null>(null);
 	const abortRef = useRef<AbortController | null>(null);
 
 	const load = useCallback(async () => {
@@ -37,6 +39,7 @@ export function useServerMessages(
 			);
 			setServerMessages(feed.messages);
 			setConversationId(feed.conversationId);
+			setCsatRating(feed.csatRating);
 		} catch {
 			// Transient poll failure — keep showing the last good feed.
 		}
@@ -58,5 +61,5 @@ export function useServerMessages(
 		void load();
 	}, [load]);
 
-	return { serverMessages, conversationId, refresh };
+	return { serverMessages, conversationId, csatRating, refresh };
 }

--- a/packages/widget/src/widget.tsx
+++ b/packages/widget/src/widget.tsx
@@ -3,10 +3,12 @@ import { DefaultChatTransport } from "ai";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { Composer } from "./components/Composer";
+import { CsatStep } from "./components/CsatStep";
 import { EscalationSection } from "./components/EscalationSection";
 import { IdentifyForm } from "./components/IdentifyForm";
 import { MessageList } from "./components/MessageList";
 import { WidgetFrame } from "./components/WidgetFrame";
+import { rateConversation, shouldPromptCsat } from "./csat";
 import { requestEscalation } from "./escalation";
 import { getOrCreateClientId, getText } from "./lib";
 import { mergeMessages } from "./messages-sync";
@@ -15,6 +17,9 @@ import { ShowcaseChat } from "./ShowcaseChat";
 import { useServerMessages } from "./useServerMessages";
 
 import type { Rating } from "./rating";
+
+/** How long the "Thanks!" screen shows before the panel closes. */
+const CSAT_THANKS_MS = 1200;
 
 /**
  * "live" (default) talks to the real API: conversations are created and
@@ -107,6 +112,12 @@ function LiveWidget({
 	const [escalating, setEscalating] = useState(false);
 	const [escalateFailed, setEscalateFailed] = useState(false);
 	const [clientId, setClientId] = useState("");
+	// CSAT closing screen: "hidden" during chat, "prompt" on close (when
+	// eligible), "thanks" briefly after a rating.
+	const [csatStep, setCsatStep] = useState<"hidden" | "prompt" | "thanks">(
+		"hidden",
+	);
+	const [csatRated, setCsatRated] = useState(false);
 
 	useEffect(() => {
 		setClientId(getOrCreateClientId());
@@ -128,12 +139,8 @@ function LiveWidget({
 
 	// Poll the persisted feed while chatting so admin replies from the
 	// dashboard appear without a refresh.
-	const { serverMessages, conversationId, refresh } = useServerMessages(
-		apiUrl,
-		projectKey,
-		clientId,
-		open && identified,
-	);
+	const { serverMessages, conversationId, csatRating, refresh } =
+		useServerMessages(apiUrl, projectKey, clientId, open && identified);
 
 	// Per-message thumbs: optimistic, rolling back if the request fails.
 	const sendRating = useCallback(
@@ -179,6 +186,52 @@ function LiveWidget({
 	const threshold = resolveEscalationThreshold(escalationThreshold);
 	const showEscalation = !escalated && userMessageCount >= threshold;
 
+	// A "real exchange" = at least one persisted visitor message and one bot
+	// reply. Only then (and only when not already rated) do we prompt on close.
+	const hasRealExchange =
+		serverMessages.some((m) => m.role === "user") &&
+		serverMessages.some((m) => m.role === "assistant");
+	const csatEligible = shouldPromptCsat({
+		hasRealExchange,
+		alreadyRated: csatRating != null || csatRated,
+	});
+
+	// Intercept close: when eligible, swap to the CSAT step instead of closing.
+	// A second close (X / Esc / Skip) always closes — never traps the visitor.
+	function handleOpenChange(next: boolean) {
+		if (!next && csatStep === "hidden" && csatEligible) {
+			setCsatStep("prompt");
+			return;
+		}
+		if (!next) {
+			setCsatStep("hidden");
+		}
+		setOpen(next);
+	}
+
+	function submitCsat(rating: number) {
+		setCsatRated(true);
+		setCsatStep("thanks");
+		// Best-effort: a failed POST must never trap the visitor — we close anyway.
+		if (conversationId) {
+			void rateConversation(apiUrl, {
+				projectKey,
+				clientId,
+				conversationId,
+				rating,
+			}).catch(() => {});
+		}
+		setTimeout(() => {
+			setCsatStep("hidden");
+			setOpen(false);
+		}, CSAT_THANKS_MS);
+	}
+
+	function skipCsat() {
+		setCsatStep("hidden");
+		setOpen(false);
+	}
+
 	function handleSend() {
 		void sendMessage({ text: text.trim() });
 		setText("");
@@ -215,9 +268,11 @@ function LiveWidget({
 			inline={inline}
 			brandColor={brandColor}
 			open={open}
-			onOpenChange={setOpen}
+			onOpenChange={handleOpenChange}
 		>
-			{!identified ? (
+			{csatStep !== "hidden" ? (
+				<CsatStep step={csatStep} onRate={submitCsat} onSkip={skipCsat} />
+			) : !identified ? (
 				<IdentifyForm
 					name={name}
 					email={email}


### PR DESCRIPTION
## What & why

Adds a **conversation-level** satisfaction rating. When a visitor closes the floating widget after a real exchange, they're prompted with a 1–5 star "How was your experience?"; the score is stored on the conversation and surfaced in the inbox's previously-disabled per-conversation placeholders.

This is **distinct from the per-message thumbs** from #18 — different table (`conversation.csatRating` vs `message.rating`), different surface (closing screen + DetailPanel/InboxStats vs the thread bubbles). They are not mixed or aggregated together.

### Step 0 findings (reported before building)
- The `conversation` table had **no** CSAT/rating column — added `csatRating` (integer 1–5, nullable).
- The inbox placeholders (DetailPanel "Satisfaction" star field, InboxStats "avg rating" stat) carried no column name/scale — just a star metaphor, which a 1–5 scale satisfies. Wired both to `csatRating`. No divergence.

## Changes
- **DB** — nullable `conversation.csatRating`; additive `0010_conversation_csat.sql` (`ADD COLUMN`, matching 0005/0009; Ploy applies each migration once).
- **API** — `POST /v1/csat` (public, CORS-open like `/v1/chat` & `/v1/rating`). Validates `project(publicKey) → conversation(id, projectId, clientId)` before writing; broken chain → 404, out-of-range/non-integer → 400; idempotent (null clears). `/v1/messages` now returns conversation-level `csatRating` so the widget never re-prompts a rated visitor.
- **Widget** — on close (X/Esc), if there was a real exchange and the conversation isn't already rated, a 1–5 star closing screen appears with a **Skip**; tapping a star submits, shows a brief "Thanks!", then closes. Empty/already-rated conversations close immediately. The POST is **best-effort** — a failure still closes gracefully, never trapping the visitor. Stays within the shadow-DOM styling.
- **Inbox** — DetailPanel shows `"4 / 5 ★"` or `"Not rated"`; InboxStats shows the average across rated conversations, `"—"` (no NaN) when none are rated. Disabled/"not collected yet" states removed. Read-only, server-fed via the existing detail/list endpoints.

## Security
A visitor can only rate **their own** conversation: the route asserts the conversation belongs to both the project (by public key) and the caller's `clientId`. No secrets; returns only `{ ok: true }`.

## Tests (offline, key-free)
- **api** (90): cross-tenant rejection, 1–5 boundaries, clear, out-of-range (0/6), non-integer (3.5), missing field → 400 — via a predicate-evaluating fake `db`.
- **widget** (66): `rateConversation` client, `shouldPromptCsat` decision (real vs empty vs already-rated), `CsatStep` render/submit/skip/thanks.
- **dashboard** (157): DetailPanel rated vs "Not rated"; InboxStats average correct, zero-safe, empty set.

## Operator notes
- **Migration `0010` auto-applies on the prod deploy** (Ploy filesystem scan), same as `0009`. Heads-up from the #18 experience: the **preview** deploy will 500 on conversation reads/writes until merge, because preview deploys run the new code against a DB that hasn't had `0010` applied — that's expected and resolves once prod deploys. Verify `0010` applied right after merge.
- **Widget bundle** (`apps/api/src/generated/widget-bundle.ts`) is gitignored and regenerated by the widget build; rebuilt and verified locally to contain the CSAT UI.

Not merged — feature branch + PR per the task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)