### PR TITLE
fix: chat auto-scroll — stick to bottom only when pinned, in widget + inbox

### DIFF
--- a/apps/dashboard/src/app/inbox/_components/MessageThread.test.tsx
+++ b/apps/dashboard/src/app/inbox/_components/MessageThread.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
 import { MessageThread } from "./MessageThread";
@@ -97,5 +97,135 @@ describe("MessageThread", () => {
 		expect(screen.queryByText("Helpful")).not.toBeInTheDocument();
 		expect(screen.queryByText("Not helpful")).not.toBeInTheDocument();
 		expect(screen.queryByText("Not rated")).not.toBeInTheDocument();
+	});
+});
+
+/**
+ * jsdom has no layout, so install a controllable scroll model: fixed
+ * scrollHeight/clientHeight and a backing scrollTop the stick-to-bottom hook
+ * reads and writes. setTop() also fires a scroll event so the hook updates its
+ * near-bottom tracking, like a real scroll.
+ */
+function mockScroll(
+	el: HTMLElement,
+	{
+		scrollHeight,
+		clientHeight,
+	}: { scrollHeight: number; clientHeight: number },
+) {
+	let top = 0;
+	Object.defineProperty(el, "scrollHeight", {
+		configurable: true,
+		get: () => scrollHeight,
+	});
+	Object.defineProperty(el, "clientHeight", {
+		configurable: true,
+		get: () => clientHeight,
+	});
+	Object.defineProperty(el, "scrollTop", {
+		configurable: true,
+		get: () => top,
+		set: (v: number) => {
+			top = v;
+		},
+	});
+	return {
+		setTop(v: number) {
+			top = v;
+			act(() => el.dispatchEvent(new Event("scroll")));
+		},
+		get top() {
+			return top;
+		},
+	};
+}
+
+function renderThread(messages: Message[]) {
+	const utils = render(<MessageThread messages={messages} />);
+	const el = utils.container.firstElementChild as HTMLElement;
+	return { ...utils, el };
+}
+
+describe("MessageThread auto-scroll (useStickToBottom)", () => {
+	it("follows a new message when the agent is near the bottom", () => {
+		const base = [
+			msg({ content: "hi", sequence: 1 }),
+			msg({ role: "assistant", content: "hello", sequence: 2 }),
+		];
+		const { el, rerender } = renderThread(base);
+		const s = mockScroll(el, { scrollHeight: 1000, clientHeight: 400 });
+		s.setTop(620); // near bottom
+
+		rerender(
+			<MessageThread
+				messages={[...base, msg({ content: "another", sequence: 3 })]}
+			/>,
+		);
+		expect(s.top).toBe(1000);
+	});
+
+	it("does NOT yank the agent down when they've scrolled up", () => {
+		const base = [
+			msg({ content: "hi", sequence: 1 }),
+			msg({ role: "assistant", content: "hello", sequence: 2 }),
+		];
+		const { el, rerender } = renderThread(base);
+		const s = mockScroll(el, { scrollHeight: 1000, clientHeight: 400 });
+		s.setTop(0); // scrolled up reading history
+
+		// A new inbound visitor message arrives via refetch.
+		rerender(
+			<MessageThread
+				messages={[...base, msg({ content: "ping", sequence: 3 })]}
+			/>,
+		);
+		expect(s.top).toBe(0);
+	});
+
+	it("does not jump to the bottom when opening a conversation with history", () => {
+		const history = Array.from({ length: 10 }, (_, i) =>
+			msg({
+				role: i % 2 ? "assistant" : "user",
+				content: `line ${i}`,
+				sequence: i + 1,
+			}),
+		);
+		const { el } = renderThread(history);
+		const s = mockScroll(el, { scrollHeight: 1000, clientHeight: 400 });
+		expect(s.top).toBe(0);
+	});
+
+	it("follows the agent's own reply (admin) even if scrolled up", () => {
+		const base = [
+			msg({ content: "hi", sequence: 1 }),
+			msg({ role: "assistant", content: "hello", sequence: 2 }),
+		];
+		const { el, rerender } = renderThread(base);
+		const s = mockScroll(el, { scrollHeight: 1000, clientHeight: 400 });
+		s.setTop(0); // scrolled up
+
+		// Agent sends a reply (role "admin") — user-initiated, should follow.
+		rerender(
+			<MessageThread
+				messages={[
+					...base,
+					msg({ role: "admin", content: "on it!", sequence: 3 }),
+				]}
+			/>,
+		);
+		expect(s.top).toBe(1000);
+	});
+
+	it("shows the scroll-to-latest button when scrolled up", () => {
+		const base = [
+			msg({ content: "hi", sequence: 1 }),
+			msg({ role: "assistant", content: "hello", sequence: 2 }),
+		];
+		const { el, container } = renderThread(base);
+		const s = mockScroll(el, { scrollHeight: 1000, clientHeight: 400 });
+		s.setTop(0);
+		expect(
+			container.querySelector('[aria-label="Scroll to latest message"]'),
+		).toBeInTheDocument();
 	});
 });

--- a/apps/dashboard/src/app/inbox/_components/MessageThread.tsx
+++ b/apps/dashboard/src/app/inbox/_components/MessageThread.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { Headset, ThumbsDown, ThumbsUp } from "lucide-react";
-import { useEffect, useRef } from "react";
+import { useStickToBottom } from "@llmchat/widget/chat";
+import { ArrowDown, Headset, ThumbsDown, ThumbsUp } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 
@@ -81,15 +81,21 @@ function MessageBubble({ message }: { message: Message }) {
 }
 
 export function MessageThread({ messages }: { messages: Message[] }) {
-	const endRef = useRef<HTMLDivElement>(null);
-
-	useEffect(() => {
-		// Guarded: jsdom (tests) doesn't implement scrollIntoView.
-		endRef.current?.scrollIntoView?.({ block: "end" });
-	}, [messages.length]);
+	const { containerRef, atBottom, scrollToBottom } =
+		useStickToBottom<HTMLDivElement>({
+			// New messages (inbound or replies) — the inbox doesn't token-stream,
+			// so message count is the growth signal.
+			contentKey: messages.length,
+			// The agent's own sends are role "admin"; following those is expected.
+			// Inbound visitor/bot messages instead obey the near-bottom rule.
+			sendKey: messages.reduce((id, m) => (m.role === "admin" ? m.id : id), ""),
+		});
 
 	return (
-		<div className="flex flex-1 flex-col gap-4 overflow-y-auto px-6 py-4">
+		<div
+			ref={containerRef}
+			className="relative flex flex-1 flex-col gap-4 overflow-y-auto px-6 py-4"
+		>
 			{messages.map((m) =>
 				m.role === "system" ? (
 					<div
@@ -111,7 +117,16 @@ export function MessageThread({ messages }: { messages: Message[] }) {
 					No messages in this conversation
 				</div>
 			)}
-			<div ref={endRef} />
+			{!atBottom && messages.length > 0 && (
+				<button
+					type="button"
+					onClick={scrollToBottom}
+					aria-label="Scroll to latest message"
+					className="sticky bottom-2 ml-auto flex size-8 items-center justify-center rounded-full bg-primary text-primary-foreground shadow-md transition-transform hover:-translate-y-0.5"
+				>
+					<ArrowDown className="size-4" />
+				</button>
+			)}
 		</div>
 	);
 }

--- a/packages/widget/src/chat.ts
+++ b/packages/widget/src/chat.ts
@@ -4,3 +4,8 @@
 export { Composer } from "./components/Composer";
 export { MessageList, type DisplayMessage } from "./components/MessageList";
 export { WidgetFrame } from "./components/WidgetFrame";
+export {
+	useStickToBottom,
+	type StickToBottom,
+	type StickToBottomOptions,
+} from "./hooks/useStickToBottom";

--- a/packages/widget/src/components/MessageList.test.tsx
+++ b/packages/widget/src/components/MessageList.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
@@ -73,5 +73,166 @@ describe("MessageList rating", () => {
 			/>,
 		);
 		expect(screen.queryByLabelText("Helpful")).not.toBeInTheDocument();
+	});
+});
+
+/**
+ * jsdom has no layout, so we install a controllable scroll model on the
+ * container: fixed scrollHeight/clientHeight and a backing scrollTop the hook
+ * reads and writes. setTop() also fires a scroll event so the hook updates its
+ * near-bottom tracking, exactly as a real scroll would.
+ */
+function mockScroll(
+	el: HTMLElement,
+	{
+		scrollHeight,
+		clientHeight,
+	}: { scrollHeight: number; clientHeight: number },
+) {
+	let top = 0;
+	Object.defineProperty(el, "scrollHeight", {
+		configurable: true,
+		get: () => scrollHeight,
+	});
+	Object.defineProperty(el, "clientHeight", {
+		configurable: true,
+		get: () => clientHeight,
+	});
+	Object.defineProperty(el, "scrollTop", {
+		configurable: true,
+		get: () => top,
+		set: (v: number) => {
+			top = v;
+		},
+	});
+	return {
+		setTop(v: number) {
+			top = v;
+			act(() => el.dispatchEvent(new Event("scroll")));
+		},
+		get top() {
+			return top;
+		},
+	};
+}
+
+const msg = (id: string, role: string, content: string): DisplayMessage => ({
+	id,
+	role,
+	content,
+});
+
+function renderList(messages: DisplayMessage[], typing = false) {
+	const utils = render(
+		<MessageList
+			greeting="hi"
+			messages={messages}
+			typing={typing}
+			error={null}
+		/>,
+	);
+	const el = utils.container.querySelector(".llmchat-messages") as HTMLElement;
+	return { ...utils, el };
+}
+
+describe("MessageList auto-scroll (useStickToBottom)", () => {
+	it("stays pinned to the bottom as a reply streams when near the bottom", () => {
+		const user = msg("u1", "user", "hello there");
+		const { el, rerender } = renderList([user], true);
+		const s = mockScroll(el, { scrollHeight: 1000, clientHeight: 400 });
+		s.setTop(620); // 1000 - 620 - 400 = -20 ≤ 100 → near bottom
+
+		rerender(
+			<MessageList
+				greeting="hi"
+				messages={[user, msg("a1", "assistant", "streaming answer so far…")]}
+				typing
+				error={null}
+			/>,
+		);
+		expect(s.top).toBe(1000); // followed to the bottom
+	});
+
+	it("does NOT scroll when the user has scrolled up to read earlier messages", () => {
+		const user = msg("u1", "user", "hello there");
+		const { el, rerender } = renderList([user], true);
+		const s = mockScroll(el, { scrollHeight: 1000, clientHeight: 400 });
+		s.setTop(0); // 1000 - 0 - 400 = 600 > 100 → scrolled up
+
+		rerender(
+			<MessageList
+				greeting="hi"
+				messages={[user, msg("a1", "assistant", "a long streaming answer…")]}
+				typing
+				error={null}
+			/>,
+		);
+		expect(s.top).toBe(0); // left alone — no yank
+	});
+
+	it("does not jump to the bottom when mounting with existing history", () => {
+		const history = Array.from({ length: 8 }, (_, i) =>
+			msg(`m${i}`, i % 2 ? "assistant" : "user", `message ${i}`),
+		);
+		const { el } = renderList(history, false);
+		const s = mockScroll(el, { scrollHeight: 1000, clientHeight: 400 });
+		expect(s.top).toBe(0);
+	});
+
+	it("follows the visitor's own sent message even if they were scrolled up", () => {
+		const a1 = msg("a1", "assistant", "previous answer");
+		const { el, rerender } = renderList([a1], false);
+		const s = mockScroll(el, { scrollHeight: 1000, clientHeight: 400 });
+		s.setTop(0); // scrolled up
+
+		rerender(
+			<MessageList
+				greeting="hi"
+				messages={[a1, msg("u2", "user", "a new question")]}
+				typing={false}
+				error={null}
+			/>,
+		);
+		expect(s.top).toBe(1000); // user-initiated → always follows
+	});
+
+	it("does not scroll on a rating-only re-render", () => {
+		const a1: DisplayMessage = {
+			id: "a1",
+			role: "assistant",
+			content: "answer",
+			rateable: true,
+		};
+		const { el, rerender } = renderList([a1], false);
+		const s = mockScroll(el, { scrollHeight: 1000, clientHeight: 400 });
+		s.setTop(0); // scrolled up
+
+		rerender(
+			<MessageList
+				greeting="hi"
+				messages={[{ ...a1, rating: "up" }]}
+				typing={false}
+				error={null}
+				onRate={() => {}}
+			/>,
+		);
+		expect(s.top).toBe(0); // rating change leaves the thread put
+	});
+
+	it("shows the scroll-to-latest button while streaming and scrolled up", () => {
+		const user = msg("u1", "user", "hello");
+		const { el, rerender, container } = renderList([user], true);
+		const s = mockScroll(el, { scrollHeight: 1000, clientHeight: 400 });
+		s.setTop(0);
+
+		rerender(
+			<MessageList
+				greeting="hi"
+				messages={[user, msg("a1", "assistant", "answering…")]}
+				typing
+				error={null}
+			/>,
+		);
+		expect(container.querySelector(".llmchat-jump")).toBeInTheDocument();
 	});
 });

--- a/packages/widget/src/components/MessageList.tsx
+++ b/packages/widget/src/components/MessageList.tsx
@@ -1,7 +1,27 @@
-import { useEffect, useRef } from "react";
-
+import { useStickToBottom } from "../hooks/useStickToBottom";
 import type { Rating } from "../rating";
 import { ThumbDownIcon, ThumbUpIcon } from "./icons";
+
+/** Down-arrow for the "scroll to latest" affordance. */
+function ArrowDownIcon() {
+	return (
+		<svg
+			width="14"
+			height="14"
+			viewBox="0 0 24 24"
+			fill="none"
+			aria-hidden="true"
+		>
+			<path
+				d="M12 5v14M5 12l7 7 7-7"
+				stroke="currentColor"
+				strokeWidth="2"
+				strokeLinecap="round"
+				strokeLinejoin="round"
+			/>
+		</svg>
+	);
+}
 
 export interface DisplayMessage {
 	id: string;
@@ -59,14 +79,18 @@ export function MessageList({
 	 * conversation exists). */
 	onRate?: (messageId: string, current: Rating, intent: "up" | "down") => void;
 }) {
-	const endRef = useRef<HTMLDivElement>(null);
-
-	useEffect(() => {
-		endRef.current?.scrollIntoView({ behavior: "smooth" });
-	}, [messages]);
+	const last = messages[messages.length - 1];
+	const { containerRef, atBottom, scrollToBottom } =
+		useStickToBottom<HTMLDivElement>({
+			// Grows as tokens stream / a message is added — but NOT on a rating
+			// toggle (same length & content), so rating doesn't trigger a scroll.
+			contentKey: `${messages.length}:${last?.content.length ?? 0}`,
+			// The visitor's own sends (role "user") always follow to the bottom.
+			sendKey: messages.reduce((id, m) => (m.role === "user" ? m.id : id), ""),
+		});
 
 	return (
-		<div className="llmchat-messages">
+		<div className="llmchat-messages" ref={containerRef}>
 			{messages.length === 0 && (
 				<div className="llmchat-msg llmchat-msg-assistant">{greeting}</div>
 			)}
@@ -110,7 +134,16 @@ export function MessageList({
 					{error}
 				</div>
 			)}
-			<div ref={endRef} />
+			{typing && !atBottom && (
+				<button
+					type="button"
+					className="llmchat-jump"
+					onClick={scrollToBottom}
+					aria-label="Scroll to latest message"
+				>
+					<ArrowDownIcon />
+				</button>
+			)}
 		</div>
 	);
 }

--- a/packages/widget/src/hooks/useStickToBottom.ts
+++ b/packages/widget/src/hooks/useStickToBottom.ts
@@ -1,0 +1,102 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export interface StickToBottomOptions {
+	/**
+	 * A value that changes whenever the rendered content GROWS — a streamed
+	 * token arriving or a new message. While the user is pinned near the bottom,
+	 * each change re-pins them; if they've scrolled up, it leaves them alone.
+	 * Derive it so unrelated re-renders (e.g. a rating toggle) DON'T change it.
+	 */
+	contentKey: unknown;
+	/**
+	 * A value that changes only when THIS user sends a message (visitor in the
+	 * widget, agent in the inbox). A change here always scrolls to the bottom —
+	 * sending is user-initiated, so following it is expected even if they'd
+	 * scrolled up. Omit on read-only surfaces.
+	 */
+	sendKey?: unknown;
+	/** How close to the bottom (px) still counts as "pinned". */
+	threshold?: number;
+}
+
+export interface StickToBottom<T extends HTMLElement> {
+	/** Attach to the scroll container (the element with `overflow-y: auto`). */
+	containerRef: React.RefObject<T | null>;
+	/** Whether the container is currently scrolled near its bottom. */
+	atBottom: boolean;
+	/** Imperatively jump to the bottom (e.g. a "scroll to latest" button). */
+	scrollToBottom: () => void;
+}
+
+/**
+ * Keep a scroll container pinned to the bottom as content arrives — but only
+ * when the user already is at the bottom, so it never fights someone reading
+ * earlier messages. Shared by the visitor widget and the dashboard inbox so the
+ * behavior is defined once.
+ *
+ * Rules:
+ * - Mounting (incl. loading prior history) never scrolls — no yank on open.
+ * - `contentKey` growth re-pins only if the user is near the bottom.
+ * - `sendKey` change always scrolls (the user just sent something).
+ */
+export function useStickToBottom<T extends HTMLElement = HTMLDivElement>({
+	contentKey,
+	sendKey,
+	threshold = 100,
+}: StickToBottomOptions): StickToBottom<T> {
+	const containerRef = useRef<T>(null);
+	// `pinned` lives in a ref so the content effect reads the latest value
+	// without re-subscribing; `atBottom` mirrors it for rendering affordances.
+	const pinned = useRef(true);
+	const [atBottom, setAtBottom] = useState(true);
+
+	const isNearBottom = useCallback(
+		(el: T) => el.scrollHeight - el.scrollTop - el.clientHeight <= threshold,
+		[threshold],
+	);
+
+	const scrollToBottom = useCallback(() => {
+		const el = containerRef.current;
+		if (!el) return;
+		el.scrollTop = el.scrollHeight;
+		pinned.current = true;
+		setAtBottom(true);
+	}, []);
+
+	// Track the user's scroll position. Runs once; reads live metrics on scroll.
+	useEffect(() => {
+		const el = containerRef.current;
+		if (!el) return;
+		const onScroll = () => {
+			const near = isNearBottom(el);
+			pinned.current = near;
+			setAtBottom(near);
+		};
+		onScroll();
+		el.addEventListener("scroll", onScroll, { passive: true });
+		return () => el.removeEventListener("scroll", onScroll);
+	}, [isNearBottom]);
+
+	// Content grew: follow it only if the user is pinned. Skip the first run so
+	// mounting with existing history doesn't jump.
+	const contentReady = useRef(false);
+	useEffect(() => {
+		if (!contentReady.current) {
+			contentReady.current = true;
+			return;
+		}
+		if (pinned.current) scrollToBottom();
+	}, [contentKey, scrollToBottom]);
+
+	// The user sent a message: always follow it. Skip the first run (mount).
+	const sendReady = useRef(false);
+	useEffect(() => {
+		if (!sendReady.current) {
+			sendReady.current = true;
+			return;
+		}
+		scrollToBottom();
+	}, [sendKey, scrollToBottom]);
+
+	return { containerRef, atBottom, scrollToBottom };
+}

--- a/packages/widget/src/styles.ts
+++ b/packages/widget/src/styles.ts
@@ -303,6 +303,29 @@ export const widgetStyles = `
 	border-radius: 9999px;
 	border: 2px solid #fff;
 }
+/* "Scroll to latest": sticky so it floats at the bottom of the scroll area
+   while the visitor reads earlier messages during a streaming reply. */
+.llmchat-jump {
+	position: sticky;
+	bottom: 0.25rem;
+	align-self: center;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 2rem;
+	height: 2rem;
+	margin-top: 0.25rem;
+	border: none;
+	border-radius: 9999px;
+	background: var(--brand);
+	color: #fff;
+	cursor: pointer;
+	box-shadow: 0 2px 8px rgba(0, 0, 0, 0.18);
+	transition: transform 0.12s ease;
+}
+.llmchat-jump:hover {
+	transform: translateY(-1px);
+}
 .llmchat-msg {
 	max-width: 85%;
 	padding: 0.5rem 0.75rem;


### PR DESCRIPTION
Fixes the message thread auto-scrolling on every render, which fought users who scrolled up to read earlier messages. **Do not merge** — for review.

## Behavior now
- Tracks whether the user is **near the bottom** (≤100px).
- Follows new content **only while pinned near the bottom** (streaming tokens in the widget; new messages in the inbox). If they've scrolled up, it leaves them alone.
- **Never** scrolls on mount / loading prior history — a returning visitor or an agent opening a conversation isn't yanked down.
- **Always** follows the user's own send (visitor in the widget, agent in the inbox) — that's user-initiated.
- Ignores unrelated re-renders (e.g. a rating toggle doesn't move the thread).
- Optional **"scroll to latest"** sticky button when scrolled up (widget: while streaming; inbox: whenever scrolled up).

## One shared hook (reuse, not duplicated)
Both surfaces share the behavior, so it's one composable hook — `useStickToBottom` in `packages/widget/src/hooks/useStickToBottom.ts`, exported via `@llmchat/widget/chat` (which the dashboard already consumes). The surfaces only differ in two inputs they pass:
- **Widget** (`MessageList`): token-streams → `contentKey` = `len:lastContentLength` (ignores rating-only changes); `sendKey` = last **user** message id.
- **Inbox** (`MessageThread`): no token streaming → `contentKey` = message count; `sendKey` = last **admin** message id (agent replies follow; inbound visitor/bot messages obey the near-bottom rule).

Both replace the old `scrollIntoView`-on-update effect + bottom sentinel. Scroll is instant (not smooth) so it doesn't jank during streaming.

## Tests (both surfaces)
near-bottom-stays-pinned, scrolled-up-is-left-alone, history-load-doesn't-jump, own-send-follows, rating-only-doesn't-scroll (widget), jump-button. Full suite green: widget 72, dashboard 194, api 98, shared 14. Lint/format + secret-scan clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)