### PR TITLE
feat(marketing): SEO foundations — robots, sitemap, canonical, OG, JSON-LD

### DIFF
--- a/apps/marketing/package.json
+++ b/apps/marketing/package.json
@@ -8,7 +8,8 @@
 		"dev": "next dev -p 3000",
 		"format": "prettier --write .",
 		"lint": "prettier --check .",
-		"start": "next start -p 3000"
+		"start": "next start -p 3000",
+		"test": "vitest run"
 	},
 	"dependencies": {
 		"@content-collections/core": "^0.15.1",
@@ -31,6 +32,7 @@
 		"autoprefixer": "^10.4.20",
 		"postcss": "^8.5.0",
 		"tailwindcss": "^3.4.17",
-		"typescript": "5.9.2"
+		"typescript": "5.9.2",
+		"vitest": "^3.0.0"
 	}
 }

--- a/apps/marketing/src/app/blog/[slug]/page.tsx
+++ b/apps/marketing/src/app/blog/[slug]/page.tsx
@@ -6,6 +6,9 @@ import { SiteHeader } from "@/components/SiteHeader";
 import { SiteFooter } from "@/components/SiteFooter";
 import { TrackView } from "@/components/TrackView";
 import { formatDate } from "@/lib/format";
+import { pageMeta } from "@/lib/seo";
+import { JsonLd } from "@/components/JsonLd";
+import { CANONICAL_SITE_URL } from "@/lib/site-urls";
 
 export function generateStaticParams() {
 	return allPosts.map((p) => ({ slug: p.slug }));
@@ -19,10 +22,13 @@ export async function generateMetadata({
 	const { slug } = await params;
 	const post = allPosts.find((p) => p.slug === slug);
 	if (!post) return {};
-	return {
+	return pageMeta({
 		title: `${post.title} — Clanker Support Journal`,
 		description: post.description,
-	};
+		path: `/blog/${slug}`,
+		type: "article",
+		publishedTime: post.date,
+	});
 }
 
 export default async function PostPage({
@@ -39,8 +45,34 @@ export default async function PostPage({
 		.toSorted((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
 		.slice(0, 2);
 
+	const url = `${CANONICAL_SITE_URL}/blog/${post.slug}`;
+	const articleLd = {
+		"@context": "https://schema.org",
+		"@type": "BlogPosting",
+		headline: post.title,
+		description: post.description,
+		datePublished: post.date,
+		dateModified: post.date,
+		url,
+		mainEntityOfPage: url,
+		author: {
+			"@type": "Organization",
+			name: "Clanker Support",
+			url: CANONICAL_SITE_URL,
+		},
+		publisher: {
+			"@type": "Organization",
+			name: "Clanker Support",
+			logo: {
+				"@type": "ImageObject",
+				url: `${CANONICAL_SITE_URL}/logo.svg`,
+			},
+		},
+	};
+
 	return (
 		<>
+			<JsonLd data={articleLd} />
 			<TrackView
 				event={ANALYTICS_EVENTS.blogPostRead}
 				props={{ slug: post.slug, category: post.category }}

--- a/apps/marketing/src/app/blog/page.tsx
+++ b/apps/marketing/src/app/blog/page.tsx
@@ -3,12 +3,14 @@ import { allPosts } from "content-collections";
 import { SiteHeader } from "@/components/SiteHeader";
 import { SiteFooter } from "@/components/SiteFooter";
 import { categories, formatDateShort, type CategoryFilter } from "@/lib/format";
+import { pageMeta } from "@/lib/seo";
 
-export const metadata = {
+export const metadata = pageMeta({
 	title: "Journal — Clanker Support",
 	description:
 		"Field notes on AI support: announcements, guides, and engineering from the Clanker Support team.",
-};
+	path: "/blog",
+});
 
 export default async function BlogPage({
 	searchParams,

--- a/apps/marketing/src/app/compare/page.tsx
+++ b/apps/marketing/src/app/compare/page.tsx
@@ -6,15 +6,17 @@ import { SiteHeader } from "@/components/SiteHeader";
 import { SiteFooter } from "@/components/SiteFooter";
 import { ComparisonCell } from "@/components/ComparisonCell";
 import { TrackedLink } from "@/components/TrackedLink";
+import { pageMeta } from "@/lib/seo";
 
 const dashboardUrl =
 	process.env.NEXT_PUBLIC_DASHBOARD_URL ?? "http://localhost:3001";
 
-export const metadata = {
+export const metadata = pageMeta({
 	title: "AI support, compared — Clanker Support vs. the alternatives",
 	description:
 		"How Clanker Support compares to Chatbase, Fin, Intercom, Chatwoot, and Crisp across setup, AI, escalation, channels, and pricing.",
-};
+	path: "/compare",
+});
 
 const { colOrder, colLabels, featureGroups } = matrix;
 

--- a/apps/marketing/src/app/docs/migrate/[slug]/page.tsx
+++ b/apps/marketing/src/app/docs/migrate/[slug]/page.tsx
@@ -6,6 +6,7 @@ import { SiteHeader } from "@/components/SiteHeader";
 import { SiteFooter } from "@/components/SiteFooter";
 import { CodeBlock } from "@/components/CodeBlock";
 import { TrackView } from "@/components/TrackView";
+import { pageMeta } from "@/lib/seo";
 
 const dashboardUrl =
 	process.env.NEXT_PUBLIC_DASHBOARD_URL ?? "http://localhost:3001";
@@ -22,10 +23,11 @@ export async function generateMetadata({
 	const { slug } = await params;
 	const guide = allMigrations.find((m) => m.slug === slug);
 	if (!guide) return {};
-	return {
+	return pageMeta({
 		title: `Migrate from ${guide.name} to Clanker Support`,
 		description: guide.intro,
-	};
+		path: `/docs/migrate/${slug}`,
+	});
 }
 
 export default async function MigratePage({

--- a/apps/marketing/src/app/docs/page.tsx
+++ b/apps/marketing/src/app/docs/page.tsx
@@ -3,15 +3,17 @@ import { allMigrations, matrix } from "content-collections";
 import { SiteHeader } from "@/components/SiteHeader";
 import { SiteFooter } from "@/components/SiteFooter";
 import { CodeBlock } from "@/components/CodeBlock";
+import { pageMeta } from "@/lib/seo";
 
 const dashboardUrl =
 	process.env.NEXT_PUBLIC_DASHBOARD_URL ?? "http://localhost:3001";
 
-export const metadata = {
+export const metadata = pageMeta({
 	title: "Docs — Clanker Support",
 	description:
 		"Get started with Clanker Support: drop in the widget, train it on your docs, configure escalation, and migrate from your current support tool.",
-};
+	path: "/docs",
+});
 
 const startCards = [
 	{

--- a/apps/marketing/src/app/layout.tsx
+++ b/apps/marketing/src/app/layout.tsx
@@ -8,6 +8,7 @@ import {
 } from "next/font/google";
 import { PostHogProvider } from "@/components/PostHogProvider";
 import { ThemeProvider } from "@/components/ThemeProvider";
+import { CANONICAL_SITE_URL } from "@/lib/site-urls";
 
 // Distinctive modern grotesque for display headlines.
 const display = Bricolage_Grotesque({
@@ -33,10 +34,41 @@ const mono = JetBrains_Mono({
 	display: "swap",
 });
 
+const TITLE = "Clanker Support — AI support, dropped in";
+const DESCRIPTION =
+	"One script tag. Any model. An AI-powered support agent that answers from your docs and escalates to your team. Built on LLM Gateway.";
+
 export const metadata: Metadata = {
-	title: "Clanker Support — AI support, dropped in",
-	description:
-		"One script tag. Any model. AI support that answers from your docs and escalates to your team. Built on LLM Gateway.",
+	// Resolves relative canonical/OG URLs (set per page via pageMeta) to absolute.
+	metadataBase: new URL(CANONICAL_SITE_URL),
+	title: TITLE,
+	description: DESCRIPTION,
+	applicationName: "Clanker Support",
+	alternates: { canonical: "/" },
+	openGraph: {
+		type: "website",
+		url: "/",
+		siteName: "Clanker Support",
+		title: TITLE,
+		description: DESCRIPTION,
+		locale: "en_US",
+	},
+	twitter: {
+		card: "summary_large_image",
+		title: TITLE,
+		description: DESCRIPTION,
+	},
+	robots: {
+		index: true,
+		follow: true,
+		googleBot: {
+			index: true,
+			follow: true,
+			"max-image-preview": "large",
+			"max-snippet": -1,
+			"max-video-preview": -1,
+		},
+	},
 };
 
 export default function RootLayout({

--- a/apps/marketing/src/app/page.tsx
+++ b/apps/marketing/src/app/page.tsx
@@ -3,9 +3,34 @@ import { ANALYTICS_EVENTS } from "@llmchat/shared";
 import { SiteHeader } from "@/components/SiteHeader";
 import { SiteFooter } from "@/components/SiteFooter";
 import { TrackedLink } from "@/components/TrackedLink";
+import { JsonLd } from "@/components/JsonLd";
+import { CANONICAL_SITE_URL } from "@/lib/site-urls";
 
 const dashboardUrl =
 	process.env.NEXT_PUBLIC_DASHBOARD_URL ?? "http://localhost:3001";
+
+// Organization + WebSite structured data for the home page.
+const orgJsonLd = {
+	"@context": "https://schema.org",
+	"@graph": [
+		{
+			"@type": "Organization",
+			"@id": `${CANONICAL_SITE_URL}/#org`,
+			name: "Clanker Support",
+			url: CANONICAL_SITE_URL,
+			logo: `${CANONICAL_SITE_URL}/logo.svg`,
+			description:
+				"An AI-powered support agent you drop into any site with one script tag — it answers from your docs and escalates to your team.",
+		},
+		{
+			"@type": "WebSite",
+			"@id": `${CANONICAL_SITE_URL}/#website`,
+			name: "Clanker Support",
+			url: CANONICAL_SITE_URL,
+			publisher: { "@id": `${CANONICAL_SITE_URL}/#org` },
+		},
+	],
+};
 
 const features = [
 	{
@@ -61,6 +86,7 @@ const steps = [
 export default function Home() {
 	return (
 		<>
+			<JsonLd data={orgJsonLd} />
 			<SiteHeader active="features" />
 
 			<main>

--- a/apps/marketing/src/app/robots.ts
+++ b/apps/marketing/src/app/robots.ts
@@ -1,0 +1,11 @@
+import type { MetadataRoute } from "next";
+
+import { CANONICAL_SITE_URL } from "@/lib/site-urls";
+
+export default function robots(): MetadataRoute.Robots {
+	return {
+		rules: { userAgent: "*", allow: "/" },
+		sitemap: `${CANONICAL_SITE_URL}/sitemap.xml`,
+		host: CANONICAL_SITE_URL,
+	};
+}

--- a/apps/marketing/src/app/sitemap.ts
+++ b/apps/marketing/src/app/sitemap.ts
@@ -1,0 +1,17 @@
+import type { MetadataRoute } from "next";
+import { allCompetitors, allMigrations, allPosts } from "content-collections";
+
+import { buildSitemap } from "@/lib/seo";
+import { CANONICAL_SITE_URL } from "@/lib/site-urls";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+	return buildSitemap(
+		CANONICAL_SITE_URL,
+		{
+			posts: allPosts.map((p) => ({ slug: p.slug, date: p.date })),
+			competitors: allCompetitors.map((c) => ({ id: c.id })),
+			migrations: allMigrations.map((m) => ({ slug: m.slug })),
+		},
+		new Date(),
+	);
+}

--- a/apps/marketing/src/app/vs/[slug]/page.tsx
+++ b/apps/marketing/src/app/vs/[slug]/page.tsx
@@ -7,6 +7,7 @@ import { SiteHeader } from "@/components/SiteHeader";
 import { SiteFooter } from "@/components/SiteFooter";
 import { TrackedLink } from "@/components/TrackedLink";
 import { TrackView } from "@/components/TrackView";
+import { pageMeta } from "@/lib/seo";
 
 const dashboardUrl =
 	process.env.NEXT_PUBLIC_DASHBOARD_URL ?? "http://localhost:3001";
@@ -23,10 +24,11 @@ export async function generateMetadata({
 	const { slug } = await params;
 	const c = allCompetitors.find((x) => x.id === slug);
 	if (!c) return {};
-	return {
+	return pageMeta({
 		title: `Why choose Clanker Support over ${c.name}? — Comparison`,
 		description: c.tldr,
-	};
+		path: `/vs/${slug}`,
+	});
 }
 
 export default async function VsPage({

--- a/apps/marketing/src/components/JsonLd.tsx
+++ b/apps/marketing/src/components/JsonLd.tsx
@@ -1,0 +1,13 @@
+/**
+ * Server-rendered JSON-LD. Because this is a server component, the script is in
+ * the initial HTML (crawlers and the Rich Results Test see it) — not injected
+ * client-side. Pass a schema.org object as `data`.
+ */
+export function JsonLd({ data }: { data: Record<string, unknown> }) {
+	return (
+		<script
+			type="application/ld+json"
+			dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }}
+		/>
+	);
+}

--- a/apps/marketing/src/lib/seo.test.ts
+++ b/apps/marketing/src/lib/seo.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+
+import { buildSitemap, pageMeta } from "./seo";
+
+const NOW = new Date("2026-06-20T00:00:00.000Z");
+const BASE = "https://clankersupport.com";
+
+const input = {
+	posts: [
+		{ slug: "introducing-llmchat", date: "2026-05-01" },
+		{ slug: "setting-up-email-threading", date: "2026-05-10" },
+	],
+	competitors: [{ id: "intercom" }, { id: "fin" }],
+	migrations: [{ slug: "intercom" }],
+};
+
+describe("buildSitemap", () => {
+	const entries = buildSitemap(BASE, input, NOW);
+	const urls = entries.map((e) => e.url);
+
+	it("includes the core static routes as absolute URLs", () => {
+		expect(urls).toEqual(
+			expect.arrayContaining([
+				`${BASE}/`,
+				`${BASE}/compare`,
+				`${BASE}/docs`,
+				`${BASE}/blog`,
+			]),
+		);
+	});
+
+	it("enumerates every dynamic blog / vs / migration page", () => {
+		expect(urls).toContain(`${BASE}/blog/introducing-llmchat`);
+		expect(urls).toContain(`${BASE}/vs/intercom`);
+		expect(urls).toContain(`${BASE}/vs/fin`);
+		expect(urls).toContain(`${BASE}/docs/migrate/intercom`);
+	});
+
+	it("has no relative or double-slashed URLs and no duplicates", () => {
+		for (const u of urls) {
+			expect(u.startsWith("https://")).toBe(true);
+			expect(u.slice("https://".length)).not.toContain("//");
+		}
+		expect(new Set(urls).size).toBe(urls.length);
+	});
+
+	it("dates blog entries from their post date", () => {
+		const post = entries.find(
+			(e) => e.url === `${BASE}/blog/introducing-llmchat`,
+		);
+		expect(post?.lastModified).toEqual(new Date("2026-05-01"));
+	});
+
+	it("counts = 4 static + posts + competitors + migrations", () => {
+		expect(entries).toHaveLength(4 + 2 + 2 + 1);
+	});
+});
+
+describe("pageMeta", () => {
+	it("sets a self-referencing canonical and an OG/Twitter block", () => {
+		const m = pageMeta({
+			title: "Docs — Clanker Support",
+			description: "Get started.",
+			path: "/docs",
+		});
+		expect(m.alternates?.canonical).toBe("/docs");
+		expect(m.openGraph?.url).toBe("/docs");
+		expect(m.openGraph).toMatchObject({
+			type: "website",
+			title: "Docs — Clanker Support",
+		});
+		// @ts-expect-error twitter card shape is a union; assert the field directly
+		expect(m.twitter?.card).toBe("summary_large_image");
+	});
+
+	it("marks blog posts as articles with a published time", () => {
+		const m = pageMeta({
+			title: "Post",
+			description: "d",
+			path: "/blog/x",
+			type: "article",
+			publishedTime: "2026-05-01",
+		});
+		expect(m.openGraph).toMatchObject({
+			type: "article",
+			publishedTime: "2026-05-01",
+		});
+	});
+});

--- a/apps/marketing/src/lib/seo.ts
+++ b/apps/marketing/src/lib/seo.ts
@@ -1,0 +1,103 @@
+import type { Metadata, MetadataRoute } from "next";
+
+/**
+ * Per-page metadata with the SEO essentials wired consistently: a self-
+ * referencing canonical, Open Graph, and a Twitter card. `path` is root-
+ * relative ("/blog") — metadataBase (set in the root layout) resolves it to an
+ * absolute URL. One helper so no page forgets the canonical or the OG block.
+ */
+export function pageMeta(opts: {
+	title: string;
+	description: string;
+	/** Root-relative path, e.g. "/compare". */
+	path: string;
+	/** OG type — "article" for blog posts, else "website". */
+	type?: "website" | "article";
+	/** ISO date for article OG (blog posts). */
+	publishedTime?: string;
+}): Metadata {
+	const { title, description, path, type = "website", publishedTime } = opts;
+	return {
+		title,
+		description,
+		alternates: { canonical: path },
+		openGraph: {
+			type,
+			url: path,
+			title,
+			description,
+			siteName: "Clanker Support",
+			...(publishedTime ? { publishedTime } : {}),
+		},
+		twitter: { card: "summary_large_image", title, description },
+	};
+}
+
+export interface SitemapInput {
+	posts: { slug: string; date: string }[];
+	competitors: { id: string }[];
+	migrations: { slug: string }[];
+}
+
+/**
+ * Build the full sitemap entry list — static routes plus every dynamic
+ * blog/comparison/migration page — as absolute URLs. Pure (data in, entries
+ * out) so it's unit-tested without the content-collections build or Next.
+ */
+export function buildSitemap(
+	base: string,
+	input: SitemapInput,
+	now: Date,
+): MetadataRoute.Sitemap {
+	const url = (path: string) => `${base}${path}`;
+
+	const staticEntries: MetadataRoute.Sitemap = [
+		{
+			url: url("/"),
+			lastModified: now,
+			changeFrequency: "weekly",
+			priority: 1,
+		},
+		{
+			url: url("/compare"),
+			lastModified: now,
+			changeFrequency: "weekly",
+			priority: 0.8,
+		},
+		{
+			url: url("/docs"),
+			lastModified: now,
+			changeFrequency: "weekly",
+			priority: 0.8,
+		},
+		{
+			url: url("/blog"),
+			lastModified: now,
+			changeFrequency: "daily",
+			priority: 0.7,
+		},
+	];
+
+	const posts: MetadataRoute.Sitemap = input.posts.map((p) => ({
+		url: url(`/blog/${p.slug}`),
+		lastModified: new Date(p.date),
+		changeFrequency: "monthly",
+		priority: 0.6,
+	}));
+
+	const vs: MetadataRoute.Sitemap = input.competitors.map((c) => ({
+		url: url(`/vs/${c.id}`),
+		lastModified: now,
+		changeFrequency: "monthly",
+		priority: 0.7,
+	}));
+
+	const migrate: MetadataRoute.Sitemap = input.migrations.map((m) => ({
+		url: url(`/docs/migrate/${m.slug}`),
+		lastModified: now,
+		changeFrequency: "monthly",
+		priority: 0.6,
+	}));
+
+	return [...staticEntries, ...posts, ...vs, ...migrate];
+}

--- a/apps/marketing/src/lib/site-urls.ts
+++ b/apps/marketing/src/lib/site-urls.ts
@@ -8,3 +8,10 @@ export const CANONICAL_DASHBOARD_URL =
 	process.env.NEXT_PUBLIC_DASHBOARD_URL ?? "http://localhost:3001";
 export const CANONICAL_SHOWCASE_URL =
 	process.env.NEXT_PUBLIC_SHOWCASE_URL ?? "http://localhost:3003";
+
+/** The marketing site's own canonical origin — the base for metadataBase,
+ * canonical tags, the sitemap, and robots. Falls back to the production host
+ * (this site *is* clankersupport.com) so SEO URLs are absolute even when
+ * NEXT_PUBLIC_SITE_URL isn't set. */
+export const CANONICAL_SITE_URL =
+	process.env.NEXT_PUBLIC_SITE_URL ?? "https://clankersupport.com";

--- a/apps/marketing/vitest.config.ts
+++ b/apps/marketing/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+
+// The marketing app's SEO helpers (lib/seo.ts) are pure, so a Node environment
+// is enough — no jsdom, no Next runtime, no content-collections build.
+export default defineConfig({
+	test: {
+		environment: "node",
+		include: ["src/**/*.test.ts"],
+	},
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -269,6 +269,9 @@ importers:
       typescript:
         specifier: 5.9.2
         version: 5.9.2
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.6(@types/debug@4.1.13)(@types/node@22.19.17)(jiti@1.21.7)(jsdom@26.1.0)(tsx@4.21.0)(yaml@2.9.0)
 
   apps/showcase:
     dependencies:


### PR DESCRIPTION
Ran the **seo-audit** skill against the marketing site (clankersupport.com) and implemented the findings. **Do not merge** — for review.

## Audit summary
The site was healthy on basics (HTTPS, responsive, `lang="en"`, unique titles + descriptions per route, single H1s, `next/font` swap). The gaps were the machine-readable foundations — fixed here.

## Implemented
| Finding | Fix |
|---|---|
| No robots | `app/robots.ts` — allow all, sitemap pointer, host |
| No sitemap (dynamic routes undiscoverable) | `app/sitemap.ts` — static + every `blog`/`vs`/`docs/migrate` URL from content collections |
| No `metadataBase` | set in root layout (resolves canonical/OG to absolute) |
| No canonical tags | per-page `alternates.canonical` via a `pageMeta()` helper |
| No Open Graph / Twitter | defaults in layout + per page (posts as `type=article` w/ publishedTime) |
| No structured data | `Organization` + `WebSite` (home), `BlogPosting` (posts) — **server-rendered** JSON-LD so crawlers see it |
| No robots directives | `index/follow` + `max-image-preview:large` in root metadata |

`lib/seo.ts` keeps it DRY: `pageMeta()` (canonical + OG + Twitter) and a pure `buildSitemap()`.

## Honest scope notes
- **No OG image fabricated** — none exists; OG/Twitter ship as rich text cards. A 1200×630 image / dynamic `opengraph-image.tsx` is a recommended follow-up.
- **Couldn't run `next build` in the sandbox** (it fetches Google Fonts, which are network-blocked here). Gated instead on: marketing **typecheck** (clean), a **new vitest** unit test for the pure sitemap/meta logic (7 tests), and lint/prettier — plus a manual review of the declarative metadata. Worth a `next build` in CI/preview to confirm the `robots.txt`/`sitemap.xml` routes render.

## Checks
Full suite green incl. the new marketing tests (marketing 7, dashboard 192, widget 72, api 98, shared 14); typecheck + lint/prettier + secret-scan clean. Added a vitest harness to the marketing app (its first tests). Conventional commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)