### PR TITLE
feat(inbox): content search with highlighted snippets

### DIFF
--- a/apps/api/src/lib/search.test.ts
+++ b/apps/api/src/lib/search.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+
+import { buildSnippet, escapeLike, includesCI } from "./search";
+
+describe("escapeLike", () => {
+	it("escapes LIKE wildcards and the escape char so a term matches literally", () => {
+		expect(escapeLike("100%")).toBe("100\\%");
+		expect(escapeLike("a_b")).toBe("a\\_b");
+		expect(escapeLike("c:\\path")).toBe("c:\\\\path");
+		expect(escapeLike("plain")).toBe("plain");
+	});
+});
+
+describe("includesCI", () => {
+	it("is case-insensitive", () => {
+		expect(includesCI("Ada Lovelace", "lovelace")).toBe(true);
+		expect(includesCI("ADA@X.IO", "ada@x")).toBe(true);
+		expect(includesCI("nope", "zzz")).toBe(false);
+	});
+});
+
+describe("buildSnippet", () => {
+	it("centers a short window on the first hit with ellipses on clipped ends", () => {
+		const content =
+			"Thanks for reaching out. Our refund policy is a full 30 days, no questions asked, for any order.";
+		const snip = buildSnippet(content, "refund", 12);
+		expect(snip).toContain("refund");
+		expect(snip.startsWith("…")).toBe(true);
+		expect(snip.endsWith("…")).toBe(true);
+		// Far shorter than the full message — it's an excerpt, not the whole body.
+		expect(snip.length).toBeLessThan(content.length);
+	});
+
+	it("collapses newlines/whitespace into a single-line preview", () => {
+		const snip = buildSnippet(
+			"line one\n\n  line   two refund here",
+			"refund",
+			40,
+		);
+		expect(snip).not.toContain("\n");
+		expect(snip).not.toContain("  ");
+		expect(snip).toContain("refund");
+	});
+
+	it("does not prepend an ellipsis when the hit is at the start", () => {
+		const snip = buildSnippet("Refund requested by the visitor", "refund", 40);
+		expect(snip.startsWith("…")).toBe(false);
+		expect(snip).toContain("Refund");
+	});
+
+	it("falls back to a head excerpt when the term isn't locatable (wildcard)", () => {
+		const long = "x".repeat(300);
+		const snip = buildSnippet(long, "%", 20);
+		expect(snip.endsWith("…")).toBe(true);
+		expect(snip.length).toBeLessThan(long.length);
+	});
+
+	it("returns the whole (trimmed) body when it's already short", () => {
+		expect(buildSnippet("short and sweet", "sweet", 48)).toBe(
+			"short and sweet",
+		);
+	});
+});

--- a/apps/api/src/lib/search.ts
+++ b/apps/api/src/lib/search.ts
@@ -1,0 +1,74 @@
+import { sql } from "@llmchat/db";
+
+import type { AnyColumn, SQL } from "drizzle-orm";
+
+/**
+ * Inbox content search helpers. The strategy is a deliberately simple, scoped
+ * `LIKE '%term%'` contains-scan — no full-text-search infra — which is the right
+ * call at this volume (a leading-wildcard LIKE can't use a B-tree index anyway,
+ * so an index on message.content would not help; FTS5 is the future path if
+ * volume ever demands it).
+ */
+
+/** Upper bound on how many message-matching conversations we gather for one
+ * search, so a broad term can't drag back an unbounded id set before we paginate
+ * the conversation list. Generous for this volume. */
+export const MAX_MATCH_CONVERSATIONS = 500;
+
+/**
+ * Escape the LIKE metacharacters in a user term so it matches *literally*. `%`
+ * and `_` are SQL wildcards and `\` is our escape char — without this, a term
+ * containing `%` would silently match everything. Pair with `ESCAPE '\'` (see
+ * {@link likeContains}).
+ */
+export function escapeLike(term: string): string {
+	return term.replace(/[\\%_]/g, (ch) => `\\${ch}`);
+}
+
+/**
+ * A case-insensitive "column contains term" SQL condition. The term is passed as
+ * a **bound parameter** (never string-concatenated into SQL — no injection), and
+ * wildcards are escaped so the match is literal. SQLite's LIKE is ASCII
+ * case-insensitive, which is what we want for names/emails/message bodies.
+ */
+export function likeContains(column: AnyColumn, term: string): SQL {
+	const pattern = `%${escapeLike(term)}%`;
+	return sql`${column} LIKE ${pattern} ESCAPE '\\'`;
+}
+
+/** Case-insensitive substring test, mirroring {@link likeContains} on the JS
+ * side so the route can classify which field matched (name vs email) and the
+ * snippet builder can locate the hit. */
+export function includesCI(haystack: string, needle: string): boolean {
+	return haystack.toLowerCase().includes(needle.toLowerCase());
+}
+
+/**
+ * Build a short, single-line snippet of `content` centered on the first
+ * occurrence of `term`, with `…` marking clipped ends. Whitespace (incl.
+ * newlines) is collapsed so a multi-line message reads as a tidy preview. The
+ * result is **plain text** — the caller is responsible for safe rendering
+ * (escaped) and for highlighting the term.
+ */
+export function buildSnippet(
+	content: string,
+	term: string,
+	radius = 48,
+): string {
+	const text = content.replace(/\s+/g, " ").trim();
+	const idx = term ? text.toLowerCase().indexOf(term.toLowerCase()) : -1;
+
+	// No locatable hit (e.g. the term used a LIKE wildcard): fall back to a head
+	// excerpt so we still show context.
+	if (idx === -1) {
+		const head = text.slice(0, radius * 2).trim();
+		return head.length < text.length ? `${head}…` : head;
+	}
+
+	const start = Math.max(0, idx - radius);
+	const end = Math.min(text.length, idx + term.length + radius);
+	let snippet = text.slice(start, end).trim();
+	if (start > 0) snippet = `…${snippet}`;
+	if (end < text.length) snippet = `${snippet}…`;
+	return snippet;
+}

--- a/apps/api/src/routes/conversations.test.ts
+++ b/apps/api/src/routes/conversations.test.ts
@@ -1,0 +1,269 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { db } from "@/lib/db";
+
+import { conversation, message, readStatus } from "@llmchat/db";
+
+import { conversations } from "./conversations";
+
+// Header-driven fake session (same pattern as projects.test): `x-test-user`
+// present ⇒ signed in; `query.member.findFirst` decides workspace membership.
+vi.mock("@/auth", () => ({
+	createAuth: () => ({
+		api: {
+			getSession: async ({ headers }: { headers: Headers }) => {
+				const id = headers.get("x-test-user");
+				return id ? { user: { id } } : null;
+			},
+		},
+	}),
+}));
+
+vi.mock("@/lib/db", () => ({ db: vi.fn() }));
+
+const ENV = { vars: {}, DB: {} } as unknown as Parameters<
+	typeof conversations.request
+>[2];
+
+type Row = Record<string, unknown>;
+
+interface State {
+	role?: "owner" | "admin" | "agent";
+	/** The project as seen by the workspace-scoped ownership check (undefined ⇒
+	 * 404, i.e. not in the caller's workspace). */
+	project?: Row;
+	/** Project-scoped conversation rows the main list query returns. */
+	conversationRows?: Row[];
+	/** Conversation ids whose message bodies match (membership query result). */
+	bodyMatchIds?: string[];
+	/** Matching message bodies for the snippet query, in sequence order. */
+	snippetRows?: { conversationId: string; content: string }[];
+	/** Sequence-1 previews for the firstMessage query. */
+	firstMessages?: { conversationId: string; content: string }[];
+}
+
+/** Records the shape of every message-table query so tests can assert the
+ * content-search queries are scoped via a conversation join. */
+let messageQueries: { distinct: boolean; joined: boolean }[];
+
+function mockDb(state: State) {
+	messageQueries = [];
+
+	function builder(distinct: boolean) {
+		const q = { table: null as unknown, joined: false };
+		const resolve = (): unknown[] => {
+			if (q.table === message) {
+				messageQueries.push({ distinct, joined: q.joined });
+				if (q.joined) {
+					return distinct
+						? (state.bodyMatchIds ?? []).map((id) => ({ id }))
+						: (state.snippetRows ?? []);
+				}
+				return state.firstMessages ?? [];
+			}
+			if (q.table === conversation) return state.conversationRows ?? [];
+			if (q.table === readStatus) return [];
+			return [];
+		};
+		const chain: Record<string, unknown> = {
+			from(t: unknown) {
+				q.table = t;
+				return chain;
+			},
+			innerJoin() {
+				q.joined = true;
+				return chain;
+			},
+			where() {
+				return chain;
+			},
+			orderBy() {
+				return chain;
+			},
+			limit() {
+				return chain;
+			},
+			offset() {
+				return chain;
+			},
+			// The fake query builder is intentionally awaitable (the route awaits the
+			// chain), so it must expose `then`.
+			// eslint-disable-next-line unicorn/no-thenable
+			then<R>(onF: (v: unknown[]) => R) {
+				return Promise.resolve(resolve()).then(onF);
+			},
+		};
+		return chain;
+	}
+
+	const fake = {
+		query: {
+			member: {
+				findFirst: async () => (state.role ? { role: state.role } : undefined),
+			},
+			project: {
+				findFirst: async () => state.project,
+			},
+		},
+		select: () => builder(false),
+		selectDistinct: () => builder(true),
+	};
+	vi.mocked(db).mockReturnValue(fake as unknown as ReturnType<typeof db>);
+}
+
+function get(path: string, headers: Record<string, string>) {
+	return conversations.request(path, { method: "GET", headers }, ENV);
+}
+
+const MEMBER = { "x-test-user": "u1", "x-workspace-id": "ws_1" };
+const PROJECT = { id: "p1", workspaceId: "ws_1" };
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("inbox search — role gating", () => {
+	it("401s an unauthenticated request", async () => {
+		mockDb({});
+		const res = await get("/projects/p1/conversations?search=hi", {
+			"x-workspace-id": "ws_1",
+		});
+		expect(res.status).toBe(401);
+	});
+
+	it("403s a non-member (no membership in the workspace)", async () => {
+		mockDb({}); // no role ⇒ not a member
+		const res = await get("/projects/p1/conversations?search=hi", MEMBER);
+		expect(res.status).toBe(403);
+	});
+
+	it("lets any member (agent) search", async () => {
+		mockDb({ role: "agent", project: PROJECT, conversationRows: [] });
+		const res = await get("/projects/p1/conversations?search=hi", MEMBER);
+		expect(res.status).toBe(200);
+	});
+});
+
+describe("inbox search — scoping", () => {
+	it("404s when the project isn't in the caller's workspace (can't search foreign data)", async () => {
+		mockDb({ role: "owner", project: undefined });
+		const res = await get("/projects/pX/conversations?search=secret", MEMBER);
+		expect(res.status).toBe(404);
+	});
+
+	it("scopes message matching via a conversation join — never an unscoped scan", async () => {
+		mockDb({
+			role: "agent",
+			project: PROJECT,
+			conversationRows: [
+				{ id: "cA", name: "Bob", email: null, messageCount: 2 },
+			],
+			bodyMatchIds: ["cA"],
+			snippetRows: [{ conversationId: "cA", content: "the refund policy" }],
+		});
+		const res = await get("/projects/p1/conversations?search=refund", MEMBER);
+		expect(res.status).toBe(200);
+		// Both content-search queries (membership + snippet) ran joined to
+		// conversation; none scanned messages unscoped.
+		const contentQueries = messageQueries.filter(
+			(m) => m.distinct || (!m.distinct && m.joined),
+		);
+		expect(messageQueries.some((m) => m.distinct && m.joined)).toBe(true);
+		expect(contentQueries.every((m) => m.joined)).toBe(true);
+	});
+});
+
+describe("inbox search — matching", () => {
+	it("matches message body text and returns a highlighted-able snippet", async () => {
+		mockDb({
+			role: "agent",
+			project: PROJECT,
+			conversationRows: [
+				{ id: "cA", name: "Bob", email: null, messageCount: 2 },
+			],
+			bodyMatchIds: ["cA"],
+			snippetRows: [
+				{
+					conversationId: "cA",
+					content:
+						"Sure — our refund policy is a full 30 days for any unused order.",
+				},
+			],
+		});
+		const res = await get("/projects/p1/conversations?search=refund", MEMBER);
+		const body = (await res.json()) as {
+			conversations: {
+				id: string;
+				match: { field: string; snippet: string };
+			}[];
+		};
+		expect(body.conversations).toHaveLength(1);
+		expect(body.conversations[0]!.match.field).toBe("body");
+		expect(body.conversations[0]!.match.snippet.toLowerCase()).toContain(
+			"refund",
+		);
+	});
+
+	it("still matches visitor name", async () => {
+		mockDb({
+			role: "agent",
+			project: PROJECT,
+			conversationRows: [
+				{ id: "cN", name: "Ada Lovelace", email: "ada@x.io", messageCount: 1 },
+			],
+		});
+		const res = await get("/projects/p1/conversations?search=lovelace", MEMBER);
+		const body = (await res.json()) as {
+			conversations: { match: { field: string; snippet: string } }[];
+		};
+		expect(body.conversations[0]!.match).toEqual({
+			field: "name",
+			snippet: "Ada Lovelace",
+		});
+	});
+
+	it("still matches visitor email", async () => {
+		mockDb({
+			role: "agent",
+			project: PROJECT,
+			conversationRows: [
+				{ id: "cE", name: "Ada", email: "ada@example.io", messageCount: 1 },
+			],
+		});
+		const res = await get(
+			"/projects/p1/conversations?search=example.io",
+			MEMBER,
+		);
+		const body = (await res.json()) as {
+			conversations: { match: { field: string } }[];
+		};
+		expect(body.conversations[0]!.match.field).toBe("email");
+	});
+
+	it("returns an empty list when nothing matches", async () => {
+		mockDb({
+			role: "agent",
+			project: PROJECT,
+			conversationRows: [],
+			bodyMatchIds: [],
+		});
+		const res = await get("/projects/p1/conversations?search=zzzznope", MEMBER);
+		const body = (await res.json()) as { conversations: unknown[] };
+		expect(body.conversations).toEqual([]);
+	});
+
+	it("omits match (null) and keeps the firstMessage preview when not searching", async () => {
+		mockDb({
+			role: "agent",
+			project: PROJECT,
+			conversationRows: [
+				{ id: "cA", name: "Bob", email: null, messageCount: 1 },
+			],
+			firstMessages: [{ conversationId: "cA", content: "hello there" }],
+		});
+		const res = await get("/projects/p1/conversations", MEMBER);
+		const body = (await res.json()) as {
+			conversations: { match: unknown; firstMessage: string }[];
+		};
+		expect(body.conversations[0]!.match).toBeNull();
+		expect(body.conversations[0]!.firstMessage).toBe("hello there");
+	});
+});

--- a/apps/api/src/routes/conversations.ts
+++ b/apps/api/src/routes/conversations.ts
@@ -5,6 +5,12 @@ import { z } from "zod";
 import { db } from "@/lib/db";
 import { buildReplyToAddress, escapeHtml, sendEmail } from "@/lib/email";
 import {
+	MAX_MATCH_CONVERSATIONS,
+	buildSnippet,
+	includesCI,
+	likeContains,
+} from "@/lib/search";
+import {
 	requireRole,
 	requireSession,
 	requireWorkspace,
@@ -12,16 +18,21 @@ import {
 
 import {
 	and,
+	asc,
 	conversation,
 	desc,
 	eq,
 	inArray,
-	like,
 	message as messageTable,
+	or,
 	readStatus,
 } from "@llmchat/db";
 
 import type { AppContext } from "@/env";
+
+/** Why a conversation surfaced in a search: an excerpt of the hit and which
+ * field it came from, so the agent sees the reason in the list. */
+type SearchMatch = { field: "body" | "name" | "email"; snippet: string };
 
 export const conversations = new Hono<AppContext>()
 	.use("*", requireSession, requireWorkspace)
@@ -50,6 +61,8 @@ export const conversations = new Hono<AppContext>()
 				return c.json({ error: "not found" }, 404);
 			}
 
+			const term = search?.trim() ?? "";
+
 			const conditions = [eq(conversation.projectId, projectId)];
 			if (archived === "true") {
 				conditions.push(
@@ -61,6 +74,38 @@ export const conversations = new Hono<AppContext>()
 				);
 			}
 
+			// Content search: a conversation matches on visitor name, email, OR any
+			// message body. The message match is scoped to THIS project via a join
+			// to conversation (never an unscoped scan of every workspace's
+			// messages), bounded, and resolved into the conversation set BEFORE
+			// pagination so search spans the whole project, not just the first page.
+			if (term) {
+				const bodyMatches = await db(c.env)
+					.selectDistinct({ id: messageTable.conversationId })
+					.from(messageTable)
+					.innerJoin(
+						conversation,
+						eq(messageTable.conversationId, conversation.id),
+					)
+					.where(
+						and(
+							eq(conversation.projectId, projectId),
+							likeContains(messageTable.content, term),
+						),
+					)
+					.limit(MAX_MATCH_CONVERSATIONS);
+				const bodyMatchIds = bodyMatches.map((m) => m.id);
+
+				const orParts = [
+					likeContains(conversation.name, term),
+					likeContains(conversation.email, term),
+				];
+				if (bodyMatchIds.length) {
+					orParts.push(inArray(conversation.id, bodyMatchIds));
+				}
+				conditions.push(or(...orParts)!);
+			}
+
 			const rows = await db(c.env)
 				.select()
 				.from(conversation)
@@ -69,19 +114,57 @@ export const conversations = new Hono<AppContext>()
 				.limit(limit)
 				.offset(offset);
 
-			let filtered = rows;
-			if (search) {
-				const matchingMessages = await db(c.env)
-					.select({ conversationId: messageTable.conversationId })
-					.from(messageTable)
-					.where(like(messageTable.content, `%${search}%`));
-				const matchSet = new Set(matchingMessages.map((m) => m.conversationId));
-				filtered = rows.filter((r) => matchSet.has(r.id));
-			}
-
 			// Attach the first visitor message (sequence 1) as a list preview —
 			// one bounded query keyed on the page of conversations we're returning.
-			const ids = filtered.map((r) => r.id);
+			const ids = rows.map((r) => r.id);
+
+			// For the page being returned, pull the first message per conversation
+			// whose body matched (scoped + bounded to these ids) so each row can show
+			// *why* it matched. Ordered by sequence so the snippet is stable.
+			const bodyMatchByConv = new Map<string, string>();
+			if (term && ids.length) {
+				const matchingBodies = await db(c.env)
+					.select({
+						conversationId: messageTable.conversationId,
+						content: messageTable.content,
+					})
+					.from(messageTable)
+					.innerJoin(
+						conversation,
+						eq(messageTable.conversationId, conversation.id),
+					)
+					.where(
+						and(
+							eq(conversation.projectId, projectId),
+							inArray(messageTable.conversationId, ids),
+							likeContains(messageTable.content, term),
+						),
+					)
+					.orderBy(asc(messageTable.sequence));
+				for (const m of matchingBodies) {
+					if (!bodyMatchByConv.has(m.conversationId)) {
+						bodyMatchByConv.set(m.conversationId, m.content);
+					}
+				}
+			}
+
+			// Classify each returned conversation's match: prefer the message body
+			// excerpt (most informative), else flag the name/email hit so the agent
+			// still sees why a no-message-match conversation surfaced.
+			const matchFor = (r: (typeof rows)[number]): SearchMatch | null => {
+				if (!term) return null;
+				const body = bodyMatchByConv.get(r.id);
+				if (body !== undefined) {
+					return { field: "body", snippet: buildSnippet(body, term) };
+				}
+				if (r.name && includesCI(r.name, term)) {
+					return { field: "name", snippet: r.name };
+				}
+				if (r.email && includesCI(r.email, term)) {
+					return { field: "email", snippet: r.email };
+				}
+				return null;
+			};
 			const firstMessages = ids.length
 				? await db(c.env)
 						.select({
@@ -121,10 +204,11 @@ export const conversations = new Hono<AppContext>()
 			);
 
 			return c.json({
-				conversations: filtered.map((r) => ({
+				conversations: rows.map((r) => ({
 					...r,
 					firstMessage: firstByConv.get(r.id) ?? null,
 					unread: (readByConv.get(r.id) ?? 0) < r.messageCount,
+					match: matchFor(r),
 				})),
 			});
 		},
@@ -148,7 +232,7 @@ export const conversations = new Hono<AppContext>()
 		}
 		const messages = await db(c.env).query.message.findMany({
 			where: (mt, { eq: e }) => e(mt.conversationId, id),
-			orderBy: (mt, { asc }) => asc(mt.sequence),
+			orderBy: (mt, ops) => ops.asc(mt.sequence),
 		});
 		return c.json({ conversation: conv, messages });
 	})

--- a/apps/dashboard/src/app/inbox/_components/ConversationList.test.tsx
+++ b/apps/dashboard/src/app/inbox/_components/ConversationList.test.tsx
@@ -108,6 +108,34 @@ describe("ConversationList", () => {
 		expect(badges).toHaveLength(1);
 	});
 
+	it("shows the match snippet with the term highlighted when searching", () => {
+		setup({
+			search: "refund",
+			conversations: [
+				conv({
+					id: "m",
+					match: { field: "body", snippet: "our refund policy is 30 days" },
+				}),
+			],
+		});
+		// The snippet replaces the default preview, with the term in a <mark>.
+		const mark = screen.getByText("refund");
+		expect(mark.tagName).toBe("MARK");
+		expect(
+			screen.queryByText("How do I reset my device?"),
+		).not.toBeInTheDocument();
+	});
+
+	it("labels a name/email match so the agent sees why it surfaced", () => {
+		setup({
+			search: "ada",
+			conversations: [
+				conv({ id: "m", match: { field: "name", snippet: "Ada Lovelace" } }),
+			],
+		});
+		expect(screen.getByText("Name")).toBeInTheDocument();
+	});
+
 	it("falls back to email then a placeholder when there's no first message", () => {
 		setup({
 			conversations: [conv({ id: "x", firstMessage: null, name: "No Msg" })],

--- a/apps/dashboard/src/app/inbox/_components/ConversationList.tsx
+++ b/apps/dashboard/src/app/inbox/_components/ConversationList.tsx
@@ -6,15 +6,27 @@ import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
 
 import { initials, pluralize, timeAgo } from "./format";
-import type { Conversation } from "./types";
+import { Highlighted } from "./highlight";
+import type { Conversation, SearchMatch } from "./types";
+
+/** Short label shown before a name/email match so the agent knows where the term
+ * was found; a body match needs no label (the excerpt speaks for itself). */
+const MATCH_LABEL: Record<SearchMatch["field"], string | null> = {
+	body: null,
+	name: "Name",
+	email: "Email",
+};
 
 function ConversationRow({
 	conversation,
 	selected,
+	search,
 	onSelect,
 }: {
 	conversation: Conversation;
 	selected: boolean;
+	/** Active (debounced) search term — drives the match snippet + highlight. */
+	search: string;
 	onSelect: () => void;
 }) {
 	const escalated = Boolean(conversation.escalatedAt);
@@ -65,18 +77,29 @@ function ConversationRow({
 						{timeAgo(conversation.updatedAt)}
 					</span>
 				</div>
-				<p
-					className={cn(
-						"truncate text-xs",
-						unread && !selected
-							? "font-medium text-foreground"
-							: "text-muted-foreground",
-					)}
-				>
-					{conversation.firstMessage?.trim() ||
-						conversation.email ||
-						"No messages yet"}
-				</p>
+				{conversation.match && search ? (
+					<p className="truncate text-xs text-muted-foreground">
+						{MATCH_LABEL[conversation.match.field] && (
+							<span className="mr-1 font-medium uppercase tracking-wide text-[10px] text-muted-foreground/70">
+								{MATCH_LABEL[conversation.match.field]}
+							</span>
+						)}
+						<Highlighted text={conversation.match.snippet} query={search} />
+					</p>
+				) : (
+					<p
+						className={cn(
+							"truncate text-xs",
+							unread && !selected
+								? "font-medium text-foreground"
+								: "text-muted-foreground",
+						)}
+					>
+						{conversation.firstMessage?.trim() ||
+							conversation.email ||
+							"No messages yet"}
+					</p>
+				)}
 				<div className="mt-0.5 flex items-center gap-1.5">
 					{escalated && (
 						<Badge variant="warning" className="h-4 px-1.5 text-[10px]">
@@ -129,6 +152,7 @@ export function ConversationList({
 								<ConversationRow
 									conversation={c}
 									selected={selectedId === c.id}
+									search={search}
 									onSelect={() => onSelect(c.id)}
 								/>
 							</li>

--- a/apps/dashboard/src/app/inbox/_components/highlight.test.tsx
+++ b/apps/dashboard/src/app/inbox/_components/highlight.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { Highlighted, highlightSegments } from "./highlight";
+
+describe("highlightSegments", () => {
+	it("splits around a case-insensitive hit", () => {
+		expect(highlightSegments("Our Refund policy", "refund")).toEqual([
+			{ text: "Our ", hit: false },
+			{ text: "Refund", hit: true },
+			{ text: " policy", hit: false },
+		]);
+	});
+
+	it("highlights every occurrence", () => {
+		const segs = highlightSegments("refund then refund", "refund");
+		expect(segs.filter((s) => s.hit)).toHaveLength(2);
+	});
+
+	it("returns the whole string unhit for an empty query", () => {
+		expect(highlightSegments("anything", "")).toEqual([
+			{ text: "anything", hit: false },
+		]);
+	});
+
+	it("returns a single unhit segment when there's no match", () => {
+		expect(highlightSegments("hello", "zzz")).toEqual([
+			{ text: "hello", hit: false },
+		]);
+	});
+});
+
+describe("Highlighted (safe rendering)", () => {
+	it("wraps the matched span in <mark>", () => {
+		render(<Highlighted text="Our refund policy" query="refund" />);
+		const mark = screen.getByText("refund");
+		expect(mark.tagName).toBe("MARK");
+	});
+
+	it("escapes HTML in the snippet — no injection", () => {
+		const malicious = 'before <img src=x onerror="alert(1)"> refund after';
+		const { container } = render(
+			<Highlighted text={malicious} query="refund" />,
+		);
+		// The tag is rendered as inert text, not a real element.
+		expect(container.querySelector("img")).toBeNull();
+		expect(container.textContent).toContain("<img src=x onerror=");
+		// And the term is still highlighted.
+		expect(screen.getByText("refund").tagName).toBe("MARK");
+	});
+});

--- a/apps/dashboard/src/app/inbox/_components/highlight.tsx
+++ b/apps/dashboard/src/app/inbox/_components/highlight.tsx
@@ -1,0 +1,63 @@
+import { Fragment } from "react";
+
+export interface HighlightSegment {
+	text: string;
+	hit: boolean;
+}
+
+/**
+ * Split `text` into segments around every case-insensitive occurrence of
+ * `query`. Pure and exported for testing. An empty query yields a single
+ * non-hit segment (no highlighting).
+ */
+export function highlightSegments(
+	text: string,
+	query: string,
+): HighlightSegment[] {
+	const needle = query.trim().toLowerCase();
+	if (!needle) return text ? [{ text, hit: false }] : [];
+
+	const segments: HighlightSegment[] = [];
+	const haystack = text.toLowerCase();
+	let cursor = 0;
+	for (;;) {
+		const idx = haystack.indexOf(needle, cursor);
+		if (idx === -1) {
+			if (cursor < text.length) {
+				segments.push({ text: text.slice(cursor), hit: false });
+			}
+			break;
+		}
+		if (idx > cursor)
+			segments.push({ text: text.slice(cursor, idx), hit: false });
+		segments.push({ text: text.slice(idx, idx + needle.length), hit: true });
+		cursor = idx + needle.length;
+	}
+	return segments;
+}
+
+/**
+ * Render `text` with every occurrence of `query` wrapped in `<mark>`. The text
+ * segments are rendered as React string children, which React **auto-escapes**,
+ * so a message containing HTML (e.g. `<img onerror=…>`) shows as inert text and
+ * can never inject — we deliberately never use dangerouslySetInnerHTML here.
+ */
+export function Highlighted({ text, query }: { text: string; query: string }) {
+	const segments = highlightSegments(text, query);
+	return (
+		<>
+			{segments.map((seg, i) =>
+				seg.hit ? (
+					<mark
+						key={i}
+						className="rounded-[2px] bg-amber-200/80 px-0.5 text-foreground dark:bg-amber-400/30 dark:text-amber-50"
+					>
+						{seg.text}
+					</mark>
+				) : (
+					<Fragment key={i}>{seg.text}</Fragment>
+				),
+			)}
+		</>
+	);
+}

--- a/apps/dashboard/src/app/inbox/_components/types.ts
+++ b/apps/dashboard/src/app/inbox/_components/types.ts
@@ -17,6 +17,16 @@ export interface Conversation {
 	firstMessage?: string | null;
 	/** True when the current user hasn't seen the latest messages. */
 	unread?: boolean;
+	/** Why this conversation matched the active search: an excerpt + which field
+	 * it came from. Present only on search responses; null when nothing matched on
+	 * text (added by the list API). The snippet is plain text — render escaped. */
+	match?: SearchMatch | null;
+}
+
+/** Where a search term was found, with a short plain-text excerpt for context. */
+export interface SearchMatch {
+	field: "body" | "name" | "email";
+	snippet: string;
 }
 
 export interface Message {

--- a/apps/dashboard/src/app/inbox/page.tsx
+++ b/apps/dashboard/src/app/inbox/page.tsx
@@ -9,6 +9,7 @@ import { Badge } from "@/components/ui/badge";
 import { api, describeApiError } from "@/lib/api";
 import { resolveOnboardingState } from "@/lib/onboarding";
 import { resolveSelectedId } from "@/lib/selection";
+import { useDebouncedValue } from "@/lib/use-debounced-value";
 import { useWorkspace } from "@/lib/workspace";
 import { track, ANALYTICS_EVENTS } from "@/lib/analytics";
 
@@ -66,15 +67,23 @@ export default function InboxPage() {
 		setSelectedId(null);
 	}
 
+	// Debounce the search term so a server query only fires once the agent pauses
+	// typing — the term is matched server-side (visitor name/email + message body)
+	// and drives the conversation list + the per-row match snippets.
+	const debouncedSearch = useDebouncedValue(search.trim(), 250);
+
 	const conversations = useQuery({
-		queryKey: ["conversations", projectId],
+		queryKey: ["conversations", projectId, debouncedSearch],
 		enabled: !!projectId && !!workspaceId,
 		refetchInterval: 5_000,
-		queryFn: () =>
-			api<{ conversations: Conversation[] }>(
-				`/api/projects/${projectId}/conversations?limit=100`,
+		queryFn: () => {
+			const params = new URLSearchParams({ limit: "100" });
+			if (debouncedSearch) params.set("search", debouncedSearch);
+			return api<{ conversations: Conversation[] }>(
+				`/api/projects/${projectId}/conversations?${params.toString()}`,
 				{ workspaceId: workspaceId! },
-			),
+			);
+		},
 	});
 
 	const thread = useQuery({
@@ -93,19 +102,15 @@ export default function InboxPage() {
 		[conversations.data],
 	);
 
-	// Left list: archived view vs active, then a client-side text filter over the
-	// fields the visitor sees (name, email, first message).
-	const visibleConversations = useMemo(() => {
-		const needle = search.trim().toLowerCase();
-		return allConversations
-			.filter((c) => (showArchived ? c.archivedAt : !c.archivedAt))
-			.filter((c) => {
-				if (!needle) return true;
-				return [c.name, c.email, c.firstMessage]
-					.filter(Boolean)
-					.some((field) => field!.toLowerCase().includes(needle));
-			});
-	}, [allConversations, search, showArchived]);
+	// Left list: text search is server-side (name/email/message body); here we
+	// only split the returned matches into the active vs archived view.
+	const visibleConversations = useMemo(
+		() =>
+			allConversations.filter((c) =>
+				showArchived ? c.archivedAt : !c.archivedAt,
+			),
+		[allConversations, showArchived],
+	);
 
 	const selectedConv = allConversations.find((c) => c.id === selectedId);
 	const detailConv = thread.data?.conversation ?? selectedConv ?? null;
@@ -270,7 +275,7 @@ export default function InboxPage() {
 							conversations={visibleConversations}
 							selectedId={selectedId}
 							onSelect={handleSelect}
-							search={search}
+							search={debouncedSearch}
 							showArchived={showArchived}
 						/>
 					)}

--- a/apps/dashboard/src/lib/use-debounced-value.ts
+++ b/apps/dashboard/src/lib/use-debounced-value.ts
@@ -1,0 +1,15 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Returns `value` after it has stopped changing for `delayMs`. Used to keep the
+ * inbox search from firing a server query on every keystroke — the request only
+ * goes out once the user pauses typing.
+ */
+export function useDebouncedValue<T>(value: T, delayMs: number): T {
+	const [debounced, setDebounced] = useState(value);
+	useEffect(() => {
+		const timer = setTimeout(() => setDebounced(value), delayMs);
+		return () => clearTimeout(timer);
+	}, [value, delayMs]);
+	return debounced;
+}


### PR DESCRIPTION
## What

Extends inbox search to match **message body text**, additively — searching a term now surfaces any conversation containing it in any message (visitor *or* agent), and still matches visitor **name + email**. Each result shows a **highlighted snippet** of the hit so the agent sees *why* it matched.

## Server-side, scoped, safe

The old search was effectively dead client-side (it filtered name/email/first-message over a fetched page) and the unused server branch scanned messages **unscoped** and *after* pagination. This moves search to the API and fixes both:

- **Scoped:** message matching `INNER JOIN`s `conversation` and filters `projectId` — it only ever touches the current project's messages. Behind `requireSession` + `requireWorkspace`, with the project→workspace ownership chain re-validated (foreign project → 404). A term living only in another workspace can't surface.
- **Safe SQL:** parameterized `LIKE` (bound value, no injection) with `ESCAPE '\'` so `%`/`_` match literally.
- **Pre-pagination + bounded:** matching happens in the `WHERE` before `LIMIT/OFFSET` (spans the whole project), membership set capped at `MAX_MATCH_CONVERSATIONS`.

## Result UX — highlighted snippets

Per match the API returns `{ field: "body" | "name" | "email", snippet }`: a short, whitespace-collapsed excerpt around the first hit (`…` at clipped ends). The client highlights the term with `<mark>` rendered over **React text children (auto-escaped)** — a message containing `<img onerror=…>` renders as inert text; **no `dangerouslySetInnerHTML`**. Name/email matches get a labeled tag so the agent sees those too. Search input is **debounced 250ms** and sent as `?search=`.

## Index?

None warranted — a leading-wildcard `LIKE '%term%'` can't use a B-tree index, so an index on `message.content` wouldn't help; the existing `message_conv_seq` covers the join. **FTS5** is the future path if volume ever demands it (out of scope).

## Tests
- **API:** body-text match; scoping (foreign project 404; content-search queries are join-scoped — no unscoped scan); name + email still match; empty results; role-gated (401 / 403 / 200); `buildSnippet`/`escapeLike`/`includesCI` units.
- **Dashboard:** `highlightSegments` spans; `<mark>` rendering; **HTML escaped (no injection)**; match snippet replaces the preview; name/email match labeled.

## Gate
✅ `pnpm test` (api + dashboard + widget) · ✅ dashboard build/typecheck + bundle check · ✅ api `tsc` · ✅ `pnpm lint` (0 errors; only pre-existing warnings) · ✅ `pnpm format` · ✅ secret-scan clean.

Do not merge — for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)