### PR TITLE
feat(marketing): AI-SEO — llms.txt + agent-readable pricing.md

### DIFF
--- a/apps/marketing/src/app/llms.txt/route.ts
+++ b/apps/marketing/src/app/llms.txt/route.ts
@@ -1,0 +1,34 @@
+import { allCompetitors, allMigrations, allPosts } from "content-collections";
+
+import { buildLlmsTxt } from "@/lib/llms-txt";
+import { CANONICAL_SITE_URL } from "@/lib/site-urls";
+
+// Static: the content collections are fixed at build time.
+export const dynamic = "force-static";
+
+export function GET() {
+	const body = buildLlmsTxt(CANONICAL_SITE_URL, {
+		posts: allPosts.map((p) => ({
+			slug: p.slug,
+			title: p.title,
+			description: p.description,
+		})),
+		competitors: allCompetitors.map((c) => ({
+			id: c.id,
+			name: c.name,
+			tldr: c.tldr,
+		})),
+		migrations: allMigrations.map((m) => ({
+			slug: m.slug,
+			name: m.name,
+			tagline: m.tagline,
+		})),
+	});
+
+	return new Response(body, {
+		headers: {
+			"content-type": "text/plain; charset=utf-8",
+			"cache-control": "public, max-age=3600",
+		},
+	});
+}

--- a/apps/marketing/src/app/pricing.md/route.ts
+++ b/apps/marketing/src/app/pricing.md/route.ts
@@ -1,0 +1,34 @@
+import { CANONICAL_SITE_URL } from "@/lib/site-urls";
+
+// Static, machine-readable pricing for AI agents evaluating the product. Honest
+// about the in-flight pricing: self-host is free, hosted is moving to
+// usage-based (per message) with the exact price still to be announced. No
+// invented numbers.
+export const dynamic = "force-static";
+
+const PRICING = `# Pricing — Clanker Support
+
+Clanker Support is an AI-powered support agent. It is open and self-hostable.
+
+## Self-hosted
+- Price: Free
+- You run it yourself and bring your own keys and infrastructure (an LLM Gateway key and a database).
+- Full feature set; no usage limits imposed by us.
+
+## Hosted (clankersupport.com)
+- Model: Usage-based — billed per message, where one message = one agent response.
+- Free tier: none.
+- Exact per-message price and any trial: to be announced.
+- Interim: a flat Pro plan ($29 / month, via Stripe) is available while usage-based pricing is finalized.
+
+More: ${CANONICAL_SITE_URL}/docs
+`;
+
+export function GET() {
+	return new Response(PRICING, {
+		headers: {
+			"content-type": "text/markdown; charset=utf-8",
+			"cache-control": "public, max-age=3600",
+		},
+	});
+}

--- a/apps/marketing/src/lib/llms-txt.test.ts
+++ b/apps/marketing/src/lib/llms-txt.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+
+import { buildLlmsTxt } from "./llms-txt";
+
+const BASE = "https://clankersupport.com";
+
+const input = {
+	posts: [
+		{
+			slug: "introducing-llmchat",
+			title: "Introducing Clanker Support",
+			description: "Why we built it.",
+		},
+	],
+	competitors: [
+		{ id: "intercom", name: "Intercom", tldr: "Lighter and cheaper." },
+	],
+	migrations: [
+		{ slug: "intercom", name: "Intercom", tagline: "Move in an afternoon." },
+	],
+};
+
+describe("buildLlmsTxt", () => {
+	const out = buildLlmsTxt(BASE, input);
+
+	it("follows the llms.txt shape: H1, then a one-line blockquote summary", () => {
+		const lines = out.split("\n");
+		expect(lines[0]).toBe("# Clanker Support");
+		expect(lines[2].startsWith("> ")).toBe(true);
+	});
+
+	it("links the core product pages with absolute URLs, incl. pricing.md", () => {
+		expect(out).toContain(`(${BASE}/)`);
+		expect(out).toContain(`(${BASE}/docs)`);
+		expect(out).toContain(`(${BASE}/compare)`);
+		expect(out).toContain(`(${BASE}/pricing.md)`);
+	});
+
+	it("enumerates comparisons, migration guides, and journal posts", () => {
+		expect(out).toContain(`[Clanker Support vs Intercom](${BASE}/vs/intercom)`);
+		expect(out).toContain(`(${BASE}/docs/migrate/intercom)`);
+		expect(out).toContain(`(${BASE}/blog/introducing-llmchat)`);
+		expect(out).toContain("## Comparisons");
+		expect(out).toContain("## Migration guides");
+		expect(out).toContain("## Journal");
+	});
+
+	it("uses the 'support agent' positioning, never 'chatbot'", () => {
+		expect(out.toLowerCase()).toContain("support agent");
+		expect(out.toLowerCase()).not.toContain("chatbot");
+	});
+
+	it("ends with a single trailing newline and emits no empty links", () => {
+		expect(out.endsWith("\n")).toBe(true);
+		expect(out.endsWith("\n\n")).toBe(false);
+		expect(out).not.toContain("]()");
+	});
+
+	it("omits a section when its collection is empty", () => {
+		const out2 = buildLlmsTxt(BASE, { ...input, posts: [] });
+		expect(out2).not.toContain("## Journal");
+	});
+});

--- a/apps/marketing/src/lib/llms-txt.ts
+++ b/apps/marketing/src/lib/llms-txt.ts
@@ -1,0 +1,54 @@
+// Builds the /llms.txt body — the llmstxt.org convention: an H1, a one-line
+// blockquote summary, then sections of markdown links so an AI system can grab
+// a map of the product and its key pages. Pure (data in, string out) so it's
+// unit-tested without the content-collections build or Next.
+
+export interface LlmsTxtInput {
+	posts: { slug: string; title: string; description: string }[];
+	competitors: { id: string; name: string; tldr: string }[];
+	migrations: { slug: string; name: string; tagline: string }[];
+}
+
+const SUMMARY =
+	"An AI-powered support agent you embed with one script tag — it answers from your docs and sources, then escalates to your team. Open and self-hostable (bring your own keys); the hosted version is usage-based, billed per message.";
+
+export function buildLlmsTxt(siteUrl: string, input: LlmsTxtInput): string {
+	const lines: string[] = [
+		"# Clanker Support",
+		"",
+		`> ${SUMMARY}`,
+		"",
+		"## Product",
+		`- [Overview](${siteUrl}/): What Clanker Support is and how the drop-in agent works.`,
+		`- [Docs](${siteUrl}/docs): Quickstart, training on your docs, escalation, and migration.`,
+		`- [Compare](${siteUrl}/compare): How Clanker Support compares to other AI support tools.`,
+		`- [Pricing](${siteUrl}/pricing.md): Self-host (free) and hosted usage-based pricing.`,
+	];
+
+	if (input.competitors.length) {
+		lines.push("", "## Comparisons");
+		for (const c of input.competitors) {
+			lines.push(
+				`- [Clanker Support vs ${c.name}](${siteUrl}/vs/${c.id}): ${c.tldr}`,
+			);
+		}
+	}
+
+	if (input.migrations.length) {
+		lines.push("", "## Migration guides");
+		for (const m of input.migrations) {
+			lines.push(
+				`- [Migrate from ${m.name} to Clanker Support](${siteUrl}/docs/migrate/${m.slug}): ${m.tagline}`,
+			);
+		}
+	}
+
+	if (input.posts.length) {
+		lines.push("", "## Journal");
+		for (const p of input.posts) {
+			lines.push(`- [${p.title}](${siteUrl}/blog/${p.slug}): ${p.description}`);
+		}
+	}
+
+	return `${lines.join("\n").trimEnd()}\n`;
+}


### PR DESCRIPTION
Ran the **ai-seo** skill (AEO/GEO/LLMO) against the marketing site and implemented the machine-readable AI-agent findings. **Do not merge** — for review.

⚠️ **Stacked on #33** (`feat/marketing-seo`) — it adds the marketing test harness + `CANONICAL_SITE_URL` this reuses. **Merge #33 first**; GitHub will then retarget this to `main`.

## Audit verdict
#33 already covers the AI-search basics — AI crawlers (GPTBot, PerplexityBot, ClaudeBot, Google-Extended) are **allowed** via robots allow-all, and Organization/WebSite/Article JSON-LD + canonical/sitemap shipped there. Comparison + per-competitor pages already exist (the highest-cited format). The AI-specific gap was the **machine-readable agent files**.

## Implemented
- **`/llms.txt`** — the llmstxt.org convention (H1 + one-line summary + linked sections: product, comparisons, migration guides, journal), generated from the content collections so it stays in sync. Lets ChatGPT/Perplexity/Claude grab a product map without scraping.
- **`/pricing.md`** — machine-readable pricing for AI buying-agents (the skill calls out opaque/JS-only pricing getting filtered from AI-mediated buying). **Data-honest**: self-host free (BYO keys), hosted usage-based per message, exact price *to be announced*, interim Pro noted. **No invented numbers.**
- `lib/llms-txt.ts`: pure `buildLlmsTxt()` + 6 unit tests (shape, absolute links, sections, positioning, trailing newline, empty-section omission).

## Recommended follow-ups (not implemented here — and why)
- **FAQPage schema + a visible FAQ** — high AEO value, but needs *real on-page* FAQ content; shipping JSON-LD-only would be AI-bait (violates Google's "don't write for AI" + FAQ-rich-result rules). Worth a dedicated content PR.
- **"Last updated" stamps** on posts; **third-party presence** (Wikipedia/Reddit/G2) — off-site/content work, not code to fabricate.

## Checks
Marketing 13 tests (7 SEO + 6 llms.txt) + full suite green (dashboard 192, widget 72, api 98, shared 14); typecheck + lint/prettier + secret-scan clean. Same sandbox caveat as #33: `next build` can't run here (Google Fonts blocked) — a preview build should confirm `/llms.txt` and `/pricing.md` render. Positioning stays "support agent".

🤖 Generated with [Claude Code](https://claude.com/claude-code)