### PR TITLE
feat(dashboard): reuse onboarding as a "create a new bot" flow

### DIFF
--- a/apps/dashboard/src/app/onboarding/page.test.tsx
+++ b/apps/dashboard/src/app/onboarding/page.test.tsx
@@ -11,7 +11,11 @@ import OnboardingPage from "./page";
 
 const push = vi.fn();
 const replace = vi.fn();
-vi.mock("next/navigation", () => ({ useRouter: () => ({ push, replace }) }));
+let searchParams = new URLSearchParams();
+vi.mock("next/navigation", () => ({
+	useRouter: () => ({ push, replace }),
+	useSearchParams: () => searchParams,
+}));
 vi.mock("@/lib/auth-client", () => ({ useSession: vi.fn() }));
 vi.mock("@/lib/use-onboarding", () => ({ useOnboardingState: vi.fn() }));
 vi.mock("sonner", () => ({
@@ -119,6 +123,7 @@ async function interview(
 
 beforeEach(() => {
 	vi.clearAllMocks();
+	searchParams = new URLSearchParams();
 	vi.mocked(useSession).mockReturnValue({
 		data: { user: { id: "u1", email: "a@b.com" } },
 		isPending: false,
@@ -284,5 +289,73 @@ describe("OnboardingPage (conversational)", () => {
 			await screen.findByRole("button", { name: /try again/i }),
 		).toBeInTheDocument();
 		expect(screen.queryByTestId("live-widget")).not.toBeInTheDocument();
+	});
+});
+
+describe("OnboardingPage — new-bot mode (already-onboarded user)", () => {
+	beforeEach(() => {
+		// ?new=1 and an existing, fully-onboarded workspace.
+		searchParams = new URLSearchParams("new=1");
+		vi.mocked(useOnboardingState).mockReturnValue({
+			state: "ready",
+			workspaceId: "ws-1",
+		});
+	});
+
+	it("shows the flow (not redirected to the dashboard) for a ready user", async () => {
+		renderPage();
+		expect(
+			await screen.findByRole("heading", { name: /build another bot/i }),
+		).toBeInTheDocument();
+		expect(replace).not.toHaveBeenCalledWith("/inbox");
+	});
+
+	it("creates a NEW project in the existing workspace — no duplication, no new workspace, lands selected", async () => {
+		const u = user();
+		renderPage();
+		await interview(u, { name: "Second Bot" });
+
+		// New project created in the existing workspace…
+		expect(api).toHaveBeenCalledWith(
+			"/api/projects",
+			expect.objectContaining({
+				method: "POST",
+				workspaceId: "ws-1",
+				body: expect.objectContaining({ name: "Second Bot" }),
+			}),
+		);
+		// …exactly once (no duplicate creation)…
+		const projectPosts = vi
+			.mocked(api)
+			.mock.calls.filter(
+				([path, opts]) =>
+					path === "/api/projects" &&
+					(opts as { method?: string } | undefined)?.method === "POST",
+			);
+		expect(projectPosts).toHaveLength(1);
+		// …and the workspace is never re-provisioned.
+		expect(api).not.toHaveBeenCalledWith("/api/workspaces", expect.anything());
+
+		// Finishing lands on the new project (selected via its settings route).
+		expect(await screen.findByTestId("live-widget")).toBeInTheDocument();
+		await u.click(screen.getByRole("button", { name: /go to dashboard/i }));
+		expect(push).toHaveBeenCalledWith("/settings/projects/p1");
+	});
+
+	it("does not re-provision the workspace on a 403 (no self-heal in new-bot mode)", async () => {
+		vi.mocked(api).mockImplementation(async (path: string) => {
+			if (path === "/api/projects")
+				throw new ApiError(403, '{"error":"forbidden"}');
+			return {};
+		});
+		const u = user();
+		renderPage();
+		await interview(u, { name: "Second Bot" });
+
+		// Surfaces as an error + retry; never spawns a workspace.
+		expect(
+			await screen.findByRole("button", { name: /try again/i }),
+		).toBeInTheDocument();
+		expect(api).not.toHaveBeenCalledWith("/api/workspaces", expect.anything());
 	});
 });

--- a/apps/dashboard/src/app/onboarding/page.tsx
+++ b/apps/dashboard/src/app/onboarding/page.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { useQueryClient } from "@tanstack/react-query";
-import { useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { Suspense, useEffect, useState } from "react";
 import { toast } from "sonner";
 
 import { widgetStyles } from "@llmchat/widget/styles";
@@ -26,12 +26,16 @@ interface CreatedProject extends LiveProject {
 	workspaceId: string;
 }
 
-export default function OnboardingPage() {
+function OnboardingFlow() {
 	const router = useRouter();
 	const qc = useQueryClient();
 	const { data: session, isPending: sessionPending } = useSession();
 	const { state, workspaceId } = useOnboardingState();
 	const { setWorkspaceId } = useWorkspace();
+
+	// "New bot" mode: an already-onboarded user adding another bot to their
+	// existing workspace. Reuses the whole flow but skips first-run-only routing.
+	const newBot = useSearchParams().get("new") === "1";
 
 	const [busy, setBusy] = useState(false);
 	const [created, setCreated] = useState<CreatedProject | null>(null);
@@ -42,10 +46,10 @@ export default function OnboardingPage() {
 		if (!sessionPending && !session?.user) router.replace("/sign-in");
 	}, [sessionPending, session, router]);
 
-	// Mark the start of the onboarding funnel once.
+	// Mark the start of the funnel once — first-run only (new-bot isn't onboarding).
 	useEffect(() => {
-		track(ANALYTICS_EVENTS.onboardingStarted);
-	}, []);
+		if (!newBot) track(ANALYTICS_EVENTS.onboardingStarted);
+	}, [newBot]);
 
 	// Warm the live-widget chunk (AI SDK) during the interview so the payoff is
 	// instant — it's lazy-loaded in LiveBotPanel to stay out of the initial load.
@@ -53,12 +57,13 @@ export default function OnboardingPage() {
 		void import("@llmchat/widget");
 	}, []);
 
-	// Already onboarded → dashboard. Suppressed once we've created a project so
-	// the flow isn't yanked away when state flips to "ready".
+	// First-run only: an already-onboarded user landing here is sent to the
+	// dashboard. In new-bot mode that's exactly who we want, so we don't redirect.
+	// Suppressed once a project is created so the flow isn't yanked away.
 	useEffect(() => {
-		if (!created && session?.user && state === "ready")
+		if (!newBot && !created && session?.user && state === "ready")
 			router.replace("/inbox");
-	}, [created, session, state, router]);
+	}, [newBot, created, session, state, router]);
 
 	// Provision a fresh free-plan workspace and make it the active selection.
 	async function provisionWorkspace(name: string): Promise<string> {
@@ -88,10 +93,15 @@ export default function OnboardingPage() {
 		return project;
 	}
 
-	// Interview complete → provision the real project. Mirrors the proven flow:
-	// create on the resolved workspace; on a workspace-auth rejection (absent /
-	// stale / foreign id) provision a fresh one and retry once so a broken
-	// context can't strand the user on a 403.
+	// Interview complete → provision the project.
+	//
+	// First-run: create on the resolved workspace; on a workspace-auth rejection
+	// (absent / stale / foreign id) provision a fresh one and retry once so a
+	// broken context can't strand the user on a 403.
+	//
+	// New-bot: the workspace already exists and is resolved (the guard waits for
+	// it), so we always create a *new* project inside it and never re-provision
+	// the workspace — a 403 surfaces as an error instead of spawning a workspace.
 	async function handleComplete(draft: BotDraft) {
 		setBusy(true);
 		setSetupError(null);
@@ -101,7 +111,7 @@ export default function OnboardingPage() {
 			try {
 				project = await createProject(wsId, draft);
 			} catch (e) {
-				if (!isWorkspaceAuthError(e)) throw e;
+				if (newBot || !isWorkspaceAuthError(e)) throw e;
 				wsId = await provisionWorkspace(draft.name);
 				project = await createProject(wsId, draft);
 			}
@@ -129,8 +139,10 @@ export default function OnboardingPage() {
 				brandColor: draft.brandColor,
 				workspaceId: wsId,
 			});
-			track(ANALYTICS_EVENTS.projectCreated, { source: "onboarding" });
-			track(ANALYTICS_EVENTS.onboardingCompleted);
+			track(ANALYTICS_EVENTS.projectCreated, {
+				source: newBot ? "new_bot" : "onboarding",
+			});
+			if (!newBot) track(ANALYTICS_EVENTS.onboardingCompleted);
 		} catch (e) {
 			setSetupError(draft);
 			setBusy(false);
@@ -140,13 +152,14 @@ export default function OnboardingPage() {
 		}
 	}
 
-	// Loading, redirecting to sign-in, or redirecting an already-onboarded user.
-	// Once a project is created we keep showing the flow regardless of state.
-	if (
-		sessionPending ||
-		!session?.user ||
-		(!created && state !== "needs-onboarding")
-	) {
+	// Wait for the session + workspace to resolve before deciding anything.
+	// First-run: an already-onboarded user (state "ready") is bounced to the
+	// dashboard by the effect above, so we hold the skeleton. New-bot: we want
+	// the "ready" user, so we only hold while still loading.
+	const resolving =
+		sessionPending || !session?.user || (!created && state === "loading");
+	const blockedFirstRun = !newBot && !created && state === "ready";
+	if (resolving || blockedFirstRun) {
 		return <OnboardingSkeleton />;
 	}
 
@@ -175,7 +188,9 @@ export default function OnboardingPage() {
 						<header className="flex flex-col items-center gap-3 text-center">
 							<BrandLogo className="size-11" />
 							<h1 className="font-display text-3xl font-semibold tracking-tight-display">
-								Let&apos;s build your support bot
+								{newBot
+									? "Let's build another bot"
+									: "Let's build your support bot"}
 							</h1>
 							<p className="max-w-md text-balance text-sm text-muted-foreground">
 								No forms, no setup wizard. Just chat with the assistant below —
@@ -210,5 +225,15 @@ export default function OnboardingPage() {
 				)}
 			</div>
 		</main>
+	);
+}
+
+export default function OnboardingPage() {
+	// useSearchParams needs a Suspense boundary; the skeleton doubles as the
+	// fallback so there's no flash before the flow resolves.
+	return (
+		<Suspense fallback={<OnboardingSkeleton />}>
+			<OnboardingFlow />
+		</Suspense>
 	);
 }

--- a/apps/dashboard/src/components/app-sidebar.tsx
+++ b/apps/dashboard/src/components/app-sidebar.tsx
@@ -13,6 +13,7 @@ import {
 	LifeBuoy,
 	LogOut,
 	MessagesSquare,
+	Plus,
 } from "lucide-react";
 
 import { api } from "@/lib/api";
@@ -229,6 +230,13 @@ export function AppSidebar({ userEmail }: { userEmail: string }) {
 												</DropdownMenuItem>
 											))}
 										</DropdownMenuGroup>
+										<DropdownMenuSeparator />
+										<DropdownMenuItem
+											onClick={() => router.push("/onboarding?new=1")}
+										>
+											<Plus />
+											<span>New bot</span>
+										</DropdownMenuItem>
 									</DropdownMenuContent>
 								</DropdownMenu>
 							</SidebarGroupContent>


### PR DESCRIPTION
Lets already-onboarded users add another bot through the **same conversational onboarding**, via `/onboarding?new=1`.

> **Stacked on #25** (conversational onboarding). Base is `feat/conversational-onboarding`; merge #25 first, then this. Rebase onto `main` once #25 lands.

## Prerequisite (verified before building)
A newly-created 2nd project is already visible/switchable today — `/settings/projects` lists all projects, the sidebar "Current project" dropdown switches between them, and the inbox `ProjectSwitcher` picks whose conversations to view. No global project selector needed. So "finish → `/settings/projects/:id`" lands on the new bot, selected.

## Behavior
- **New-bot mode (`?new=1`)**: skips the first-run "already onboarded → `/inbox`" redirect and the funnel-start analytics; waits for the existing workspace to resolve, then creates a **new project inside it**.
- **Invariant (a)** — never re-provisions the workspace and never duplicates a project: exactly one `POST /api/projects` in the existing workspace, and in new-bot mode a `403` surfaces as an error/retry instead of self-healing into a new workspace (only first-run keeps provision-and-retry).
- **Invariant (b)** — first-run preserved: brand-new users still auto-route in, the anti-trap guard and the post-create live-bot payoff are unchanged.
- **Invariant (c)** — finishing routes to `/settings/projects/:id`, so the new bot lands selected.
- **Entry point**: a "New bot" item in the sidebar project switcher → `/onboarding?new=1`.
- Page wrapped in `Suspense` for `useSearchParams`; still prerenders (251 kB First Load, unchanged).

## Tests (both paths)
- **New-bot**: creates a new project in the existing workspace, single POST, no workspace creation, lands on the new project; and no 403 self-heal in new-bot mode.
- **First-run unchanged**: provision-first, 403 self-heal, source-add, retry-on-failure, live-bot reveal + routing.
- 177 dashboard tests pass; `tsc` + lint + format + secret-scan clean; `next build` green (bundle gate OK).

🤖 Generated with [Claude Code](https://claude.com/claude-code)