### PR TITLE
feat(inbox): highlight search term inside the open conversation thread

### DIFF
--- a/apps/dashboard/src/app/inbox/_components/MessageThread.test.tsx
+++ b/apps/dashboard/src/app/inbox/_components/MessageThread.test.tsx
@@ -1,5 +1,5 @@
 import { act, render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { MessageThread } from "./MessageThread";
 
@@ -227,5 +227,121 @@ describe("MessageThread auto-scroll (useStickToBottom)", () => {
 		expect(
 			container.querySelector('[aria-label="Scroll to latest message"]'),
 		).toBeInTheDocument();
+	});
+});
+
+describe("MessageThread search highlighting", () => {
+	// jsdom has no layout and doesn't implement scrollIntoView; install a spy so
+	// the scroll-to-first-hit effect runs (and is assertable) like in a browser.
+	let scrollSpy: ReturnType<typeof vi.fn>;
+	beforeEach(() => {
+		scrollSpy = vi.fn();
+		Element.prototype.scrollIntoView = scrollSpy;
+	});
+	afterEach(() => {
+		delete (Element.prototype as { scrollIntoView?: unknown }).scrollIntoView;
+	});
+
+	function lowerMarks(container: HTMLElement): string[] {
+		return [...container.querySelectorAll("mark")].map((m) =>
+			(m.textContent ?? "").toLowerCase(),
+		);
+	}
+
+	it("highlights the term across visitor and bot messages (case-insensitive)", () => {
+		const { container } = render(
+			<MessageThread
+				messages={[
+					msg({ role: "user", content: "I want a Refund please", sequence: 1 }),
+					msg({
+						role: "assistant",
+						content: "Your refund is on the way",
+						sequence: 2,
+					}),
+				]}
+				search="refund"
+			/>,
+		);
+		const marks = lowerMarks(container);
+		expect(marks).toHaveLength(2);
+		expect(marks.every((t) => t === "refund")).toBe(true);
+	});
+
+	it("marks every occurrence within a single message", () => {
+		const { container } = render(
+			<MessageThread
+				messages={[msg({ content: "refund then refund again", sequence: 1 })]}
+				search="refund"
+			/>,
+		);
+		expect(container.querySelectorAll("mark")).toHaveLength(2);
+	});
+
+	it("escapes HTML in a message — highlighting can't inject", () => {
+		const { container } = render(
+			<MessageThread
+				messages={[
+					msg({
+						content: 'evil <img src=x onerror="alert(1)"> refund',
+						sequence: 1,
+					}),
+				]}
+				search="refund"
+			/>,
+		);
+		// The tag is inert text, not a real element…
+		expect(container.querySelector("img")).toBeNull();
+		expect(container.textContent).toContain("<img src=x onerror=");
+		// …and the term is still highlighted.
+		expect(lowerMarks(container)).toEqual(["refund"]);
+	});
+
+	it("renders no marks when the search term is empty (highlights clear)", () => {
+		const { container, rerender } = render(
+			<MessageThread
+				messages={[msg({ content: "a refund here", sequence: 1 })]}
+				search="refund"
+			/>,
+		);
+		expect(container.querySelectorAll("mark")).toHaveLength(1);
+
+		rerender(
+			<MessageThread
+				messages={[msg({ content: "a refund here", sequence: 1 })]}
+				search=""
+			/>,
+		);
+		expect(container.querySelectorAll("mark")).toHaveLength(0);
+	});
+
+	it("scrolls the first matching message into view on open", () => {
+		const { container } = render(
+			<MessageThread
+				messages={[
+					msg({ role: "user", content: "hello there", sequence: 1 }),
+					msg({
+						role: "assistant",
+						content: "about your refund policy",
+						sequence: 2,
+					}),
+					msg({ role: "user", content: "the refund again", sequence: 3 }),
+				]}
+				search="refund"
+			/>,
+		);
+		// Exactly one scroll, onto the FIRST matching message's bubble.
+		expect(scrollSpy).toHaveBeenCalledTimes(1);
+		const hit = container.querySelector('[data-search-hit="true"]');
+		expect(hit?.textContent).toContain("about your refund policy");
+		expect(scrollSpy.mock.contexts[0]).toBe(hit);
+	});
+
+	it("does not scroll when there's no active search term", () => {
+		render(
+			<MessageThread
+				messages={[msg({ content: "a refund here", sequence: 1 })]}
+			/>,
+		);
+		expect(scrollSpy).not.toHaveBeenCalled();
 	});
 });

--- a/apps/dashboard/src/app/inbox/_components/MessageThread.tsx
+++ b/apps/dashboard/src/app/inbox/_components/MessageThread.tsx
@@ -2,11 +2,19 @@
 
 import { useStickToBottom } from "@llmchat/widget/chat";
 import { ArrowDown, Headset, ThumbsDown, ThumbsUp } from "lucide-react";
+import { useEffect, useMemo } from "react";
 
 import { cn } from "@/lib/utils";
 
 import { formatMessageTime } from "./format";
+import { Highlighted } from "./highlight";
 import type { Message } from "./types";
+
+/** Case-insensitive "does this message contain the term" — used to find the
+ * first hit to scroll to. Mirrors the (case-insensitive) highlight matching. */
+function messageContains(content: string, term: string): boolean {
+	return content.toLowerCase().includes(term.toLowerCase());
+}
 
 /**
  * Visitor's per-message thumbs (answer quality) on an assistant reply. Shows
@@ -46,13 +54,24 @@ const ROLE = {
 	admin: { side: "right", label: "Admin", labelClass: "text-primary" },
 } as const;
 
-function MessageBubble({ message }: { message: Message }) {
+function MessageBubble({
+	message,
+	search,
+	firstHit,
+}: {
+	message: Message;
+	/** Active search term; occurrences are highlighted via the shared component. */
+	search: string;
+	/** True for the first message in the thread that matches — the scroll target. */
+	firstHit: boolean;
+}) {
 	const { side, label, labelClass } =
 		ROLE[message.role as keyof typeof ROLE] ?? ROLE.user;
 	const right = side === "right";
 	return (
 		<div
 			data-side={side}
+			data-search-hit={firstHit ? "true" : undefined}
 			className={cn("flex flex-col gap-1", right ? "items-end" : "items-start")}
 		>
 			<span className={cn("px-1 text-[11px] font-medium", labelClass)}>
@@ -68,7 +87,9 @@ function MessageBubble({ message }: { message: Message }) {
 						"rounded-br-sm bg-primary text-primary-foreground",
 				)}
 			>
-				<p className="whitespace-pre-wrap break-words">{message.content}</p>
+				<p className="whitespace-pre-wrap break-words">
+					<Highlighted text={message.content} query={search} />
+				</p>
 			</div>
 			<span className="px-1 text-[11px] text-muted-foreground">
 				{formatMessageTime(message.createdAt)}
@@ -80,7 +101,15 @@ function MessageBubble({ message }: { message: Message }) {
 	);
 }
 
-export function MessageThread({ messages }: { messages: Message[] }) {
+export function MessageThread({
+	messages,
+	search = "",
+}: {
+	messages: Message[];
+	/** Active inbox search term. When set, every occurrence is highlighted in the
+	 * thread and the first matching message is scrolled into view on open. */
+	search?: string;
+}) {
 	const { containerRef, atBottom, scrollToBottom } =
 		useStickToBottom<HTMLDivElement>({
 			// New messages (inbound or replies) — the inbox doesn't token-stream,
@@ -91,6 +120,27 @@ export function MessageThread({ messages }: { messages: Message[] }) {
 			sendKey: messages.reduce((id, m) => (m.role === "admin" ? m.id : id), ""),
 		});
 
+	// The first message (in order) containing the term — the scroll target. A
+	// stable id, so the scroll effect below fires once per open/term-change, not
+	// on every 3s poll. Null when not searching or nothing matches.
+	const firstHitId = useMemo(() => {
+		const term = search.trim();
+		if (!term) return null;
+		return messages.find((m) => messageContains(m.content, term))?.id ?? null;
+	}, [messages, search]);
+
+	// Bring the first hit into view when a conversation opens with an active
+	// term. One-shot per first-hit id — it doesn't re-fire on polls. This leaves
+	// the user mid-thread, which sets stick-to-bottom's `pinned` false, so later
+	// inbound messages won't yank to the bottom (the two cooperate, never fight).
+	useEffect(() => {
+		if (!firstHitId) return;
+		const hit = containerRef.current?.querySelector<HTMLElement>(
+			'[data-search-hit="true"]',
+		);
+		hit?.scrollIntoView({ block: "center" });
+	}, [firstHitId, containerRef]);
+
 	return (
 		<div
 			ref={containerRef}
@@ -100,16 +150,24 @@ export function MessageThread({ messages }: { messages: Message[] }) {
 				m.role === "system" ? (
 					<div
 						key={m.id}
+						data-search-hit={m.id === firstHitId ? "true" : undefined}
 						className="mx-auto my-1 flex max-w-[80%] items-center gap-2 rounded-lg border bg-muted/40 px-3 py-2 text-xs text-muted-foreground"
 					>
 						<Headset className="size-4 shrink-0 text-amber-500" />
-						<span className="flex-1">{m.content}</span>
+						<span className="flex-1">
+							<Highlighted text={m.content} query={search} />
+						</span>
 						<span className="shrink-0 tabular-nums text-muted-foreground/70">
 							{formatMessageTime(m.createdAt)}
 						</span>
 					</div>
 				) : (
-					<MessageBubble key={m.id} message={m} />
+					<MessageBubble
+						key={m.id}
+						message={m}
+						search={search}
+						firstHit={m.id === firstHitId}
+					/>
 				),
 			)}
 			{messages.length === 0 && (

--- a/apps/dashboard/src/app/inbox/page.tsx
+++ b/apps/dashboard/src/app/inbox/page.tsx
@@ -296,7 +296,10 @@ export default function InboxPage() {
 								)}
 							</div>
 							{thread.data ? (
-								<MessageThread messages={thread.data.messages} />
+								<MessageThread
+									messages={thread.data.messages}
+									search={debouncedSearch}
+								/>
 							) : (
 								<div className="flex flex-1 items-center justify-center text-sm text-muted-foreground">
 									Loading…


### PR DESCRIPTION
## What

Search highlighting now extends from the conversation-list snippet **into the open thread**. With an active search term, every occurrence is highlighted inside the open conversation's messages (visitor, bot, admin, and system notes), and the first match is scrolled into view on open — so a buried hit is found without manual scrolling.

## Reuse, not duplication

Message bodies render through the **existing** `<Highlighted text={content} query={search} />` (the same component + `highlightSegments` the list snippet uses). That means, for free:
- `<mark>` over **auto-escaped React text** — no `dangerouslySetInnerHTML`, so HTML in a message stays inert.
- Case-insensitive matching and the same amber `<mark>` styling (legible on every bubble type in dark mode via `text-foreground`).
- With an empty query, `Highlighted` returns the text as a single fragment, so non-search rendering is identical to before and **clears all marks** the moment the term is gone (search-mode only).

## Auto-scroll cooperates with stick-to-bottom (doesn't fight)

`useStickToBottom` does nothing on mount and only acts on content *growth while pinned* or the agent's own send. The scroll-to-first-hit is a **separate one-shot effect keyed on the first-hit message id** (a stable derived string), so it fires once per open / term-change — **not** on the 3s poll. After it centers the hit, the hook's scroll listener observes the mid-thread position and sets `pinned = false`, so subsequent inbound messages won't yank to bottom. No term (or no hit) → effect early-returns, behavior unchanged.

## Tests
Term highlighted across visitor+bot messages; every occurrence within a message marked; **HTML escaped (no injection)**; marks clear on empty search; **scroll-to-first-hit lands on the first match** (asserts the spy's call context is the `data-search-hit` element); no scroll without a term. The 6 existing stick-to-bottom tests are untouched and still pass.

## Gate
✅ `pnpm test` (api + dashboard + widget) · ✅ dashboard build/typecheck + bundle check · ✅ `pnpm lint` (0 errors) · ✅ `pnpm format` · ✅ secret-scan clean.

Do not merge — for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)