### PR TITLE
fix: honest interim billing, docs link, showcase DNS diagnosis

### DIFF
--- a/apps/dashboard/src/app/settings/billing/_components/CurrentPlanCard.tsx
+++ b/apps/dashboard/src/app/settings/billing/_components/CurrentPlanCard.tsx
@@ -1,15 +1,16 @@
-import { Check } from "lucide-react";
-
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import type { Plan } from "@/lib/workspace-utils";
 
-import { PRICING_TIERS } from "./billing-plans";
+import { PRO_TIER } from "./billing-plans";
 
 /**
- * The caller's current plan: price, tagline, included features, and the
- * plan-driven action (free → upgrade, paid → manage in the Stripe portal).
+ * The caller's billing status. There is no free tier any more, so a workspace
+ * that isn't on a paid plan shows "No active subscription" (never a "$0 Free
+ * plan"), and the action follows the status: not subscribed → upgrade, paid →
+ * manage in the Stripe portal. Capabilities live on the Pro card below, so this
+ * card stays lean — status + price + one action.
  */
 export function CurrentPlanCard({
 	plan,
@@ -22,43 +23,41 @@ export function CurrentPlanCard({
 	onUpgrade: () => void;
 	onManage: () => void;
 }) {
-	const tier = PRICING_TIERS.find((t) => t.plan === plan) ?? PRICING_TIERS[0];
-	const isFree = plan === "free";
+	const subscribed = plan !== "free";
 
 	return (
 		<Card className="flex flex-col">
 			<CardHeader>
 				<div className="flex items-center justify-between gap-3">
 					<CardTitle>Current plan</CardTitle>
-					<Badge variant={isFree ? "secondary" : "success"}>{tier.name}</Badge>
+					<Badge variant={subscribed ? "success" : "secondary"}>
+						{subscribed ? PRO_TIER.name : "No subscription"}
+					</Badge>
 				</div>
 			</CardHeader>
 			<CardContent className="flex flex-1 flex-col">
-				<div className="flex items-baseline gap-1">
-					<span className="text-3xl font-semibold tracking-tight-display">
-						{tier.price}
-					</span>
-					<span className="text-sm text-muted-foreground">/ month</span>
-				</div>
-				<p className="mt-1 text-sm text-muted-foreground">
-					{isFree ? "Perfect for getting started." : tier.tagline}
-				</p>
+				{subscribed ? (
+					<>
+						<div className="flex items-baseline gap-1">
+							<span className="text-3xl font-semibold tracking-tight-display">
+								{plan === "pro" ? PRO_TIER.price : ""}
+							</span>
+							{plan === "pro" && (
+								<span className="text-sm text-muted-foreground">/ month</span>
+							)}
+						</div>
+						<p className="mt-1 text-sm text-muted-foreground">
+							{PRO_TIER.tagline}
+						</p>
+					</>
+				) : (
+					<p className="text-sm text-muted-foreground">
+						You&apos;re not on a paid plan — nothing is being billed yet.
+					</p>
+				)}
 
-				<ul className="mt-5 flex flex-1 flex-col gap-2.5">
-					{tier.features.map((f) => (
-						<li key={f} className="flex items-start gap-2 text-sm">
-							<Check className="mt-0.5 size-4 shrink-0 text-primary" />
-							<span>{f}</span>
-						</li>
-					))}
-				</ul>
-
-				<div className="mt-6">
-					{isFree ? (
-						<Button className="w-full" onClick={onUpgrade} disabled={pending}>
-							{pending ? "Redirecting…" : "Upgrade to Pro"}
-						</Button>
-					) : (
+				<div className="mt-auto pt-6">
+					{subscribed ? (
 						<Button
 							variant="outline"
 							className="w-full"
@@ -66,6 +65,10 @@ export function CurrentPlanCard({
 							disabled={pending}
 						>
 							{pending ? "Redirecting…" : "Manage billing"}
+						</Button>
+					) : (
+						<Button className="w-full" onClick={onUpgrade} disabled={pending}>
+							{pending ? "Redirecting…" : "Upgrade to Pro"}
 						</Button>
 					)}
 				</div>

--- a/apps/dashboard/src/app/settings/billing/_components/PricingTiers.tsx
+++ b/apps/dashboard/src/app/settings/billing/_components/PricingTiers.tsx
@@ -1,83 +1,16 @@
 import { Check } from "lucide-react";
 
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { cn } from "@/lib/utils";
 import type { Plan } from "@/lib/workspace-utils";
 
-import { PRICING_TIERS, type PricingTier } from "./billing-plans";
+import { PRO_TIER } from "./billing-plans";
 
-function TierCard({
-	tier,
-	currentPlan,
-	pending,
-	onUpgrade,
-}: {
-	tier: PricingTier;
-	currentPlan: Plan;
-	pending: boolean;
-	onUpgrade: () => void;
-}) {
-	const isCurrent = tier.plan === currentPlan;
-
-	function action() {
-		if (isCurrent) {
-			return (
-				<Button variant="outline" className="w-full" disabled>
-					Current plan
-				</Button>
-			);
-		}
-		if (tier.id === "pro") {
-			return (
-				<Button className="w-full" onClick={onUpgrade} disabled={pending}>
-					{pending ? "Redirecting…" : "Upgrade to Pro"}
-				</Button>
-			);
-		}
-		// Free tier while on a paid plan: no self-serve downgrade.
-		return (
-			<Button variant="outline" className="w-full" disabled>
-				Free plan
-			</Button>
-		);
-	}
-
-	return (
-		<div
-			className={cn(
-				"relative flex flex-col rounded-2xl border bg-card p-6",
-				tier.popular && "ring-1 ring-primary",
-			)}
-		>
-			{tier.popular && (
-				<Badge className="absolute right-4 top-4">Most popular</Badge>
-			)}
-			<h3 className="font-display text-lg font-semibold tracking-tight-display">
-				{tier.name}
-			</h3>
-			<div className="mt-2 flex items-baseline gap-1">
-				<span className="text-3xl font-semibold tracking-tight-display">
-					{tier.price}
-				</span>
-				<span className="text-sm text-muted-foreground">/ month</span>
-			</div>
-			<p className="mt-1 text-sm text-muted-foreground">{tier.tagline}</p>
-
-			<ul className="mt-5 flex flex-1 flex-col gap-2.5">
-				{tier.features.map((f) => (
-					<li key={f} className="flex items-start gap-2 text-sm">
-						<Check className="mt-0.5 size-4 shrink-0 text-primary" />
-						<span>{f}</span>
-					</li>
-				))}
-			</ul>
-
-			<div className="mt-6">{action()}</div>
-		</div>
-	);
-}
-
+/**
+ * The single hosted tier (Pro). With the free tier removed there's nothing to
+ * compare against, so this renders one full-width card — no tier grid and no
+ * "Most popular" badge (which would be meaningless with one option). Features
+ * are capabilities only; usage limits are intentionally not listed.
+ */
 export function PricingTiers({
 	currentPlan,
 	pending,
@@ -87,17 +20,50 @@ export function PricingTiers({
 	pending: boolean;
 	onUpgrade: () => void;
 }) {
+	const isCurrent = currentPlan === PRO_TIER.plan;
+
 	return (
-		<div className="grid gap-4 sm:grid-cols-2">
-			{PRICING_TIERS.map((tier) => (
-				<TierCard
-					key={tier.id}
-					tier={tier}
-					currentPlan={currentPlan}
-					pending={pending}
-					onUpgrade={onUpgrade}
-				/>
-			))}
-		</div>
+		<section className="rounded-2xl border bg-card p-6">
+			<div className="flex flex-wrap items-start justify-between gap-4">
+				<div>
+					<h3 className="font-display text-lg font-semibold tracking-tight-display">
+						{PRO_TIER.name}
+					</h3>
+					<div className="mt-2 flex items-baseline gap-1">
+						<span className="text-3xl font-semibold tracking-tight-display">
+							{PRO_TIER.price}
+						</span>
+						<span className="text-sm text-muted-foreground">/ month</span>
+					</div>
+					<p className="mt-1 text-sm text-muted-foreground">
+						{PRO_TIER.tagline}
+					</p>
+				</div>
+				<div className="w-full sm:w-auto">
+					{isCurrent ? (
+						<Button variant="outline" className="w-full sm:w-auto" disabled>
+							Current plan
+						</Button>
+					) : (
+						<Button
+							className="w-full sm:w-auto"
+							onClick={onUpgrade}
+							disabled={pending}
+						>
+							{pending ? "Redirecting…" : "Upgrade to Pro"}
+						</Button>
+					)}
+				</div>
+			</div>
+
+			<ul className="mt-5 grid gap-2.5 sm:grid-cols-2">
+				{PRO_TIER.features.map((f) => (
+					<li key={f} className="flex items-start gap-2 text-sm">
+						<Check className="mt-0.5 size-4 shrink-0 text-primary" />
+						<span>{f}</span>
+					</li>
+				))}
+			</ul>
+		</section>
 	);
 }

--- a/apps/dashboard/src/app/settings/billing/_components/billing-plans.ts
+++ b/apps/dashboard/src/app/settings/billing/_components/billing-plans.ts
@@ -1,51 +1,41 @@
 import type { Plan } from "@/lib/workspace-utils";
 
 /**
- * Pricing tiers shown on the billing page. These are static product copy (not
- * fetched from Stripe), so the displayed price must be kept in sync with the
- * Stripe price behind STRIPE_PRO_PRICE_ID. Only Pro maps to a live checkout;
- * Free is the default plan.
+ * The hosted plan shown on the billing page. Static product copy (not fetched
+ * from Stripe), so the displayed price must stay in sync with the Stripe price
+ * behind STRIPE_PRO_PRICE_ID.
  *
- * `plan` ties a tier to the internal workspace plan enum so we can mark the
+ * Interim state: the free tier has been removed (hosted is moving to usage-based
+ * per-message pricing — see the billing notice). Pro remains the one live,
+ * self-serve checkout. We list only capabilities, never invented usage limits.
+ *
+ * `plan` ties the tier to the internal workspace plan enum so we can mark the
  * caller's current tier.
  */
 export interface PricingTier {
-	id: "free" | "pro";
+	id: "pro";
 	plan: Plan;
 	name: string;
 	price: string;
 	tagline: string;
 	features: string[];
-	popular?: boolean;
 }
 
 export const PRICING_TIERS: PricingTier[] = [
-	{
-		id: "free",
-		plan: "free",
-		name: "Free",
-		price: "$0",
-		tagline: "For starters",
-		features: [
-			"1 project",
-			"1,000 messages / month",
-			"Basic AI models",
-			"Community support",
-		],
-	},
 	{
 		id: "pro",
 		plan: "pro",
 		name: "Pro",
 		price: "$29",
 		tagline: "For growing teams",
-		popular: true,
 		features: [
 			"Unlimited projects",
-			"10,000 messages / month",
 			"All AI models",
 			"Priority support",
 			"Custom branding",
 		],
 	},
 ];
+
+/** The single live tier. Convenience accessor so cards don't re-find it. */
+export const PRO_TIER = PRICING_TIERS[0];

--- a/apps/dashboard/src/app/settings/billing/page.test.tsx
+++ b/apps/dashboard/src/app/settings/billing/page.test.tsx
@@ -72,15 +72,34 @@ describe("BillingPage", () => {
 		expect(screen.queryByText("Current plan")).not.toBeInTheDocument();
 	});
 
-	it("free plan → upgrade starts checkout for the workspace", async () => {
+	it("no subscription → upgrade starts checkout for the workspace", async () => {
 		setWorkspace("free");
 		vi.mocked(startCheckout).mockResolvedValue("https://checkout.stripe.com/x");
 		renderPage();
 
-		expect(screen.getAllByText("Free").length).toBeGreaterThan(0);
+		// A non-paying workspace is shown as "No subscription", never a Free plan.
+		expect(screen.getByText("No subscription")).toBeInTheDocument();
 		await clickUpgrade(userEvent.setup());
 		expect(startCheckout).toHaveBeenCalledWith("ws_1");
 		expect(openPortal).not.toHaveBeenCalled();
+	});
+
+	// Data honesty: the free tier is gone and we never render invented prices or
+	// usage limits while usage-based pricing is still TBD.
+	it("never shows a Free tier, a $0 price, or fabricated message limits", () => {
+		setWorkspace("free");
+		renderPage();
+
+		expect(screen.queryByText(/free/i)).not.toBeInTheDocument();
+		expect(screen.queryByText(/\$0/)).not.toBeInTheDocument();
+		expect(
+			screen.queryByText(/messages?\s*\/\s*month/i),
+		).not.toBeInTheDocument();
+		expect(screen.queryByText(/1,000|10,000/)).not.toBeInTheDocument();
+		// The honest forward-looking notice is present instead.
+		expect(
+			screen.getByText(/usage-based pricing is on the way/i),
+		).toBeInTheDocument();
 	});
 
 	it("pro plan → manage opens the billing portal", async () => {

--- a/apps/dashboard/src/app/settings/billing/page.tsx
+++ b/apps/dashboard/src/app/settings/billing/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Info } from "lucide-react";
 import { useSearchParams } from "next/navigation";
 import { Suspense, useEffect, useState } from "react";
 
@@ -129,6 +130,18 @@ function BillingContent() {
 				pending={pending}
 				onUpgrade={() => checkout.mutate()}
 			/>
+
+			<div className="flex items-start gap-2.5 rounded-lg border bg-muted/40 p-4 text-sm text-muted-foreground">
+				<Info className="mt-0.5 size-4 shrink-0" />
+				<p>
+					<span className="font-medium text-foreground">
+						Usage-based pricing is on the way.
+					</span>{" "}
+					We&apos;re moving to simple per-message pricing — you&apos;ll pay only
+					for the answers your agent sends. Details are coming soon; nothing
+					changes until then.
+				</p>
+			</div>
 		</div>
 	);
 }

--- a/apps/dashboard/src/components/app-sidebar.tsx
+++ b/apps/dashboard/src/components/app-sidebar.tsx
@@ -298,7 +298,7 @@ export function AppSidebar({ userEmail }: { userEmail: string }) {
 						</p>
 						<Button asChild variant="outline" size="sm" className="mt-3 w-full">
 							<a
-								href="https://docs.meetploy.com"
+								href="https://clankersupport.com/docs"
 								target="_blank"
 								rel="noreferrer"
 							>


### PR DESCRIPTION
Three fixes from the review pass. **Do not merge** — for review.

## 1. Billing screen — remove the free-tier model (honest interim)
We're removing the free tier; hosted is moving to **usage-based per-message** pricing, but the price/trial is TBD — so this just makes the current screen honest, it does **not** build the new pricing. Layout was approved before building (Option B: keep Pro, drop Free + limits).
- Removed the **Free** tier card and all free-plan framing — a non-paying workspace now reads **"No subscription"**, never "$0 / Free plan".
- Removed all **invented usage limits** ("1,000 / 10,000 messages / month"); the Pro card lists capabilities only.
- Kept **Pro** as the one live Stripe checkout; `CurrentPlanCard` is lean (status + price + action), `PricingTiers` is a single full-width card (dropped the meaningless "Most popular" badge).
- Added an honest forward-looking notice: *"Usage-based pricing is on the way — you'll pay only for the answers your agent sends. Details coming soon; nothing changes until then."* No fabricated numbers. Kept the existing "coming soon / per-message tracking" UsageCard notice.
- Tests updated + a **data-honesty guard** (asserts no Free tier, no $0, no message caps render).

## 2. "View docs" link → clankersupport.com/docs
Was pointing at Ploy's docs (`docs.meetploy.com`). Swept for other stray Ploy/llmchat user-facing links — none (the `.llmchat-*` classes / `llmchat_client_id` are intentional internal identifiers).

## 3. showcase.clankersupport.com — DNS, not code (no code change in this PR)
Diagnosed: `app`/`api`/apex resolve via `CNAME → meetploy.app. → 34.60.9.252`; **`showcase.clankersupport.com` returns NXDOMAIN — no record exists.** The showcase app + its `ploy.yaml` are correct (domains are Ploy-dashboard-managed, not in code), so there's nothing to fix in code.

**Action needed (DNS — you have access, I don't):** add
```
showcase.clankersupport.com.   CNAME   meetploy.app.
```
(matches the existing `app`/`api` records; or an A record to `34.60.9.252`), then map the domain to the showcase project in the Ploy dashboard.

## Checks
Full suite green (dashboard 189, incl. the new honesty guard), typecheck + lint/prettier + secret-scan clean. Conventional commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)