### PR TITLE
fix(inbox): filter active/archived server-side, scoped + composing with search

### DIFF
--- a/apps/api/src/routes/conversations.test.ts
+++ b/apps/api/src/routes/conversations.test.ts
@@ -1,3 +1,4 @@
+import { SQLiteSyncDialect } from "drizzle-orm/sqlite-core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { db } from "@/lib/db";
@@ -5,6 +6,15 @@ import { db } from "@/lib/db";
 import { conversation, message, readStatus } from "@llmchat/db";
 
 import { conversations } from "./conversations";
+
+// Render a captured drizzle WHERE to SQL text so tests can assert on the actual
+// generated predicate (active vs archived, project scoping) rather than trusting
+// the fake db to evaluate it.
+const dialect = new SQLiteSyncDialect({ casing: "snake_case" });
+function whereSql(): string {
+	if (!lastConversationWhere) return "";
+	return dialect.sqlToQuery(lastConversationWhere).sql.toLowerCase();
+}
 
 // Header-driven fake session (same pattern as projects.test): `x-test-user`
 // present ⇒ signed in; `query.member.findFirst` decides workspace membership.
@@ -45,9 +55,12 @@ interface State {
 /** Records the shape of every message-table query so tests can assert the
  * content-search queries are scoped via a conversation join. */
 let messageQueries: { distinct: boolean; joined: boolean }[];
+/** The WHERE passed to the main conversation list query, for SQL inspection. */
+let lastConversationWhere: Parameters<typeof dialect.sqlToQuery>[0] | null;
 
 function mockDb(state: State) {
 	messageQueries = [];
+	lastConversationWhere = null;
 
 	function builder(distinct: boolean) {
 		const q = { table: null as unknown, joined: false };
@@ -74,7 +87,12 @@ function mockDb(state: State) {
 				q.joined = true;
 				return chain;
 			},
-			where() {
+			where(cond: unknown) {
+				if (q.table === conversation) {
+					lastConversationWhere = cond as Parameters<
+						typeof dialect.sqlToQuery
+					>[0];
+				}
 				return chain;
 			},
 			orderBy() {
@@ -265,5 +283,56 @@ describe("inbox search — matching", () => {
 		};
 		expect(body.conversations[0]!.match).toBeNull();
 		expect(body.conversations[0]!.firstMessage).toBe("hello there");
+	});
+});
+
+describe("inbox archived filter", () => {
+	it("defaults to the active view — WHERE keeps only non-archived rows, scoped to the project", async () => {
+		mockDb({ role: "agent", project: PROJECT, conversationRows: [] });
+		const res = await get("/projects/p1/conversations", MEMBER);
+		expect(res.status).toBe(200);
+		const sql = whereSql();
+		expect(sql).toContain('"archived_at" is null');
+		expect(sql).not.toContain("is not null");
+		// Always project-scoped (no cross-workspace leak).
+		expect(sql).toContain('"project_id"');
+	});
+
+	it("archived=true returns only archived rows (archived_at is not null)", async () => {
+		mockDb({ role: "agent", project: PROJECT, conversationRows: [] });
+		const res = await get("/projects/p1/conversations?archived=true", MEMBER);
+		expect(res.status).toBe(200);
+		const sql = whereSql();
+		expect(sql).toContain('"archived_at" is not null');
+	});
+
+	it("archived=false is treated as the active view", async () => {
+		mockDb({ role: "agent", project: PROJECT, conversationRows: [] });
+		await get("/projects/p1/conversations?archived=false", MEMBER);
+		const sql = whereSql();
+		expect(sql).toContain('"archived_at" is null');
+		expect(sql).not.toContain("is not null");
+	});
+
+	it("composes with search — archived view AND a text match in the same WHERE", async () => {
+		mockDb({
+			role: "agent",
+			project: PROJECT,
+			conversationRows: [],
+			bodyMatchIds: ["cZ"],
+		});
+		await get("/projects/p1/conversations?archived=true&search=refund", MEMBER);
+		const sql = whereSql();
+		// The archived predicate and the search OR-group coexist, project-scoped.
+		expect(sql).toContain('"archived_at" is not null');
+		expect(sql).toContain("like");
+		expect(sql).toContain('"project_id"');
+	});
+
+	it("is role-gated: a non-member can't list archived (403, no query)", async () => {
+		mockDb({}); // not a member
+		const res = await get("/projects/p1/conversations?archived=true", MEMBER);
+		expect(res.status).toBe(403);
+		expect(lastConversationWhere).toBeNull();
 	});
 });

--- a/apps/api/src/routes/conversations.ts
+++ b/apps/api/src/routes/conversations.ts
@@ -23,6 +23,8 @@ import {
 	desc,
 	eq,
 	inArray,
+	isNotNull,
+	isNull,
 	message as messageTable,
 	or,
 	readStatus,
@@ -63,16 +65,16 @@ export const conversations = new Hono<AppContext>()
 
 			const term = search?.trim() ?? "";
 
-			const conditions = [eq(conversation.projectId, projectId)];
-			if (archived === "true") {
-				conditions.push(
-					// archivedAt IS NOT NULL
-					// drizzle has isNotNull but we can also do gte epoch 0
-					// keep simple:
-					// eslint-disable-next-line @typescript-eslint/no-explicit-any
-					eq(conversation.archivedAt, conversation.archivedAt) as any,
-				);
-			}
+			// Active vs archived split, server-side and explicit: archived rows have
+			// a non-null archivedAt. Default (param absent or "false") is the active
+			// view. This goes into the WHERE before LIMIT/OFFSET and composes with
+			// the search OR-group below, so search runs within the chosen view.
+			const conditions = [
+				eq(conversation.projectId, projectId),
+				archived === "true"
+					? isNotNull(conversation.archivedAt)
+					: isNull(conversation.archivedAt),
+			];
 
 			// Content search: a conversation matches on visitor name, email, OR any
 			// message body. The message match is scoped to THIS project via a join

--- a/apps/dashboard/src/app/inbox/page.tsx
+++ b/apps/dashboard/src/app/inbox/page.tsx
@@ -73,12 +73,13 @@ export default function InboxPage() {
 	const debouncedSearch = useDebouncedValue(search.trim(), 250);
 
 	const conversations = useQuery({
-		queryKey: ["conversations", projectId, debouncedSearch],
+		queryKey: ["conversations", projectId, debouncedSearch, showArchived],
 		enabled: !!projectId && !!workspaceId,
 		refetchInterval: 5_000,
 		queryFn: () => {
 			const params = new URLSearchParams({ limit: "100" });
 			if (debouncedSearch) params.set("search", debouncedSearch);
+			if (showArchived) params.set("archived", "true");
 			return api<{ conversations: Conversation[] }>(
 				`/api/projects/${projectId}/conversations?${params.toString()}`,
 				{ workspaceId: workspaceId! },
@@ -97,19 +98,12 @@ export default function InboxPage() {
 			),
 	});
 
+	// Both filters are server-side now: text search (name/email/message body) and
+	// the active-vs-archived split. The returned rows are exactly what the list
+	// should show, so there's no client-side filtering left to do.
 	const allConversations = useMemo(
 		() => conversations.data?.conversations ?? [],
 		[conversations.data],
-	);
-
-	// Left list: text search is server-side (name/email/message body); here we
-	// only split the returned matches into the active vs archived view.
-	const visibleConversations = useMemo(
-		() =>
-			allConversations.filter((c) =>
-				showArchived ? c.archivedAt : !c.archivedAt,
-			),
-		[allConversations, showArchived],
 	);
 
 	const selectedConv = allConversations.find((c) => c.id === selectedId);
@@ -272,7 +266,7 @@ export default function InboxPage() {
 						<ConversationListSkeleton />
 					) : (
 						<ConversationList
-							conversations={visibleConversations}
+							conversations={allConversations}
 							selectedId={selectedId}
 							onSelect={handleSelect}
 							search={debouncedSearch}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -20,5 +20,7 @@ export {
 	like,
 	count,
 	inArray,
+	isNull,
+	isNotNull,
 	gte,
 } from "drizzle-orm";


### PR DESCRIPTION
## What was broken

The inbox active-vs-archived split was not done correctly server-side:

- `conversations.ts` only added a filter for `archived=true`, and that filter was `eq(conversation.archivedAt, conversation.archivedAt)` cast `as any`. It returns archived-only *by accident* of `NULL = NULL` being NULL (falsy) — fragile, opaque, `as any`.
- For the **active/default** case (`archived` omitted or `"false"`) it added **no condition**, so the server returned **both** active and archived rows. `archived=false` was effectively **ignored**.
- The real split happened **client-side** (`page.tsx`: `filter(c => showArchived ? c.archivedAt : !c.archivedAt)`) over a `?limit=100` fetch — a post-fetch filter that, combined with the now `LIMIT`-bounded server search, lets archived rows eat page slots the client then hides.

## Fix

- **Server:** always push an explicit archived predicate into the `WHERE` (before `LIMIT/OFFSET`, composing with the search OR-group): default/`false` → `isNull(archivedAt)` (active), `true` → `isNotNull(archivedAt)` (archived). Dropped the `as any` hack. Project→workspace ownership + `requireSession`/`requireWorkspace` unchanged.
- **Client:** send `archived=true` when viewing archived, add it to the React Query key, and delete the client-side filter (server owns the split now).
- Re-export `isNull`/`isNotNull` from `@llmchat/db`.

## Tests

The route tests render the **actual generated `WHERE`** (via `SQLiteSyncDialect` with `snake_case`) and assert: active default → `archived_at is null`; `archived=true` → `archived_at is not null`; `archived=false` → active; **search + archived compose** (both predicates + `like`, project-scoped) in one WHERE; project-scoped; role-gated (non-member → 403, no query issued). Existing search tests still pass.

## Gate
✅ `pnpm test` (api + dashboard + widget) · ✅ dashboard build + api `tsc` · ✅ `pnpm lint` (0 errors) · ✅ `pnpm format` · ✅ secret-scan clean.

Do not merge — for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)