### PR TITLE
feat(dashboard): responsive shell + simple surfaces (PR 1/3)

### DIFF
--- a/apps/dashboard/src/app/settings/billing/_components/TierGrid.tsx
+++ b/apps/dashboard/src/app/settings/billing/_components/TierGrid.tsx
@@ -34,7 +34,7 @@ export function TierGrid({
 	ctaPrefix?: string;
 }) {
 	return (
-		<div className="grid gap-4 md:grid-cols-3">
+		<div className="grid gap-4 lg:grid-cols-3">
 			{TIERS.map((tier) => {
 				const isCurrent = currentPlan === tier.plan;
 				const available = !availablePlans || availablePlans.includes(tier.plan);

--- a/apps/dashboard/src/app/settings/projects/[id]/page.tsx
+++ b/apps/dashboard/src/app/settings/projects/[id]/page.tsx
@@ -101,7 +101,7 @@ export default function ProjectSettingsPage() {
 			<div className="min-h-svh">
 				<div className="mx-auto flex max-w-[1400px] flex-col gap-6 px-6 py-8 lg:flex-row">
 					<div className="flex flex-1 flex-col gap-6">
-						<Skeleton className="h-20 w-80" />
+						<Skeleton className="h-20 w-full sm:w-80" />
 						<Skeleton className="h-48 w-full rounded-2xl" />
 						<Skeleton className="h-40 w-full rounded-2xl" />
 					</div>

--- a/apps/dashboard/src/components/dashboard-shell.tsx
+++ b/apps/dashboard/src/components/dashboard-shell.tsx
@@ -51,7 +51,8 @@ export function DashboardShell({
 			<SidebarInset className="bg-background">
 				{/* Mobile-only bar to open the sidebar drawer; desktop matches the mockup with no top bar. */}
 				<header className="sticky top-0 z-10 flex h-12 items-center gap-2 border-b bg-background/80 px-4 backdrop-blur-md md:hidden">
-					<SidebarTrigger className="-ml-1" />
+					{/* Finger-sized (40px) — this is the only way to open the nav on a phone. */}
+					<SidebarTrigger className="-ml-1 size-10" />
 					<BrandLogo className="size-6" />
 					<span className="font-display font-semibold tracking-tight-display">
 						Clanker Support

--- a/apps/dashboard/src/components/ui/sidebar.test.tsx
+++ b/apps/dashboard/src/components/ui/sidebar.test.tsx
@@ -1,0 +1,80 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { SidebarProvider, SidebarTrigger, useSidebar } from "./sidebar";
+
+// The drawer-vs-docked decision is driven by the viewport hook; mock it so each
+// test can pin "mobile" or "desktop" deterministically (jsdom has no layout).
+const isMobile = vi.fn();
+vi.mock("@/hooks/use-mobile", () => ({
+	useIsMobile: () => isMobile(),
+}));
+
+afterEach(() => {
+	isMobile.mockReset();
+});
+
+/** Surfaces the sidebar context so tests can assert open/close state directly,
+ * without depending on the Radix Sheet portal rendering. */
+function Probe() {
+	const { isMobile: mobile, open, openMobile, state } = useSidebar();
+	return (
+		<div>
+			<span data-testid="state">{state}</span>
+			<span data-testid="open">{String(open)}</span>
+			<span data-testid="openMobile">{String(openMobile)}</span>
+			<span data-testid="isMobile">{String(mobile)}</span>
+		</div>
+	);
+}
+
+function setup() {
+	return render(
+		<SidebarProvider>
+			<SidebarTrigger />
+			<Probe />
+		</SidebarProvider>,
+	);
+}
+
+describe("Sidebar drawer open/close", () => {
+	it("on mobile: the trigger opens then closes the drawer (openMobile), leaving the docked state untouched", async () => {
+		isMobile.mockReturnValue(true);
+		const user = userEvent.setup();
+		setup();
+
+		// Drawer starts closed — no yank-open on mount.
+		expect(screen.getByTestId("isMobile")).toHaveTextContent("true");
+		expect(screen.getByTestId("openMobile")).toHaveTextContent("false");
+
+		await user.click(screen.getByRole("button", { name: /toggle sidebar/i }));
+		expect(screen.getByTestId("openMobile")).toHaveTextContent("true");
+
+		await user.click(screen.getByRole("button", { name: /toggle sidebar/i }));
+		expect(screen.getByTestId("openMobile")).toHaveTextContent("false");
+
+		// The desktop docked state is never touched by the mobile drawer toggle.
+		expect(screen.getByTestId("open")).toHaveTextContent("true");
+		expect(screen.getByTestId("state")).toHaveTextContent("expanded");
+	});
+
+	it("on desktop: the trigger collapses then expands the docked sidebar (not the drawer)", async () => {
+		isMobile.mockReturnValue(false);
+		const user = userEvent.setup();
+		setup();
+
+		expect(screen.getByTestId("isMobile")).toHaveTextContent("false");
+		expect(screen.getByTestId("state")).toHaveTextContent("expanded");
+
+		await user.click(screen.getByRole("button", { name: /toggle sidebar/i }));
+		expect(screen.getByTestId("open")).toHaveTextContent("false");
+		expect(screen.getByTestId("state")).toHaveTextContent("collapsed");
+
+		await user.click(screen.getByRole("button", { name: /toggle sidebar/i }));
+		expect(screen.getByTestId("state")).toHaveTextContent("expanded");
+
+		// The mobile drawer stays closed throughout a desktop toggle.
+		expect(screen.getByTestId("openMobile")).toHaveTextContent("false");
+	});
+});


### PR DESCRIPTION
**PR 1 of 3** in the responsive-dashboard series. Scope: the shared shell + the *simple* surfaces. Inbox and onboarding are intentionally deferred to their own PRs.

## Audit first
I read every in-scope surface before touching anything. The headline: the dashboard was already built **mobile-first** — the shadcn sidebar collapses to a `Sheet` drawer with a hamburger, billing/projects grids stack, auth is a `lg:grid-cols-2` split that collapses to one column, and long content (URLs, embed code, config summary) already uses `min-w-0`/`truncate`/`overflow-x-auto`. So this PR is **verification + three targeted fixes**, not a rewrite, and adds **no mobile forks**.

## Gaps found & fixed
| Issue | Fix |
|---|---|
| Mobile nav trigger was a **28px** tap target (`h-7 w-7`) — the only way to open nav on a phone | bump to `size-10` (40px); header is `h-12` so it fits |
| Pricing tiers (`md:grid-cols-3`) crammed **3-across in the ~512px tablet content area** at the 768 breakpoint | `md:` → `lg:grid-cols-3` (stack until desktop) |
| Project-config loading skeleton `w-80` (320px) **overflowed** the 312px content column at 360px | `w-full sm:w-80` |

## How each surface adapts (360 / 390 / 768 / 1024+)
- **Shell** — drawer + hamburger below `md`; docked sidebar at `md+`. Content full-width.
- **Billing** — current-plan/usage stack below `md`; tiers now stack until `lg` (no tablet cram).
- **Projects** — list `grid-cols-1 sm:grid-cols-2 lg:grid-cols-3`; `[id]` config stacks `flex-col` and goes side-by-side with a sticky aside at `lg`.
- **Auth** — brand panel `hidden lg:flex`; single centered form column below `lg`.

## Tests
New `src/components/ui/sidebar.test.tsx` covers the **drawer open/close logic** — the one piece of real interactive logic:
- mobile: trigger opens then closes `openMobile`, leaving the docked state untouched, and no yank-open on mount;
- desktop: trigger collapses/expands the docked sidebar without ever opening the mobile drawer.

## Gate
- `vitest run` (dashboard): **215 passed / 27 files** (incl. 2 new).
- `next build` + bundle check: ✓ clean.
- Prettier: changed files clean. Oxlint: no new warnings.
- Secret-scan: clean.

The pre-existing `packages/shared/src/consent.ts` prettier drift on `main` is left untouched to keep this PR atomic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)