### PR TITLE
feat: enforce RBAC roles (owner/admin/agent)

### DIFF
--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -3,9 +3,14 @@
 // variables live here, since they're app state rather than Ploy bindings.
 export type Env = PloyEnv;
 
+export type Role = "owner" | "admin" | "agent";
+
 export interface Variables {
 	userId: string;
 	workspaceId: string;
+	/** The caller's role in the active workspace, cached by requireWorkspace so
+	 * requireRole can assert without a second membership query. */
+	role: Role;
 }
 
 export type AppContext = {

--- a/apps/api/src/middleware/session.ts
+++ b/apps/api/src/middleware/session.ts
@@ -3,7 +3,8 @@ import { createMiddleware } from "hono/factory";
 import { createAuth } from "@/auth";
 import { db } from "@/lib/db";
 
-import type { AppContext } from "@/env";
+import type { AppContext, Role } from "@/env";
+import type { Context } from "hono";
 
 export const requireSession = createMiddleware<AppContext>(async (c, next) => {
 	const auth = createAuth(c.env);
@@ -15,28 +16,20 @@ export const requireSession = createMiddleware<AppContext>(async (c, next) => {
 	return next();
 });
 
-export const requireWorkspace = createMiddleware<AppContext>(
-	async (c, next) => {
-		const userId = c.get("userId");
-		const workspaceId = c.req.header("x-workspace-id");
-		if (!workspaceId) {
-			return c.json({ error: "workspace required" }, 400);
-		}
-		const m = await db(c.env).query.member.findFirst({
-			where: (mt, { and, eq: e }) =>
-				and(e(mt.userId, userId), e(mt.workspaceId, workspaceId)),
-		});
-		if (!m) {
-			return c.json({ error: "forbidden" }, 403);
-		}
-		c.set("workspaceId", workspaceId);
-		return next();
-	},
-);
+/** Role hierarchy: a higher rank includes every capability of the ranks below.
+ * owner ⊃ admin ⊃ agent. Centralized so authorization is one comparison, not a
+ * scatter of equality checks. */
+const ROLE_RANK: Record<Role, number> = { agent: 1, admin: 2, owner: 3 };
 
-// Like requireWorkspace, but asserts the caller is the workspace OWNER (not
-// just a member). Billing actions — checkout, portal — are owner-only.
-export const requireOwner = createMiddleware<AppContext>(async (c, next) => {
+/** Look up the caller's membership for the `x-workspace-id` workspace and cache
+ * (workspaceId, role) on the context. Returns the role, or a JSON error
+ * Response to short-circuit with (400 missing header / 403 not a member). */
+async function resolveMembership(
+	c: Context<AppContext>,
+): Promise<Role | Response> {
+	const cachedRole = c.get("role");
+	if (cachedRole && c.get("workspaceId")) return cachedRole;
+
 	const userId = c.get("userId");
 	const workspaceId = c.req.header("x-workspace-id");
 	if (!workspaceId) {
@@ -44,15 +37,49 @@ export const requireOwner = createMiddleware<AppContext>(async (c, next) => {
 	}
 	const m = await db(c.env).query.member.findFirst({
 		where: (mt, { and, eq: e }) =>
-			and(
-				e(mt.userId, userId),
-				e(mt.workspaceId, workspaceId),
-				e(mt.role, "owner"),
-			),
+			and(e(mt.userId, userId), e(mt.workspaceId, workspaceId)),
 	});
 	if (!m) {
 		return c.json({ error: "forbidden" }, 403);
 	}
+	// role is a non-null enum in practice; coerce a legacy null to the least
+	// privileged role so a bad row can never escalate.
+	const role = (m.role ?? "agent") as Role;
 	c.set("workspaceId", workspaceId);
-	return next();
-});
+	c.set("role", role);
+	return role;
+}
+
+/** Assert the caller is a member of the active workspace (any role). Caches the
+ * role so a later requireRole on the same request needs no extra query. */
+export const requireWorkspace = createMiddleware<AppContext>(
+	async (c, next) => {
+		const result = await resolveMembership(c);
+		if (result instanceof Response) return result;
+		return next();
+	},
+);
+
+/**
+ * Assert the caller's role is at least `min` in the hierarchy. Composes after
+ * requireWorkspace (reuses the cached role) or stands alone — billing mounts it
+ * without requireWorkspace, so it resolves membership itself when needed.
+ *
+ * Deny-by-default: an unknown role or missing membership is forbidden.
+ */
+export function requireRole(min: Role) {
+	return createMiddleware<AppContext>(async (c, next) => {
+		const result = await resolveMembership(c);
+		if (result instanceof Response) return result;
+		if (ROLE_RANK[result] < ROLE_RANK[min]) {
+			return c.json(
+				{ error: "forbidden", code: "insufficient_role", required: min },
+				403,
+			);
+		}
+		return next();
+	});
+}
+
+/** Billing actions — checkout, portal — are owner-only. */
+export const requireOwner = requireRole("owner");

--- a/apps/api/src/routes/conversations.ts
+++ b/apps/api/src/routes/conversations.ts
@@ -4,7 +4,11 @@ import { z } from "zod";
 
 import { db } from "@/lib/db";
 import { buildReplyToAddress, escapeHtml, sendEmail } from "@/lib/email";
-import { requireSession, requireWorkspace } from "@/middleware/session";
+import {
+	requireRole,
+	requireSession,
+	requireWorkspace,
+} from "@/middleware/session";
 
 import {
 	and,
@@ -261,16 +265,20 @@ export const conversations = new Hono<AppContext>()
 			return c.json({ ok: true });
 		},
 	)
-	.delete("/projects/:projectId/conversations/:id", async (c) => {
-		const { projectId, id } = c.req.param();
-		const workspaceId = c.get("workspaceId");
-		const proj = await db(c.env).query.project.findFirst({
-			where: (pt, { and: a, eq: e }) =>
-				a(e(pt.id, projectId), e(pt.workspaceId, workspaceId)),
-		});
-		if (!proj) {
-			return c.json({ error: "not found" }, 404);
-		}
-		await db(c.env).delete(conversation).where(eq(conversation.id, id));
-		return c.json({ ok: true });
-	});
+	.delete(
+		"/projects/:projectId/conversations/:id",
+		requireRole("admin"),
+		async (c) => {
+			const { projectId, id } = c.req.param();
+			const workspaceId = c.get("workspaceId");
+			const proj = await db(c.env).query.project.findFirst({
+				where: (pt, { and: a, eq: e }) =>
+					a(e(pt.id, projectId), e(pt.workspaceId, workspaceId)),
+			});
+			if (!proj) {
+				return c.json({ error: "not found" }, 404);
+			}
+			await db(c.env).delete(conversation).where(eq(conversation.id, id));
+			return c.json({ ok: true });
+		},
+	);

--- a/apps/api/src/routes/projects.test.ts
+++ b/apps/api/src/routes/projects.test.ts
@@ -1,0 +1,153 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { db } from "@/lib/db";
+
+import { projects } from "./projects";
+
+// Header-driven fake session so requireSession/requireWorkspace/requireRole run
+// for real without standing up Better Auth. `x-test-user` present ⇒ signed in.
+vi.mock("@/auth", () => ({
+	createAuth: () => ({
+		api: {
+			getSession: async ({ headers }: { headers: Headers }) => {
+				const id = headers.get("x-test-user");
+				return id ? { user: { id } } : null;
+			},
+		},
+	}),
+}));
+
+vi.mock("@/lib/db", () => ({ db: vi.fn() }));
+
+const ENV = { vars: {}, DB: {} } as unknown as Parameters<
+	typeof projects.request
+>[2];
+
+interface State {
+	/** Membership role for the requesting user, or undefined = not a member. */
+	role?: "owner" | "admin" | "agent";
+	existingProject?: Record<string, unknown>;
+}
+
+let insertSpy: ReturnType<typeof vi.fn>;
+let deleteSpy: ReturnType<typeof vi.fn>;
+
+function mockDb(state: State) {
+	insertSpy = vi.fn(() => ({
+		values: () => ({ returning: async () => [{ id: "p_new", name: "New" }] }),
+	}));
+	deleteSpy = vi.fn(() => ({ where: async () => [] }));
+	const fake = {
+		query: {
+			member: {
+				findFirst: async () => (state.role ? { role: state.role } : undefined),
+			},
+			project: {
+				findFirst: async () => state.existingProject,
+				findMany: async () => [{ id: "p1", name: "Existing" }],
+			},
+		},
+		insert: insertSpy,
+		delete: deleteSpy,
+	};
+	vi.mocked(db).mockReturnValue(fake as unknown as ReturnType<typeof db>);
+	return state;
+}
+
+function req(path: string, init: RequestInit = {}) {
+	return projects.request(path, init, ENV);
+}
+
+const json = { "content-type": "application/json" };
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("RBAC — POST /projects (create)", () => {
+	it("403s an agent (insufficient_role) and never inserts", async () => {
+		mockDb({ role: "agent" });
+		const res = await req("/projects", {
+			method: "POST",
+			headers: { "x-test-user": "u1", "x-workspace-id": "ws_1", ...json },
+			body: JSON.stringify({ name: "Bot" }),
+		});
+		expect(res.status).toBe(403);
+		expect(await res.json()).toMatchObject({ code: "insufficient_role" });
+		expect(insertSpy).not.toHaveBeenCalled();
+	});
+
+	it("lets an admin create", async () => {
+		mockDb({ role: "admin" });
+		const res = await req("/projects", {
+			method: "POST",
+			headers: { "x-test-user": "u1", "x-workspace-id": "ws_1", ...json },
+			body: JSON.stringify({ name: "Bot" }),
+		});
+		expect(res.status).toBe(200);
+		expect(insertSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it("lets an owner create", async () => {
+		mockDb({ role: "owner" });
+		const res = await req("/projects", {
+			method: "POST",
+			headers: { "x-test-user": "u1", "x-workspace-id": "ws_1", ...json },
+			body: JSON.stringify({ name: "Bot" }),
+		});
+		expect(res.status).toBe(200);
+	});
+
+	it("403s a non-member (forbidden) before touching the body", async () => {
+		mockDb({}); // no role ⇒ not a member
+		const res = await req("/projects", {
+			method: "POST",
+			headers: { "x-test-user": "u1", "x-workspace-id": "ws_1", ...json },
+			body: JSON.stringify({ name: "Bot" }),
+		});
+		expect(res.status).toBe(403);
+		expect(insertSpy).not.toHaveBeenCalled();
+	});
+
+	it("400s when no workspace is selected", async () => {
+		mockDb({ role: "admin" });
+		const res = await req("/projects", {
+			method: "POST",
+			headers: { "x-test-user": "u1", ...json },
+			body: JSON.stringify({ name: "Bot" }),
+		});
+		expect(res.status).toBe(400);
+	});
+});
+
+describe("RBAC — read & delete", () => {
+	it("lets an agent LIST projects (read is open to members)", async () => {
+		mockDb({ role: "agent" });
+		const res = await req("/projects", {
+			method: "GET",
+			headers: { "x-test-user": "u1", "x-workspace-id": "ws_1" },
+		});
+		expect(res.status).toBe(200);
+		expect(await res.json()).toEqual({
+			projects: [{ id: "p1", name: "Existing" }],
+		});
+	});
+
+	it("403s an agent deleting a project, never calls delete", async () => {
+		mockDb({ role: "agent", existingProject: { id: "p1" } });
+		const res = await req("/projects/p1", {
+			method: "DELETE",
+			headers: { "x-test-user": "u1", "x-workspace-id": "ws_1" },
+		});
+		expect(res.status).toBe(403);
+		expect(deleteSpy).not.toHaveBeenCalled();
+	});
+
+	it("lets an admin delete an existing project", async () => {
+		mockDb({ role: "admin", existingProject: { id: "p1" } });
+		const res = await req("/projects/p1", {
+			method: "DELETE",
+			headers: { "x-test-user": "u1", "x-workspace-id": "ws_1" },
+		});
+		expect(res.status).toBe(200);
+		expect(deleteSpy).toHaveBeenCalledTimes(1);
+	});
+});

--- a/apps/api/src/routes/projects.ts
+++ b/apps/api/src/routes/projects.ts
@@ -3,7 +3,11 @@ import { Hono } from "hono";
 import { z } from "zod";
 
 import { db } from "@/lib/db";
-import { requireSession, requireWorkspace } from "@/middleware/session";
+import {
+	requireRole,
+	requireSession,
+	requireWorkspace,
+} from "@/middleware/session";
 
 import { eq, project } from "@llmchat/db";
 import { DEFAULT_MODEL } from "@llmchat/shared";
@@ -46,22 +50,28 @@ export const projects = new Hono<AppContext>()
 		});
 		return c.json({ projects: rows });
 	})
-	.post("/projects", zValidator("json", projectInput), async (c) => {
-		const workspaceId = c.get("workspaceId");
-		const data = c.req.valid("json");
-		const [created] = await db(c.env)
-			.insert(project)
-			.values({
-				...data,
-				workspaceId,
-				publicKey: generatePublicKey(),
-				inboundEmailLocal: generateInboundLocal(),
-			})
-			.returning();
-		return c.json({ project: created });
-	})
+	.post(
+		"/projects",
+		requireRole("admin"),
+		zValidator("json", projectInput),
+		async (c) => {
+			const workspaceId = c.get("workspaceId");
+			const data = c.req.valid("json");
+			const [created] = await db(c.env)
+				.insert(project)
+				.values({
+					...data,
+					workspaceId,
+					publicKey: generatePublicKey(),
+					inboundEmailLocal: generateInboundLocal(),
+				})
+				.returning();
+			return c.json({ project: created });
+		},
+	)
 	.patch(
 		"/projects/:id",
+		requireRole("admin"),
 		zValidator("json", projectInput.partial()),
 		async (c) => {
 			const { id } = c.req.param();
@@ -82,7 +92,7 @@ export const projects = new Hono<AppContext>()
 			return c.json({ project: updated });
 		},
 	)
-	.delete("/projects/:id", async (c) => {
+	.delete("/projects/:id", requireRole("admin"), async (c) => {
 		const { id } = c.req.param();
 		const workspaceId = c.get("workspaceId");
 		const existing = await db(c.env).query.project.findFirst({

--- a/apps/api/src/routes/sources.ts
+++ b/apps/api/src/routes/sources.ts
@@ -4,7 +4,11 @@ import { z } from "zod";
 
 import { db } from "@/lib/db";
 import { fetchUrlContent } from "@/lib/fetch-url";
-import { requireSession, requireWorkspace } from "@/middleware/session";
+import {
+	requireRole,
+	requireSession,
+	requireWorkspace,
+} from "@/middleware/session";
 
 import { and, eq, source } from "@llmchat/db";
 
@@ -48,6 +52,7 @@ export const sources = new Hono<AppContext>()
 	})
 	.post(
 		"/projects/:projectId/sources",
+		requireRole("admin"),
 		zValidator("json", createInput),
 		async (c) => {
 			const { projectId } = c.req.param();
@@ -84,6 +89,7 @@ export const sources = new Hono<AppContext>()
 	)
 	.patch(
 		"/projects/:projectId/sources/:id",
+		requireRole("admin"),
 		zValidator("json", updateInput),
 		async (c) => {
 			const { projectId, id } = c.req.param();
@@ -133,43 +139,53 @@ export const sources = new Hono<AppContext>()
 			return c.json({ source: updated });
 		},
 	)
-	.post("/projects/:projectId/sources/:id/refresh", async (c) => {
-		const { projectId, id } = c.req.param();
-		const workspaceId = c.get("workspaceId");
-		const proj = await ensureProject(c.env, projectId, workspaceId);
-		if (!proj) return c.json({ error: "not found" }, 404);
-		const existing = await db(c.env).query.source.findFirst({
-			where: (s, { and: a, eq: e }) =>
-				a(e(s.id, id), e(s.projectId, projectId)),
-		});
-		if (!existing) return c.json({ error: "not found" }, 404);
+	.post(
+		"/projects/:projectId/sources/:id/refresh",
+		requireRole("admin"),
+		async (c) => {
+			const { projectId, id } = c.req.param();
+			const workspaceId = c.get("workspaceId");
+			const proj = await ensureProject(c.env, projectId, workspaceId);
+			if (!proj) return c.json({ error: "not found" }, 404);
+			const existing = await db(c.env).query.source.findFirst({
+				where: (s, { and: a, eq: e }) =>
+					a(e(s.id, id), e(s.projectId, projectId)),
+			});
+			if (!existing) return c.json({ error: "not found" }, 404);
 
-		const fetched = await tryFetch(existing.url);
-		const [updated] = await db(c.env)
-			.update(source)
-			.set({
-				title: fetched.error ? existing.title : fetched.title || existing.title,
-				content: fetched.error ? existing.content : fetched.content,
-				lastError: fetched.error,
-				lastFetchedAt: new Date(),
-				updatedAt: new Date(),
-			})
-			.where(and(eq(source.id, id), eq(source.projectId, projectId)))
-			.returning();
-		return c.json({ source: updated });
-	})
-	.delete("/projects/:projectId/sources/:id", async (c) => {
-		const { projectId, id } = c.req.param();
-		const workspaceId = c.get("workspaceId");
-		const proj = await ensureProject(c.env, projectId, workspaceId);
-		if (!proj) return c.json({ error: "not found" }, 404);
-		const result = await db(c.env)
-			.delete(source)
-			.where(and(eq(source.id, id), eq(source.projectId, projectId)))
-			.returning({ id: source.id });
-		if (result.length === 0) return c.json({ error: "not found" }, 404);
-		return c.json({ ok: true });
-	});
+			const fetched = await tryFetch(existing.url);
+			const [updated] = await db(c.env)
+				.update(source)
+				.set({
+					title: fetched.error
+						? existing.title
+						: fetched.title || existing.title,
+					content: fetched.error ? existing.content : fetched.content,
+					lastError: fetched.error,
+					lastFetchedAt: new Date(),
+					updatedAt: new Date(),
+				})
+				.where(and(eq(source.id, id), eq(source.projectId, projectId)))
+				.returning();
+			return c.json({ source: updated });
+		},
+	)
+	.delete(
+		"/projects/:projectId/sources/:id",
+		requireRole("admin"),
+		async (c) => {
+			const { projectId, id } = c.req.param();
+			const workspaceId = c.get("workspaceId");
+			const proj = await ensureProject(c.env, projectId, workspaceId);
+			if (!proj) return c.json({ error: "not found" }, 404);
+			const result = await db(c.env)
+				.delete(source)
+				.where(and(eq(source.id, id), eq(source.projectId, projectId)))
+				.returning({ id: source.id });
+			if (result.length === 0) return c.json({ error: "not found" }, 404);
+			return c.json({ ok: true });
+		},
+	);
 async function tryFetch(url: string): Promise<{
 	title: string;
 	content: string;

--- a/apps/api/src/routes/system-prompts.ts
+++ b/apps/api/src/routes/system-prompts.ts
@@ -3,7 +3,11 @@ import { Hono } from "hono";
 import { z } from "zod";
 
 import { db } from "@/lib/db";
-import { requireSession, requireWorkspace } from "@/middleware/session";
+import {
+	requireRole,
+	requireSession,
+	requireWorkspace,
+} from "@/middleware/session";
 
 import { and, eq, project, systemPrompt } from "@llmchat/db";
 
@@ -44,6 +48,7 @@ export const systemPrompts = new Hono<AppContext>()
 	})
 	.post(
 		"/projects/:projectId/system-prompts",
+		requireRole("admin"),
 		zValidator("json", promptInput),
 		async (c) => {
 			const { projectId } = c.req.param();
@@ -67,6 +72,7 @@ export const systemPrompts = new Hono<AppContext>()
 	)
 	.patch(
 		"/projects/:projectId/system-prompts/:id",
+		requireRole("admin"),
 		zValidator("json", promptInput.partial()),
 		async (c) => {
 			const { projectId, id } = c.req.param();
@@ -85,42 +91,50 @@ export const systemPrompts = new Hono<AppContext>()
 			return c.json({ prompt: updated });
 		},
 	)
-	.post("/projects/:projectId/system-prompts/:id/activate", async (c) => {
-		const { projectId, id } = c.req.param();
-		const workspaceId = c.get("workspaceId");
-		const proj = await ensureProject(c.env, projectId, workspaceId);
-		if (!proj) return c.json({ error: "not found" }, 404);
-		const existing = await db(c.env).query.systemPrompt.findFirst({
-			where: (sp, { and: a, eq: e }) =>
-				a(e(sp.id, id), e(sp.projectId, projectId)),
-		});
-		if (!existing) return c.json({ error: "not found" }, 404);
-		await db(c.env)
-			.update(project)
-			.set({ activeSystemPromptId: id })
-			.where(eq(project.id, projectId));
-		return c.json({ ok: true, activeSystemPromptId: id });
-	})
-	.delete("/projects/:projectId/system-prompts/:id", async (c) => {
-		const { projectId, id } = c.req.param();
-		const workspaceId = c.get("workspaceId");
-		const proj = await ensureProject(c.env, projectId, workspaceId);
-		if (!proj) return c.json({ error: "not found" }, 404);
-		await db(c.env)
-			.delete(systemPrompt)
-			.where(
-				and(eq(systemPrompt.id, id), eq(systemPrompt.projectId, projectId)),
-			);
-		// If the deleted one was active, fall back to another (or null).
-		if (proj.activeSystemPromptId === id) {
-			const next = await db(c.env).query.systemPrompt.findFirst({
-				where: (sp, { eq: e }) => e(sp.projectId, projectId),
-				orderBy: (sp, { asc }) => asc(sp.createdAt),
+	.post(
+		"/projects/:projectId/system-prompts/:id/activate",
+		requireRole("admin"),
+		async (c) => {
+			const { projectId, id } = c.req.param();
+			const workspaceId = c.get("workspaceId");
+			const proj = await ensureProject(c.env, projectId, workspaceId);
+			if (!proj) return c.json({ error: "not found" }, 404);
+			const existing = await db(c.env).query.systemPrompt.findFirst({
+				where: (sp, { and: a, eq: e }) =>
+					a(e(sp.id, id), e(sp.projectId, projectId)),
 			});
+			if (!existing) return c.json({ error: "not found" }, 404);
 			await db(c.env)
 				.update(project)
-				.set({ activeSystemPromptId: next?.id ?? null })
+				.set({ activeSystemPromptId: id })
 				.where(eq(project.id, projectId));
-		}
-		return c.json({ ok: true });
-	});
+			return c.json({ ok: true, activeSystemPromptId: id });
+		},
+	)
+	.delete(
+		"/projects/:projectId/system-prompts/:id",
+		requireRole("admin"),
+		async (c) => {
+			const { projectId, id } = c.req.param();
+			const workspaceId = c.get("workspaceId");
+			const proj = await ensureProject(c.env, projectId, workspaceId);
+			if (!proj) return c.json({ error: "not found" }, 404);
+			await db(c.env)
+				.delete(systemPrompt)
+				.where(
+					and(eq(systemPrompt.id, id), eq(systemPrompt.projectId, projectId)),
+				);
+			// If the deleted one was active, fall back to another (or null).
+			if (proj.activeSystemPromptId === id) {
+				const next = await db(c.env).query.systemPrompt.findFirst({
+					where: (sp, { eq: e }) => e(sp.projectId, projectId),
+					orderBy: (sp, { asc }) => asc(sp.createdAt),
+				});
+				await db(c.env)
+					.update(project)
+					.set({ activeSystemPromptId: next?.id ?? null })
+					.where(eq(project.id, projectId));
+			}
+			return c.json({ ok: true });
+		},
+	);

--- a/apps/dashboard/src/app/inbox/page.tsx
+++ b/apps/dashboard/src/app/inbox/page.tsx
@@ -6,7 +6,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 
 import { Badge } from "@/components/ui/badge";
-import { api } from "@/lib/api";
+import { api, describeApiError } from "@/lib/api";
 import { resolveOnboardingState } from "@/lib/onboarding";
 import { resolveSelectedId } from "@/lib/selection";
 import { useWorkspace } from "@/lib/workspace";
@@ -173,9 +173,7 @@ export default function InboxPage() {
 			await thread.refetch();
 			await conversations.refetch();
 		} catch (e) {
-			toast.error("Failed to send reply", {
-				description: e instanceof Error ? e.message : undefined,
-			});
+			toast.error(describeApiError(e, "Failed to send reply"));
 		} finally {
 			setSending(false);
 		}
@@ -197,9 +195,7 @@ export default function InboxPage() {
 			setSelectedId(null);
 			await conversations.refetch();
 		} catch (e) {
-			toast.error("Failed to update conversation", {
-				description: e instanceof Error ? e.message : undefined,
-			});
+			toast.error(describeApiError(e, "Failed to update conversation"));
 		} finally {
 			setArchiving(false);
 		}
@@ -217,9 +213,7 @@ export default function InboxPage() {
 			setSelectedId(null);
 			await conversations.refetch();
 		} catch (e) {
-			toast.error("Failed to delete conversation", {
-				description: e instanceof Error ? e.message : undefined,
-			});
+			toast.error(describeApiError(e, "Failed to delete conversation"));
 		} finally {
 			setDeleting(false);
 		}

--- a/apps/dashboard/src/app/settings/billing/page.test.tsx
+++ b/apps/dashboard/src/app/settings/billing/page.test.tsx
@@ -35,10 +35,12 @@ const clickUpgrade = (user: ReturnType<typeof userEvent.setup>) =>
 
 function setWorkspace(plan: Plan | null, isLoading = false) {
 	vi.mocked(useWorkspace).mockReturnValue({
-		workspaces: plan ? [{ id: "ws_1", name: "WS", plan }] : [],
+		workspaces: plan ? [{ id: "ws_1", name: "WS", plan, role: "owner" }] : [],
 		workspaceId: plan ? "ws_1" : null,
 		setWorkspaceId: vi.fn(),
 		isLoading,
+		role: plan ? "owner" : null,
+		canManage: !!plan,
 	});
 }
 

--- a/apps/dashboard/src/app/settings/projects/[id]/useProjectMutations.ts
+++ b/apps/dashboard/src/app/settings/projects/[id]/useProjectMutations.ts
@@ -4,7 +4,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 
-import { api } from "@/lib/api";
+import { api, describeApiError } from "@/lib/api";
 
 import type { Project, Source } from "./types";
 
@@ -25,7 +25,7 @@ export function useProjectMutations(id: string, workspaceId: string | null) {
 			qc.invalidateQueries({ queryKey: ["projects"] });
 			toast.success("Project updated successfully");
 		},
-		onError: () => toast.error("Could not save project"),
+		onError: (e) => toast.error(describeApiError(e, "Could not save project")),
 	});
 
 	const remove = useMutation({
@@ -39,7 +39,8 @@ export function useProjectMutations(id: string, workspaceId: string | null) {
 			toast.success("Project deleted");
 			router.push("/settings/projects");
 		},
-		onError: () => toast.error("Could not delete project"),
+		onError: (e) =>
+			toast.error(describeApiError(e, "Could not delete project")),
 	});
 
 	const addSource = useMutation({
@@ -53,7 +54,7 @@ export function useProjectMutations(id: string, workspaceId: string | null) {
 			qc.invalidateQueries({ queryKey: ["sources", id] });
 			toast.success("Source added successfully");
 		},
-		onError: () => toast.error("Could not add source"),
+		onError: (e) => toast.error(describeApiError(e, "Could not add source")),
 	});
 
 	const refreshSource = useMutation({
@@ -66,7 +67,8 @@ export function useProjectMutations(id: string, workspaceId: string | null) {
 			qc.invalidateQueries({ queryKey: ["sources", id] });
 			toast.success("Source refreshed");
 		},
-		onError: () => toast.error("Could not refresh source"),
+		onError: (e) =>
+			toast.error(describeApiError(e, "Could not refresh source")),
 	});
 
 	const deleteSource = useMutation({
@@ -79,7 +81,7 @@ export function useProjectMutations(id: string, workspaceId: string | null) {
 			qc.invalidateQueries({ queryKey: ["sources", id] });
 			toast.success("Source removed");
 		},
-		onError: () => toast.error("Could not remove source"),
+		onError: (e) => toast.error(describeApiError(e, "Could not remove source")),
 	});
 
 	return { save, remove, addSource, refreshSource, deleteSource };

--- a/apps/dashboard/src/app/settings/projects/page.tsx
+++ b/apps/dashboard/src/app/settings/projects/page.tsx
@@ -14,9 +14,10 @@ import {
 	EmptyMedia,
 	EmptyTitle,
 } from "@/components/ui/empty";
-import { api } from "@/lib/api";
+import { api, describeApiError } from "@/lib/api";
 import { useWorkspace } from "@/lib/workspace";
 import { track, ANALYTICS_EVENTS } from "@/lib/analytics";
+import { RoleGate } from "@/components/role-gate";
 
 import { CreateProjectDialog } from "./_components/CreateProjectDialog";
 import { DeleteProjectDialog } from "./_components/DeleteProjectDialog";
@@ -67,9 +68,7 @@ export default function ProjectsPage() {
 			toast.success("Project created");
 		},
 		onError: (e) =>
-			toast.error("Failed to create project", {
-				description: e instanceof Error ? e.message : undefined,
-			}),
+			toast.error(describeApiError(e, "Failed to create project")),
 	});
 
 	const remove = useMutation({
@@ -85,9 +84,7 @@ export default function ProjectsPage() {
 			toast.success("Project deleted");
 		},
 		onError: (e) =>
-			toast.error("Failed to delete project", {
-				description: e instanceof Error ? e.message : undefined,
-			}),
+			toast.error(describeApiError(e, "Failed to delete project")),
 	});
 
 	const toggle = useMutation({
@@ -141,10 +138,12 @@ export default function ProjectsPage() {
 						Manage your chat projects and their configurations.
 					</p>
 				</div>
-				<Button onClick={() => setShowCreate(true)}>
-					<Plus />
-					New Project
-				</Button>
+				<RoleGate>
+					<Button onClick={() => setShowCreate(true)}>
+						<Plus />
+						New Project
+					</Button>
+				</RoleGate>
 			</div>
 
 			{(list.length > 0 || search || favOnly) && (
@@ -191,10 +190,18 @@ export default function ProjectsPage() {
 						</EmptyDescription>
 					</EmptyHeader>
 					<EmptyContent>
-						<Button onClick={() => setShowCreate(true)}>
-							<FolderPlus />
-							Create Project
-						</Button>
+						<RoleGate
+							fallback={
+								<p className="text-sm text-muted-foreground">
+									Ask a workspace owner or admin to create one.
+								</p>
+							}
+						>
+							<Button onClick={() => setShowCreate(true)}>
+								<FolderPlus />
+								Create Project
+							</Button>
+						</RoleGate>
 					</EmptyContent>
 				</Empty>
 			) : filtered.length === 0 ? (

--- a/apps/dashboard/src/components/app-sidebar.tsx
+++ b/apps/dashboard/src/components/app-sidebar.tsx
@@ -21,6 +21,7 @@ import { signOut } from "@/lib/auth-client";
 import { track, resetAnalytics, ANALYTICS_EVENTS } from "@/lib/analytics";
 import { useWorkspace } from "@/lib/workspace";
 import { BrandLogo } from "@/components/brand-logo";
+import { RoleGate } from "@/components/role-gate";
 import { ModeToggle } from "@/components/mode-toggle";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
@@ -103,8 +104,9 @@ function scrollToStep(stepId: string) {
 export function AppSidebar({ userEmail }: { userEmail: string }) {
 	const pathname = usePathname();
 	const router = useRouter();
-	const { workspaces, workspaceId, setWorkspaceId } = useWorkspace();
+	const { workspaces, workspaceId, setWorkspaceId, role } = useWorkspace();
 	const initials = userEmail.slice(0, 2).toUpperCase();
+	const roleLabel = role ? role[0].toUpperCase() + role.slice(1) : "Member";
 
 	const projectMatch = pathname.match(/^\/settings\/projects\/([^/]+)$/);
 	const currentProjectId = projectMatch?.[1] ?? null;
@@ -230,13 +232,15 @@ export function AppSidebar({ userEmail }: { userEmail: string }) {
 												</DropdownMenuItem>
 											))}
 										</DropdownMenuGroup>
-										<DropdownMenuSeparator />
-										<DropdownMenuItem
-											onClick={() => router.push("/onboarding?new=1")}
-										>
-											<Plus />
-											<span>New bot</span>
-										</DropdownMenuItem>
+										<RoleGate>
+											<DropdownMenuSeparator />
+											<DropdownMenuItem
+												onClick={() => router.push("/onboarding?new=1")}
+											>
+												<Plus />
+												<span>New bot</span>
+											</DropdownMenuItem>
+										</RoleGate>
 									</DropdownMenuContent>
 								</DropdownMenu>
 							</SidebarGroupContent>
@@ -323,7 +327,7 @@ export function AppSidebar({ userEmail }: { userEmail: string }) {
 									<div className="grid flex-1 text-left text-sm leading-tight">
 										<span className="truncate font-medium">{userEmail}</span>
 										<span className="truncate text-xs text-muted-foreground">
-											Admin
+											{roleLabel}
 										</span>
 									</div>
 									<ChevronsUpDown className="ml-auto size-4" />

--- a/apps/dashboard/src/components/role-gate.test.tsx
+++ b/apps/dashboard/src/components/role-gate.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { RoleGate } from "./role-gate";
+
+const useWorkspace = vi.fn();
+vi.mock("@/lib/workspace", () => ({
+	useWorkspace: () => useWorkspace(),
+}));
+
+describe("RoleGate", () => {
+	it("renders children for a manager", () => {
+		useWorkspace.mockReturnValue({ canManage: true });
+		render(
+			<RoleGate fallback={<span>denied</span>}>
+				<button>Delete</button>
+			</RoleGate>,
+		);
+		expect(screen.getByRole("button", { name: "Delete" })).toBeInTheDocument();
+		expect(screen.queryByText("denied")).not.toBeInTheDocument();
+	});
+
+	it("renders the fallback (and never the children) for a non-manager", () => {
+		useWorkspace.mockReturnValue({ canManage: false });
+		render(
+			<RoleGate fallback={<span>denied</span>}>
+				<button>Delete</button>
+			</RoleGate>,
+		);
+		expect(
+			screen.queryByRole("button", { name: "Delete" }),
+		).not.toBeInTheDocument();
+		expect(screen.getByText("denied")).toBeInTheDocument();
+	});
+
+	it("renders nothing by default when denied", () => {
+		useWorkspace.mockReturnValue({ canManage: false });
+		const { container } = render(
+			<RoleGate>
+				<button>Delete</button>
+			</RoleGate>,
+		);
+		expect(container).toBeEmptyDOMElement();
+	});
+});

--- a/apps/dashboard/src/components/role-gate.tsx
+++ b/apps/dashboard/src/components/role-gate.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import type { ReactNode } from "react";
+
+import { useWorkspace } from "@/lib/workspace";
+
+/**
+ * Render `children` only when the active role may manage the workspace
+ * (owner/admin); otherwise render `fallback` (nothing by default).
+ *
+ * Composition over flags: instead of threading a `canManage` boolean into every
+ * button, wrap the management-only UI. The server enforces the same rule via
+ * requireRole("admin") — this is purely so agents aren't shown actions that
+ * would only 403. Keep destructive/irreversible affordances inside a gate.
+ */
+export function RoleGate({
+	children,
+	fallback = null,
+}: {
+	children: ReactNode;
+	fallback?: ReactNode;
+}) {
+	const { canManage } = useWorkspace();
+	return <>{canManage ? children : fallback}</>;
+}

--- a/apps/dashboard/src/lib/api.test.ts
+++ b/apps/dashboard/src/lib/api.test.ts
@@ -1,6 +1,22 @@
 import { describe, expect, it } from "vitest";
 
-import { ApiError, isWorkspaceAuthError } from "./api";
+import { ApiError, describeApiError, isWorkspaceAuthError } from "./api";
+
+describe("ApiError.code", () => {
+	it("parses a machine code from a JSON body (code preferred, error fallback)", () => {
+		expect(
+			new ApiError(403, '{"error":"forbidden","code":"insufficient_role"}')
+				.code,
+		).toBe("insufficient_role");
+		expect(new ApiError(429, '{"error":"rate_limited"}').code).toBe(
+			"rate_limited",
+		);
+	});
+
+	it("leaves code undefined for a non-JSON body", () => {
+		expect(new ApiError(500, "Internal Server Error").code).toBeUndefined();
+	});
+});
 
 describe("isWorkspaceAuthError", () => {
 	it("is true for the workspace-assertion failures (400 missing, 403 not a member)", () => {
@@ -8,6 +24,16 @@ describe("isWorkspaceAuthError", () => {
 			true,
 		);
 		expect(isWorkspaceAuthError(new ApiError(403, "forbidden"))).toBe(true);
+	});
+
+	// Critical: a role denial is a legitimate 403, NOT a broken workspace — it
+	// must not trigger onboarding's workspace re-provisioning self-heal.
+	it("is false for a role denial (insufficient_role), even though it's a 403", () => {
+		expect(
+			isWorkspaceAuthError(
+				new ApiError(403, '{"error":"forbidden","code":"insufficient_role"}'),
+			),
+		).toBe(false);
 	});
 
 	it("is false for other statuses and non-ApiError throwables", () => {
@@ -23,5 +49,32 @@ describe("isWorkspaceAuthError", () => {
 		expect(e.status).toBe(403);
 		expect(e.body).toBe('{"error":"forbidden"}');
 		expect(e.message).toContain("403");
+	});
+});
+
+describe("describeApiError", () => {
+	it("maps a permission denial to actionable copy", () => {
+		expect(
+			describeApiError(new ApiError(403, '{"code":"insufficient_role"}'), "x"),
+		).toMatch(/permission/i);
+	});
+
+	it("maps bare 429/403 statuses without a code", () => {
+		expect(describeApiError(new ApiError(429, "slow down"), "x")).toMatch(
+			/too many requests/i,
+		);
+		expect(describeApiError(new ApiError(403, "forbidden"), "x")).toMatch(
+			/access to this workspace/i,
+		);
+	});
+
+	it("falls back for unknown ApiErrors and plain errors", () => {
+		expect(describeApiError(new ApiError(500, "boom"), "fallback")).toBe(
+			"fallback",
+		);
+		expect(describeApiError(new Error("network down"), "fallback")).toBe(
+			"network down",
+		);
+		expect(describeApiError("weird", "fallback")).toBe("fallback");
 	});
 });

--- a/apps/dashboard/src/lib/api.ts
+++ b/apps/dashboard/src/lib/api.ts
@@ -6,25 +6,56 @@ export interface ApiOptions {
 	workspaceId?: string;
 }
 
-/** Carries the HTTP status so callers can branch (e.g. recover from a stale
- * workspace) instead of string-matching the message. */
+/** Carries the HTTP status (and machine `code`, when the body is a JSON error)
+ * so callers can branch — recover from a stale workspace, distinguish a
+ * plan-limit from a permission denial — instead of string-matching the message. */
 export class ApiError extends Error {
+	/** Machine-readable error code from a `{ error | code }` JSON body, if any. */
+	readonly code?: string;
+
 	constructor(
 		readonly status: number,
 		readonly body: string,
 	) {
 		super(`API ${status}: ${body}`);
 		this.name = "ApiError";
+		try {
+			const parsed = JSON.parse(body) as { error?: string; code?: string };
+			this.code = parsed.code ?? parsed.error;
+		} catch {
+			// Non-JSON body (e.g. a plain-text 500) — leave code undefined.
+		}
 	}
 }
 
 /** A failed `x-workspace-id` assertion: the active workspace is missing (400)
  * or the user isn't a member of it (403). Onboarding uses this to self-heal a
- * stale/broken workspace context by provisioning a fresh workspace. */
+ * stale/broken workspace context by provisioning a fresh workspace.
+ *
+ * Excludes role denials (`insufficient_role`): an agent hitting an admin-only
+ * route is a legitimately-forbidden action, not a broken workspace context, so
+ * it must NOT trigger re-provisioning. */
 export function isWorkspaceAuthError(error: unknown): boolean {
 	return (
-		error instanceof ApiError && (error.status === 400 || error.status === 403)
+		error instanceof ApiError &&
+		error.code !== "insufficient_role" &&
+		(error.status === 400 || error.status === 403)
 	);
+}
+
+/** Map an API failure to a friendly, actionable sentence for a toast. Centralized
+ * so every mutation surfaces permission / rate-limit errors consistently
+ * instead of leaking the raw `API 4xx: …` string. */
+export function describeApiError(error: unknown, fallback: string): string {
+	if (!(error instanceof ApiError)) {
+		return error instanceof Error ? error.message : fallback;
+	}
+	if (error.code === "insufficient_role") {
+		return "You don't have permission to do that. Ask a workspace owner or admin.";
+	}
+	if (error.status === 429) return "Too many requests — try again in a moment.";
+	if (error.status === 403) return "You don't have access to this workspace.";
+	return fallback;
 }
 
 export async function api<T>(

--- a/apps/dashboard/src/lib/workspace-utils.test.ts
+++ b/apps/dashboard/src/lib/workspace-utils.test.ts
@@ -1,9 +1,14 @@
 import { describe, expect, it } from "vitest";
 
-import { resolveWorkspaceId } from "./workspace-utils";
+import { canManage, resolveWorkspaceId } from "./workspace-utils";
 
 const ws = (...ids: string[]) =>
-	ids.map((id) => ({ id, name: id, plan: "free" as const }));
+	ids.map((id) => ({
+		id,
+		name: id,
+		plan: "free" as const,
+		role: "owner" as const,
+	}));
 
 describe("resolveWorkspaceId", () => {
 	it("returns null when the user has no workspaces", () => {
@@ -27,5 +32,18 @@ describe("resolveWorkspaceId", () => {
 
 	it("does not treat an empty string as a valid stored id", () => {
 		expect(resolveWorkspaceId("", ws("a", "b"))).toBe("a");
+	});
+});
+
+describe("canManage", () => {
+	it("grants owner and admin", () => {
+		expect(canManage("owner")).toBe(true);
+		expect(canManage("admin")).toBe(true);
+	});
+
+	it("denies agents and unresolved/unknown roles", () => {
+		expect(canManage("agent")).toBe(false);
+		expect(canManage(null)).toBe(false);
+		expect(canManage(undefined)).toBe(false);
 	});
 });

--- a/apps/dashboard/src/lib/workspace-utils.ts
+++ b/apps/dashboard/src/lib/workspace-utils.ts
@@ -5,15 +5,32 @@ import { resolveSelectedId } from "./selection";
 
 export type Plan = "free" | "pro" | "scale";
 
+/** Workspace RBAC roles, mirrored from the API. Higher roles include the
+ * capabilities of lower ones: owner ⊃ admin ⊃ agent. */
+export type WorkspaceRole = "owner" | "admin" | "agent";
+
 export interface WorkspaceSummary {
 	id: string;
 	name: string;
 	plan: Plan;
+	/** The current user's role in this workspace. */
+	role: WorkspaceRole;
 }
 
-/** Shape of the API's /api/workspaces response. */
+/** Shape of the API's /api/workspaces response — a join row pairing each
+ * workspace with the caller's membership role. */
 export interface WorkspacesResponse {
-	workspaces: { workspace: WorkspaceSummary }[];
+	workspaces: {
+		workspace: Omit<WorkspaceSummary, "role">;
+		role: WorkspaceRole;
+	}[];
+}
+
+/** Whether a role may perform workspace-management actions (create/edit/delete
+ * projects, manage sources & prompts). Agents are support-only: they work the
+ * inbox but can't reconfigure bots. Mirrors the API's requireRole("admin"). */
+export function canManage(role: WorkspaceRole | null | undefined): boolean {
+	return role === "owner" || role === "admin";
 }
 
 /** Shared react-query key so server prefetch and the client provider hydrate

--- a/apps/dashboard/src/lib/workspace.tsx
+++ b/apps/dashboard/src/lib/workspace.tsx
@@ -12,7 +12,9 @@ import {
 
 import { api } from "./api";
 import {
+	canManage,
 	resolveWorkspaceId,
+	type WorkspaceRole,
 	type WorkspaceSummary,
 	type WorkspacesResponse,
 	WORKSPACES_KEY,
@@ -23,6 +25,11 @@ interface WorkspaceCtx {
 	workspaceId: string | null;
 	setWorkspaceId: (id: string) => void;
 	isLoading: boolean;
+	/** The current user's role in the active workspace (null until resolved). */
+	role: WorkspaceRole | null;
+	/** Whether the active role may manage the workspace (create/edit/delete
+	 * projects, sources, prompts). Drives RoleGate and button enablement. */
+	canManage: boolean;
 }
 
 const Ctx = createContext<WorkspaceCtx>({
@@ -30,6 +37,8 @@ const Ctx = createContext<WorkspaceCtx>({
 	workspaceId: null,
 	setWorkspaceId: () => {},
 	isLoading: false,
+	role: null,
+	canManage: false,
 });
 
 const KEY = "llmchat_workspace_id";
@@ -47,7 +56,7 @@ export function WorkspaceProvider({ children }: { children: React.ReactNode }) {
 	// each render just because `.map()` produced a fresh array.
 	const { data, isLoading } = query;
 	const workspaces = useMemo(
-		() => data?.workspaces.map((w) => w.workspace) ?? [],
+		() => data?.workspaces.map((w) => ({ ...w.workspace, role: w.role })) ?? [],
 		[data],
 	);
 
@@ -70,9 +79,18 @@ export function WorkspaceProvider({ children }: { children: React.ReactNode }) {
 		set(id);
 	}, []);
 
+	const role = workspaces.find((w) => w.id === workspaceId)?.role ?? null;
+
 	const value = useMemo<WorkspaceCtx>(
-		() => ({ workspaces, workspaceId, setWorkspaceId, isLoading }),
-		[workspaces, workspaceId, setWorkspaceId, isLoading],
+		() => ({
+			workspaces,
+			workspaceId,
+			setWorkspaceId,
+			isLoading,
+			role,
+			canManage: canManage(role),
+		}),
+		[workspaces, workspaceId, setWorkspaceId, isLoading, role],
 	);
 
 	return <Ctx.Provider value={value}>{children}</Ctx.Provider>;


### PR DESCRIPTION
Enforces workspace RBAC server-side and reflects it in the dashboard UI. Split out from the combined RBAC + plan-limits work — **flat-tier plan limits are parked separately and intentionally excluded** (the hosted product is going usage-based per message), so this PR is the clean, mergeable half.

## Server (`feat(api)`)
- Role hierarchy **owner > admin > agent** with a composable `requireRole(min)` middleware; `requireWorkspace` caches the role so `requireRole` adds no extra query. `requireOwner = requireRole("owner")`.
- Mutations gated at **admin+** (projects, sources, system-prompts, conversation delete); reads + reply/archive stay open to members; **billing stays owner-only**.
- **Deny-by-default** → `403 { code: "insufficient_role" }`.

## Client (`feat(dashboard)`)
- `useWorkspace` now exposes `role` + `canManage`; sidebar shows the real role (was hardcoded "Admin").
- `<RoleGate>` composition component hides management-only UI from agents (hide-by-default, so agents never see actions that would only 403).
- `ApiError` parses the JSON error code; `describeApiError` centralizes friendly permission/rate-limit copy. `isWorkspaceAuthError` excludes `insufficient_role` so a role denial no longer triggers onboarding's re-provisioning self-heal.

## Safe to deploy — load-bearing checks confirmed
- **No member lockout / no backfill:** `member.role` is `NOT NULL DEFAULT 'agent'`; the only member-insert path (`provisionWorkspace`) sets `"owner"`, and there's no invite feature yet — so every existing member (incl. the owner's own workspace, and the dev-seed admin) is already an `owner`.
- **Billing is owner-gated:** `checkout`/`portal` use `requireOwner`; the webhook is Stripe-signature-verified. Admin/agent cannot change billing.

## Tests / checks
- API 98 + dashboard 188 pass; typecheck, lint/prettier, secret-scan all clean. Adversarial tests cover agent-forbidden-no-write, admin/owner-allowed, non-member 403, missing-workspace 400, reads open, RoleGate hide/fallback, error mapping.

Parked half (no PR): `parked/flat-plan-limits` — caps + the per-message metering that will seed usage billing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)