### PR TITLE
feat(dashboard): inbox redesign — Conversations screen matched to mockups

### DIFF
--- a/apps/dashboard/src/app/inbox/_components/ConversationList.test.tsx
+++ b/apps/dashboard/src/app/inbox/_components/ConversationList.test.tsx
@@ -29,21 +29,17 @@ function setup(
 	props: Partial<React.ComponentProps<typeof ConversationList>> = {},
 ) {
 	const onSelect = vi.fn();
-	const onSearch = vi.fn();
-	const onToggleArchived = vi.fn();
 	render(
 		<ConversationList
 			conversations={[conv({ id: "a" })]}
 			selectedId={null}
 			onSelect={onSelect}
 			search=""
-			onSearch={onSearch}
 			showArchived={false}
-			onToggleArchived={onToggleArchived}
 			{...props}
 		/>,
 	);
-	return { onSelect, onSearch, onToggleArchived };
+	return { onSelect };
 }
 
 describe("ConversationList", () => {
@@ -66,9 +62,7 @@ describe("ConversationList", () => {
 				selectedId={null}
 				onSelect={vi.fn()}
 				search=""
-				onSearch={vi.fn()}
 				showArchived={false}
-				onToggleArchived={vi.fn()}
 			/>,
 		);
 		expect(screen.getByLabelText("Unread")).toBeInTheDocument();
@@ -79,9 +73,7 @@ describe("ConversationList", () => {
 				selectedId={null}
 				onSelect={vi.fn()}
 				search=""
-				onSearch={vi.fn()}
 				showArchived={false}
-				onToggleArchived={vi.fn()}
 			/>,
 		);
 		expect(screen.queryByLabelText("Unread")).not.toBeInTheDocument();
@@ -94,9 +86,7 @@ describe("ConversationList", () => {
 				selectedId="a"
 				onSelect={vi.fn()}
 				search=""
-				onSearch={vi.fn()}
 				showArchived={false}
-				onToggleArchived={vi.fn()}
 			/>,
 		);
 		expect(screen.queryByLabelText("Unread")).not.toBeInTheDocument();
@@ -125,22 +115,12 @@ describe("ConversationList", () => {
 		expect(screen.getByText("ada@example.com")).toBeInTheDocument();
 	});
 
-	it("reports the typed query and selection upward", async () => {
+	it("reports the selected conversation upward", async () => {
 		const user = userEvent.setup();
-		const { onSearch, onSelect } = setup();
-
-		await user.type(screen.getByLabelText("Search conversations"), "x");
-		expect(onSearch).toHaveBeenCalledWith("x");
+		const { onSelect } = setup();
 
 		await user.click(screen.getByText("Ada Lovelace"));
 		expect(onSelect).toHaveBeenCalledWith("a");
-	});
-
-	it("toggles the archived view", async () => {
-		const user = userEvent.setup();
-		const { onToggleArchived } = setup();
-		await user.click(screen.getByRole("button", { name: /archived/i }));
-		expect(onToggleArchived).toHaveBeenCalled();
 	});
 
 	it("distinguishes the empty states", () => {
@@ -150,9 +130,7 @@ describe("ConversationList", () => {
 				selectedId={null}
 				onSelect={vi.fn()}
 				search="zzz"
-				onSearch={vi.fn()}
 				showArchived={false}
-				onToggleArchived={vi.fn()}
 			/>,
 		);
 		expect(
@@ -165,9 +143,7 @@ describe("ConversationList", () => {
 				selectedId={null}
 				onSelect={vi.fn()}
 				search=""
-				onSearch={vi.fn()}
 				showArchived
-				onToggleArchived={vi.fn()}
 			/>,
 		);
 		expect(screen.getByText(/no archived conversations/i)).toBeInTheDocument();

--- a/apps/dashboard/src/app/inbox/_components/ConversationList.tsx
+++ b/apps/dashboard/src/app/inbox/_components/ConversationList.tsx
@@ -1,9 +1,8 @@
 "use client";
 
-import { Archive, MessageCircle, Search } from "lucide-react";
+import { MessageCircle } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
-import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
 
 import { initials, pluralize, timeAgo } from "./format";
@@ -27,7 +26,9 @@ function ConversationRow({
 			aria-current={selected}
 			className={cn(
 				"flex w-full items-start gap-3 rounded-lg px-3 py-2.5 text-left transition-colors",
-				selected ? "bg-primary/10 ring-1 ring-primary/20" : "hover:bg-muted/60",
+				selected
+					? "bg-primary/10 ring-1 ring-inset ring-primary/20"
+					: "hover:bg-muted/60",
 			)}
 		>
 			<div className="relative shrink-0">
@@ -41,15 +42,9 @@ function ConversationRow({
 				>
 					{initials(conversation.name)}
 				</span>
-				{escalated && (
-					<span
-						className="absolute -right-0.5 -top-0.5 size-3 rounded-full bg-amber-500 ring-2 ring-card"
-						aria-hidden
-					/>
-				)}
 				{unread && !selected && (
 					<span
-						className="absolute -left-0.5 -top-0.5 size-2.5 rounded-full bg-sky-500 ring-2 ring-card"
+						className="absolute -left-0.5 -top-0.5 size-2.5 rounded-full bg-primary ring-2 ring-card"
 						aria-label="Unread"
 					/>
 				)}
@@ -60,9 +55,7 @@ function ConversationRow({
 					<span
 						className={cn(
 							"truncate text-sm",
-							unread && !selected
-								? "font-semibold text-foreground"
-								: "font-medium",
+							unread && !selected ? "font-semibold" : "font-medium",
 							selected ? "text-primary" : "text-foreground",
 						)}
 					>
@@ -103,10 +96,9 @@ export interface ConversationListProps {
 	conversations: Conversation[];
 	selectedId: string | null;
 	onSelect: (id: string) => void;
+	/** Read-only context for the empty-state copy; filtering lives in the toolbar. */
 	search: string;
-	onSearch: (value: string) => void;
 	showArchived: boolean;
-	onToggleArchived: () => void;
 }
 
 export function ConversationList({
@@ -114,44 +106,10 @@ export function ConversationList({
 	selectedId,
 	onSelect,
 	search,
-	onSearch,
 	showArchived,
-	onToggleArchived,
 }: ConversationListProps) {
 	return (
 		<div className="flex min-h-0 flex-1 flex-col">
-			<div className="border-b px-3 py-3">
-				<div className="mb-2.5 flex items-center justify-between">
-					<h2 className="text-sm font-semibold tracking-tight">
-						Conversations
-					</h2>
-					<button
-						type="button"
-						onClick={onToggleArchived}
-						aria-pressed={showArchived}
-						className={cn(
-							"flex items-center gap-1 rounded px-2 py-0.5 text-xs transition-colors",
-							showArchived
-								? "bg-primary text-primary-foreground"
-								: "text-muted-foreground hover:text-foreground",
-						)}
-					>
-						<Archive className="size-3" />
-						Archived
-					</button>
-				</div>
-				<div className="relative">
-					<Search className="pointer-events-none absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground" />
-					<Input
-						value={search}
-						onChange={(e) => onSearch(e.target.value)}
-						placeholder="Search by name, email, or message…"
-						aria-label="Search conversations"
-						className="h-8 pl-8 text-xs"
-					/>
-				</div>
-			</div>
-
 			<div className="min-h-0 flex-1 overflow-y-auto p-1.5">
 				{conversations.length === 0 ? (
 					<div className="flex flex-col items-center justify-center gap-2 px-4 py-12 text-center">

--- a/apps/dashboard/src/app/inbox/_components/DetailPanel.tsx
+++ b/apps/dashboard/src/app/inbox/_components/DetailPanel.tsx
@@ -127,7 +127,7 @@ export function DetailPanel({
 					</div>
 				)}
 
-				<Section title="Contact">
+				<Section title="Contact details">
 					<Field
 						icon={<User className="size-4" />}
 						label="Name"
@@ -140,7 +140,7 @@ export function DetailPanel({
 					/>
 				</Section>
 
-				<Section title="Session">
+				<Section title="Session info">
 					<Field
 						icon={<Clock className="size-4" />}
 						label="Started"
@@ -167,33 +167,34 @@ export function DetailPanel({
 					/>
 				</Section>
 
-				<Section title="Satisfaction">
+				<Section title="Rating">
 					{/* Conversation-level CSAT (1–5), prompted on widget close — distinct
 					    from the per-message thumbs shown in the thread. */}
-					<div className="flex items-center gap-3">
-						<span
-							className={
-								conversation.csatRating != null
-									? "text-amber-500"
-									: "text-muted-foreground/50"
-							}
-						>
-							<Star
-								className="size-4"
-								fill={conversation.csatRating != null ? "currentColor" : "none"}
-							/>
-						</span>
-						<div>
-							<p className="text-xs font-medium text-muted-foreground">
-								Overall conversation rating
-							</p>
-							<p className="text-sm text-foreground">
-								{conversation.csatRating != null
-									? `${conversation.csatRating} / 5 ★`
-									: "Not rated"}
-							</p>
+					{conversation.csatRating != null ? (
+						<div className="flex items-center gap-2">
+							<div className="flex items-center gap-0.5">
+								{[1, 2, 3, 4, 5].map((n) => (
+									<Star
+										key={n}
+										className={cn(
+											"size-4",
+											n <= conversation.csatRating!
+												? "text-amber-500"
+												: "text-muted-foreground/30",
+										)}
+										fill={
+											n <= conversation.csatRating! ? "currentColor" : "none"
+										}
+									/>
+								))}
+							</div>
+							<span className="text-sm font-medium text-foreground">
+								{conversation.csatRating} / 5
+							</span>
 						</div>
-					</div>
+					) : (
+						<p className="text-sm text-muted-foreground">Not rated</p>
+					)}
 				</Section>
 			</div>
 

--- a/apps/dashboard/src/app/inbox/_components/InboxStats.test.tsx
+++ b/apps/dashboard/src/app/inbox/_components/InboxStats.test.tsx
@@ -23,10 +23,10 @@ function conv(overrides: Partial<Conversation> = {}): Conversation {
 	};
 }
 
-/** The avg rating chip is the only stat labelled "avg rating". */
+/** The avg rating card is the only stat labelled "Avg rating". */
 function avgValue(): string | null {
-	const label = screen.getByText("avg rating");
-	// StatItem renders [value][label] as siblings; value is the previous span.
+	const label = screen.getByText("Avg rating");
+	// StatCard renders [value][label] as sibling divs; value is the previous one.
 	return label.previousElementSibling?.textContent ?? null;
 }
 

--- a/apps/dashboard/src/app/inbox/_components/InboxStats.tsx
+++ b/apps/dashboard/src/app/inbox/_components/InboxStats.tsx
@@ -1,49 +1,44 @@
 "use client";
 
-import { Archive, MessageSquare, Star, TriangleAlert } from "lucide-react";
+import { Star } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 
 import type { Conversation } from "./types";
 
-function StatItem({
-	icon,
+function StatCard({
 	value,
 	label,
+	icon,
 	tone,
 }: {
-	icon: React.ReactNode;
 	value: React.ReactNode;
 	label: string;
-	tone?: "amber" | "muted";
+	icon?: React.ReactNode;
+	tone?: "amber";
 }) {
 	return (
-		<div className="flex items-center gap-1.5">
-			<span
+		<div className="min-w-[5rem] rounded-lg border bg-card px-4 py-2 text-center">
+			<div
 				className={cn(
-					"flex size-4 items-center justify-center",
-					tone === "amber"
-						? "text-amber-500"
-						: tone === "muted"
-							? "text-muted-foreground/50"
-							: "text-muted-foreground",
+					"flex items-center justify-center gap-1 text-xl font-semibold leading-none tabular-nums",
+					tone === "amber" ? "text-amber-500" : "text-foreground",
 				)}
 			>
 				{icon}
-			</span>
-			<span className="text-sm font-semibold tabular-nums text-foreground">
 				{value}
-			</span>
-			<span className="text-xs text-muted-foreground">{label}</span>
+			</div>
+			<div className="mt-1 text-[11px] text-muted-foreground">{label}</div>
 		</div>
 	);
 }
 
 /**
- * At-a-glance counts derived from the loaded conversation set. The avg rating
- * is a disabled placeholder for the upcoming per-conversation CSAT feature
- * (distinct from the per-message thumbs in the thread), so we never show a
- * fabricated number.
+ * Header stat cards derived from the loaded conversation set. "Resolved" is
+ * backed by the archived count — archiving is this app's only "closed" state;
+ * there is no separate resolved status. The avg rating is the mean CSAT across
+ * rated conversations only, shown as "—" when none are rated (never NaN or a
+ * fabricated number).
  */
 export function InboxStats({
 	conversations,
@@ -51,12 +46,9 @@ export function InboxStats({
 	conversations: Conversation[];
 }) {
 	const total = conversations.length;
-	const unread = conversations.filter((c) => c.unread).length;
 	const escalated = conversations.filter((c) => c.escalatedAt).length;
-	const archived = conversations.filter((c) => c.archivedAt).length;
+	const resolved = conversations.filter((c) => c.archivedAt).length;
 
-	// Average CSAT across rated conversations only. Null when none are rated —
-	// shown as "—" rather than a fabricated number or NaN.
 	const rated = conversations.filter((c) => c.csatRating != null);
 	const avgRating =
 		rated.length > 0
@@ -64,39 +56,20 @@ export function InboxStats({
 			: null;
 
 	return (
-		<div className="flex flex-wrap items-center gap-x-6 gap-y-2 border-b bg-card px-4 py-2.5">
-			<StatItem
-				icon={<MessageSquare className="size-4" />}
-				value={total}
-				label={total === 1 ? "conversation" : "conversations"}
+		<div className="flex flex-wrap items-stretch gap-2">
+			<StatCard value={total} label="Conversations" />
+			<StatCard value={escalated} label="Escalated" tone="amber" />
+			<StatCard value={resolved} label="Resolved" />
+			<StatCard
+				value={avgRating != null ? avgRating.toFixed(1) : "—"}
+				label="Avg rating"
+				icon={
+					<Star
+						className="size-4 text-amber-500"
+						fill={avgRating != null ? "currentColor" : "none"}
+					/>
+				}
 			/>
-			{unread > 0 && (
-				<StatItem
-					icon={<span className="size-2 rounded-full bg-sky-500" />}
-					value={unread}
-					label="unread"
-				/>
-			)}
-			<StatItem
-				icon={<TriangleAlert className="size-4" />}
-				value={escalated}
-				label="escalated"
-				tone="amber"
-			/>
-			<StatItem
-				icon={<Archive className="size-4" />}
-				value={archived}
-				label="archived"
-			/>
-
-			<div className="ml-auto">
-				<StatItem
-					icon={<Star className="size-4" />}
-					value={avgRating != null ? avgRating.toFixed(1) : "—"}
-					label="avg rating"
-					tone={avgRating != null ? undefined : "muted"}
-				/>
-			</div>
 		</div>
 	);
 }

--- a/apps/dashboard/src/app/inbox/_components/InboxToolbar.test.tsx
+++ b/apps/dashboard/src/app/inbox/_components/InboxToolbar.test.tsx
@@ -1,0 +1,70 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+import { InboxToolbar } from "./InboxToolbar";
+
+beforeAll(() => {
+	// Radix Select uses pointer-capture + scrollIntoView, unimplemented in jsdom.
+	Element.prototype.scrollIntoView = vi.fn();
+	Element.prototype.hasPointerCapture ??= () => false;
+});
+
+function setup(props: Partial<React.ComponentProps<typeof InboxToolbar>> = {}) {
+	const onSearch = vi.fn();
+	const onShowArchivedChange = vi.fn();
+	render(
+		<InboxToolbar
+			search=""
+			onSearch={onSearch}
+			showArchived={false}
+			onShowArchivedChange={onShowArchivedChange}
+			{...props}
+		/>,
+	);
+	return { onSearch, onShowArchivedChange };
+}
+
+describe("InboxToolbar", () => {
+	it("reports the typed search query upward", async () => {
+		const user = userEvent.setup();
+		const { onSearch } = setup();
+		await user.type(screen.getByLabelText("Search conversations"), "x");
+		expect(onSearch).toHaveBeenCalledWith("x");
+	});
+
+	it("reflects the active status in the filter control", () => {
+		const { rerender } = render(
+			<InboxToolbar
+				search=""
+				onSearch={vi.fn()}
+				showArchived={false}
+				onShowArchivedChange={vi.fn()}
+			/>,
+		);
+		expect(screen.getByText("All conversations")).toBeInTheDocument();
+
+		rerender(
+			<InboxToolbar
+				search=""
+				onSearch={vi.fn()}
+				showArchived
+				onShowArchivedChange={vi.fn()}
+			/>,
+		);
+		expect(screen.getByText("Archived")).toBeInTheDocument();
+	});
+
+	it("switches to the archived view from the filter dropdown", async () => {
+		const user = userEvent.setup();
+		const { onShowArchivedChange } = setup();
+		await user.click(screen.getByRole("combobox", { name: /filter/i }));
+		await user.click(screen.getByRole("option", { name: "Archived" }));
+		expect(onShowArchivedChange).toHaveBeenCalledWith(true);
+	});
+
+	it("marks the not-yet-available Filters control as disabled", () => {
+		setup();
+		expect(screen.getByRole("button", { name: /filters/i })).toBeDisabled();
+	});
+});

--- a/apps/dashboard/src/app/inbox/_components/InboxToolbar.tsx
+++ b/apps/dashboard/src/app/inbox/_components/InboxToolbar.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { Search, SlidersHorizontal } from "lucide-react";
+
+import { Input } from "@/components/ui/input";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+
+export interface InboxToolbarProps {
+	search: string;
+	onSearch: (value: string) => void;
+	/** Active vs archived view — the only real conversation filter we have. */
+	showArchived: boolean;
+	onShowArchivedChange: (archived: boolean) => void;
+}
+
+/**
+ * Top toolbar spanning the inbox panes: status filter + search are real and
+ * drive the list. "Filters" and "Sort" are clearly-disabled placeholders — there
+ * is no filter/sort backend yet, and the list is always ordered latest-first
+ * (so the "Latest" label is truthful, not a fabricated control).
+ */
+export function InboxToolbar({
+	search,
+	onSearch,
+	showArchived,
+	onShowArchivedChange,
+}: InboxToolbarProps) {
+	return (
+		<div className="flex items-center gap-2 border-b px-4 py-2.5">
+			<Select
+				value={showArchived ? "archived" : "all"}
+				onValueChange={(v) => onShowArchivedChange(v === "archived")}
+			>
+				<SelectTrigger
+					className="h-9 w-[11rem] shrink-0"
+					aria-label="Filter conversations"
+				>
+					<SelectValue />
+				</SelectTrigger>
+				<SelectContent>
+					<SelectItem value="all">All conversations</SelectItem>
+					<SelectItem value="archived">Archived</SelectItem>
+				</SelectContent>
+			</Select>
+
+			<div className="relative min-w-0 flex-1">
+				<Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+				<Input
+					value={search}
+					onChange={(e) => onSearch(e.target.value)}
+					placeholder="Search conversations…"
+					aria-label="Search conversations"
+					className="h-9 pl-9"
+				/>
+			</div>
+
+			{/* Placeholders: no filter/sort backend yet. Disabled so they read as
+			    not-yet-available rather than fabricating behavior. */}
+			<button
+				type="button"
+				disabled
+				title="Advanced filters aren't available yet"
+				className="inline-flex h-9 shrink-0 cursor-not-allowed items-center gap-1.5 rounded-md border px-3 text-sm text-muted-foreground opacity-60"
+			>
+				<SlidersHorizontal className="size-4" />
+				Filters
+			</button>
+			<span className="hidden shrink-0 px-1 text-sm text-muted-foreground sm:inline">
+				Sort: <span className="font-medium text-foreground">Latest</span>
+			</span>
+		</div>
+	);
+}

--- a/apps/dashboard/src/app/inbox/_components/MessageThread.test.tsx
+++ b/apps/dashboard/src/app/inbox/_components/MessageThread.test.tsx
@@ -35,9 +35,9 @@ describe("MessageThread", () => {
 				]}
 			/>,
 		);
-		expect(screen.getByText("Visitor requested a human operator")).toHaveClass(
-			"mx-auto",
-		);
+		expect(
+			screen.getByText("Visitor requested a human operator").closest("div"),
+		).toHaveClass("mx-auto");
 		// System notes carry no Visitor/Bot/Admin label.
 		expect(screen.queryByText("Visitor")).not.toBeInTheDocument();
 		expect(screen.queryByText("Admin")).not.toBeInTheDocument();

--- a/apps/dashboard/src/app/inbox/_components/MessageThread.tsx
+++ b/apps/dashboard/src/app/inbox/_components/MessageThread.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ThumbsDown, ThumbsUp } from "lucide-react";
+import { Headset, ThumbsDown, ThumbsUp } from "lucide-react";
 import { useEffect, useRef } from "react";
 
 import { cn } from "@/lib/utils";
@@ -94,9 +94,13 @@ export function MessageThread({ messages }: { messages: Message[] }) {
 				m.role === "system" ? (
 					<div
 						key={m.id}
-						className="mx-auto my-1 rounded-full bg-muted px-3 py-1 text-xs text-muted-foreground"
+						className="mx-auto my-1 flex max-w-[80%] items-center gap-2 rounded-lg border bg-muted/40 px-3 py-2 text-xs text-muted-foreground"
 					>
-						{m.content}
+						<Headset className="size-4 shrink-0 text-amber-500" />
+						<span className="flex-1">{m.content}</span>
+						<span className="shrink-0 tabular-nums text-muted-foreground/70">
+							{formatMessageTime(m.createdAt)}
+						</span>
 					</div>
 				) : (
 					<MessageBubble key={m.id} message={m} />

--- a/apps/dashboard/src/app/inbox/_components/ReplyComposer.tsx
+++ b/apps/dashboard/src/app/inbox/_components/ReplyComposer.tsx
@@ -31,22 +31,25 @@ export function ReplyComposer({
 	}
 
 	return (
-		<div className="flex flex-col gap-2 border-t p-3">
-			<Textarea
-				rows={2}
-				value={value}
-				onChange={(e) => onChange(e.target.value)}
-				onKeyDown={handleKeyDown}
-				placeholder={placeholder}
-			/>
-			<div className="flex items-center justify-between gap-2">
-				<span className="text-[11px] text-muted-foreground">
-					Enter to send · Shift+Enter for a new line
-				</span>
-				<Button type="button" size="sm" onClick={onSend} disabled={!canSend}>
-					<Send />
-					{pending ? "Sending…" : "Send"}
-				</Button>
+		<div className="border-t p-3">
+			<div className="rounded-lg border bg-card focus-within:ring-1 focus-within:ring-ring">
+				<Textarea
+					rows={2}
+					value={value}
+					onChange={(e) => onChange(e.target.value)}
+					onKeyDown={handleKeyDown}
+					placeholder={placeholder}
+					className="resize-none border-0 bg-transparent focus-visible:ring-0 focus-visible:ring-offset-0"
+				/>
+				<div className="flex items-center justify-between gap-2 px-3 pb-2">
+					<span className="text-[11px] text-muted-foreground">
+						Enter to send · Shift+Enter for a new line
+					</span>
+					<Button type="button" size="sm" onClick={onSend} disabled={!canSend}>
+						<Send />
+						{pending ? "Sending…" : "Send"}
+					</Button>
+				</div>
 			</div>
 		</div>
 	);

--- a/apps/dashboard/src/app/inbox/page.tsx
+++ b/apps/dashboard/src/app/inbox/page.tsx
@@ -15,9 +15,10 @@ import { track, ANALYTICS_EVENTS } from "@/lib/analytics";
 import { ConversationList } from "./_components/ConversationList";
 import { ConversationListSkeleton } from "./_components/ConversationListSkeleton";
 import { DetailPanel } from "./_components/DetailPanel";
-import { initials, pluralize } from "./_components/format";
+import { initials, parseDevice, pluralize } from "./_components/format";
 import { InboxSkeleton } from "./_components/InboxSkeleton";
 import { InboxStats } from "./_components/InboxStats";
+import { InboxToolbar } from "./_components/InboxToolbar";
 import { MessageThread } from "./_components/MessageThread";
 import { ProjectSwitcher } from "./_components/ProjectSwitcher";
 import { ReplyComposer } from "./_components/ReplyComposer";
@@ -229,9 +230,36 @@ export default function InboxPage() {
 		return <InboxSkeleton />;
 	}
 
+	const threadSubtitle =
+		[detailConv?.email, parseDevice(detailConv?.userAgent)]
+			.filter(Boolean)
+			.join(" · ") ||
+		(detailConv ? pluralize(detailConv.messageCount, "message") : "");
+
 	return (
 		<div className="flex h-[calc(100vh-3.5rem)] flex-col">
-			<InboxStats conversations={allConversations} />
+			{/* Header band — title + at-a-glance stats */}
+			<header className="flex flex-wrap items-start justify-between gap-4 border-b px-6 py-4">
+				<div>
+					<h1 className="font-display text-2xl font-semibold tracking-tight-display">
+						Conversations
+					</h1>
+					<p className="mt-0.5 text-sm text-muted-foreground">
+						All visitor conversations in one inbox.
+					</p>
+				</div>
+				<InboxStats conversations={allConversations} />
+			</header>
+
+			<InboxToolbar
+				search={search}
+				onSearch={setSearch}
+				showArchived={showArchived}
+				onShowArchivedChange={(archived) => {
+					setShowArchived(archived);
+					setSelectedId(null);
+				}}
+			/>
 
 			<div className="flex min-h-0 flex-1">
 				{/* Left — list */}
@@ -249,12 +277,7 @@ export default function InboxPage() {
 							selectedId={selectedId}
 							onSelect={handleSelect}
 							search={search}
-							onSearch={setSearch}
 							showArchived={showArchived}
-							onToggleArchived={() => {
-								setShowArchived((v) => !v);
-								setSelectedId(null);
-							}}
 						/>
 					)}
 				</div>
@@ -264,15 +287,15 @@ export default function InboxPage() {
 					{selectedId && detailConv ? (
 						<>
 							<div className="flex items-center gap-3 border-b px-6 py-3">
-								<span className="flex size-8 items-center justify-center rounded-full bg-primary text-xs font-medium text-primary-foreground">
+								<span className="flex size-9 items-center justify-center rounded-full bg-muted text-xs font-semibold text-muted-foreground">
 									{initials(detailConv.name)}
 								</span>
 								<div className="min-w-0 flex-1">
-									<p className="truncate text-sm font-medium">
+									<p className="truncate text-sm font-semibold">
 										{detailConv.name ?? "Anonymous"}
 									</p>
-									<p className="text-xs text-muted-foreground">
-										{pluralize(detailConv.messageCount, "message")}
+									<p className="truncate text-xs text-muted-foreground">
+										{threadSubtitle}
 									</p>
 								</div>
 								{detailConv.escalatedAt && (


### PR DESCRIPTION
## Phase 2 — Inbox (Conversations) restyled to the mockups, both modes

A composition/styling pass on the existing three-pane inbox. Real data is wired into the mockup's layout; **no data or behavior changes** — selecting, replying, escalation, archiving, and both rating systems work exactly as before. Builds on the merged Phase 1 tokens.

### What changed

**Header + stats** — a header band with the "Conversations" title + subtitle, and the stats restyled as **4 bordered cards** (Conversations / Escalated / Resolved / Avg rating with star).

**Toolbar (new `InboxToolbar`)** — spans the panes: a status filter dropdown ("All conversations" / "Archived", wired to the existing archived state) + search (both real). Search and the filter moved out of the list header into here.

**Conversation list** — slimmed `ConversationList` to the rows + footer; rows keep avatar, name, last-message preview, timestamp, escalation badge, and unread indicator (now indigo), with the selected row in an indigo highlight.

**Message thread** — header shows visitor name + `email · device` + Escalated badge; the "Visitor requested a human operator" system message is a bordered centered note with an icon + time; Visitor/Bot/Admin bubbles unchanged; the **per-message 👍/👎 (from #18)** preserved on assistant bubbles; unified bordered reply box.

**Visitor details** — avatar + name + email; the amber Escalated alert; **Contact details / Session info / Visitor device / Rating** sections; the **CSAT (from #19)** rendered as a 5-star row (`4 / 5`); Archive + Delete kept.

### Dropped / diverged for data honesty (you asked me to call these out)

1. **TAGS / "Potential lead"** — the mockup's visitor-details TAGS section has **no data source** (no tagging system exists). **Omitted** entirely — no fabricated tags.
2. **"Resolved" stat** — there's **no resolved status** in the schema. Backed it with the **archived count** (archiving is this app's only "closed" state) under the "Resolved" label. Real number, mockup label — flagging the mapping.
3. **"Filters" button + "Sort" control** — no filter/sort backend, and adding one would be a behavior change. Rendered **"Filters" as a clearly-disabled placeholder** and **"Sort: Latest" as a static label** (truthful — the list is always ordered latest-first). No fake interactivity.
4. **Reply placeholder** — the mockup says *"only visible to your team,"* which is **inaccurate** here (replies are sent to the visitor via email / shown in the widget). Kept the existing honest, behavior-accurate placeholder instead.
5. **Project switcher** — the mockup shows the project only in the sidebar; the inbox still needs its own picker to scope conversations (sidebar's global current-project is the deferred Phase-1 item), so I **kept the project switcher atop the list**, restyled.

### Verification
- `pnpm --filter @llmchat/dashboard test`: **160 pass** (added `InboxToolbar.test.tsx`; updated `ConversationList` / `InboxStats` / `MessageThread` tests for the new markup — behavior assertions unchanged).
- Build clean; lint + format clean across the workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
