### PR TITLE
feat(inbox): one-pane-at-a-time mobile/tablet layout (PR 2/3)

### DIFF
--- a/apps/dashboard/src/app/inbox/_components/InboxPanes.test.tsx
+++ b/apps/dashboard/src/app/inbox/_components/InboxPanes.test.tsx
@@ -1,0 +1,233 @@
+import { act, render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { InboxPanes, type InboxPanesProps } from "./InboxPanes";
+import { MessageThread } from "./MessageThread";
+import type { Message } from "./types";
+
+function renderPanes(overrides: Partial<InboxPanesProps> = {}) {
+	const props: InboxPanesProps = {
+		hasSelection: false,
+		onBack: vi.fn(),
+		detailsOpen: false,
+		onDetailsOpenChange: vi.fn(),
+		list: <div data-testid="list">LIST</div>,
+		threadHeader: <div data-testid="thread-header">HEADER</div>,
+		threadBody: <div data-testid="thread-body">BODY</div>,
+		composer: <div data-testid="composer">COMPOSER</div>,
+		details: <div data-testid="details">DETAILS</div>,
+		emptyState: <div data-testid="empty">Select a conversation</div>,
+		detailsEmptyState: <div data-testid="details-empty">No details</div>,
+		...overrides,
+	};
+	return { props, ...render(<InboxPanes {...props} />) };
+}
+
+const back = () =>
+	screen.getByRole("button", { name: /back to conversations/i });
+const backQuery = () =>
+	screen.queryByRole("button", { name: /back to conversations/i });
+const detailsBtn = () =>
+	screen.queryByRole("button", { name: /conversation details/i });
+
+describe("InboxPanes navigation (list ↔ thread ↔ back)", () => {
+	it("with no selection shows the list and the empty state — no thread chrome", () => {
+		renderPanes({ hasSelection: false });
+		expect(screen.getByTestId("list")).toBeInTheDocument();
+		expect(screen.getByTestId("empty")).toBeInTheDocument();
+		// The thread header/body/composer and the back button only exist once open.
+		expect(screen.queryByTestId("thread-body")).not.toBeInTheDocument();
+		expect(screen.queryByTestId("composer")).not.toBeInTheDocument();
+		expect(backQuery()).not.toBeInTheDocument();
+		expect(detailsBtn()).not.toBeInTheDocument();
+	});
+
+	it("with a selection reveals the thread (header + body + composer) and a back button", () => {
+		renderPanes({ hasSelection: true });
+		expect(screen.getByTestId("thread-header")).toBeInTheDocument();
+		expect(screen.getByTestId("thread-body")).toBeInTheDocument();
+		expect(screen.getByTestId("composer")).toBeInTheDocument();
+		expect(back()).toBeInTheDocument();
+		// The list stays mounted (CSS-hidden on mobile) so it never re-fetches/re-scrolls.
+		expect(screen.getByTestId("list")).toBeInTheDocument();
+	});
+
+	it("the back button returns to the list (calls onBack)", async () => {
+		const onBack = vi.fn();
+		renderPanes({ hasSelection: true, onBack });
+		await userEvent.click(back());
+		expect(onBack).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe("InboxPanes contact-details toggle", () => {
+	it("the details button opens the sheet (calls onDetailsOpenChange)", async () => {
+		const onDetailsOpenChange = vi.fn();
+		renderPanes({ hasSelection: true, onDetailsOpenChange });
+		const btn = detailsBtn();
+		expect(btn).toBeInTheDocument();
+		await userEvent.click(btn!);
+		expect(onDetailsOpenChange).toHaveBeenCalledWith(true);
+	});
+
+	it("renders no details affordance when there is no details panel", () => {
+		renderPanes({ hasSelection: true, details: null });
+		expect(detailsBtn()).not.toBeInTheDocument();
+	});
+
+	it("the details sheet (a dialog) appears only when open", () => {
+		const { rerender, props } = renderPanes({
+			hasSelection: true,
+			detailsOpen: false,
+		});
+		expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+
+		rerender(<InboxPanes {...props} hasSelection detailsOpen />);
+		const dialog = screen.getByRole("dialog");
+		expect(within(dialog).getByTestId("details")).toBeInTheDocument();
+	});
+});
+
+/**
+ * jsdom has no layout. Install a controllable scroll model so the reused
+ * stick-to-bottom hook (inside MessageThread) behaves like a real container.
+ */
+function mockScroll(
+	el: HTMLElement,
+	{
+		scrollHeight,
+		clientHeight,
+	}: { scrollHeight: number; clientHeight: number },
+) {
+	let top = 0;
+	Object.defineProperty(el, "scrollHeight", {
+		configurable: true,
+		get: () => scrollHeight,
+	});
+	Object.defineProperty(el, "clientHeight", {
+		configurable: true,
+		get: () => clientHeight,
+	});
+	Object.defineProperty(el, "scrollTop", {
+		configurable: true,
+		get: () => top,
+		set: (v: number) => {
+			top = v;
+		},
+	});
+	return {
+		setTop(v: number) {
+			top = v;
+			act(() => el.dispatchEvent(new Event("scroll")));
+		},
+		get top() {
+			return top;
+		},
+	};
+}
+
+function msg(overrides: Partial<Message>): Message {
+	return {
+		id: crypto.randomUUID(),
+		role: "user",
+		content: "hello",
+		sequence: 1,
+		createdAt: "2026-06-16T05:00:00.000Z",
+		...overrides,
+	};
+}
+
+/** The MessageThread scroll container, as mounted inside the thread pane. */
+function threadScroller(container: HTMLElement): HTMLElement {
+	return container.querySelector<HTMLElement>(
+		'[data-pane="thread"] .overflow-y-auto',
+	)!;
+}
+
+describe("InboxPanes reuses MessageThread search + scroll logic in the mobile thread", () => {
+	// MessageThread scrolls the first hit into view; jsdom lacks scrollIntoView.
+	let scrollSpy: ReturnType<typeof vi.fn>;
+	beforeEach(() => {
+		scrollSpy = vi.fn();
+		Element.prototype.scrollIntoView = scrollSpy;
+	});
+	afterEach(() => {
+		delete (Element.prototype as { scrollIntoView?: unknown }).scrollIntoView;
+	});
+
+	it("highlights the active term and scrolls to the first hit inside the thread pane", () => {
+		const { container } = renderPanes({
+			hasSelection: true,
+			details: null,
+			threadBody: (
+				<MessageThread
+					messages={[
+						msg({ role: "user", content: "I want a Refund", sequence: 1 }),
+						msg({
+							role: "assistant",
+							content: "your refund is processing",
+							sequence: 2,
+						}),
+					]}
+					search="refund"
+				/>
+			),
+		});
+		// Highlight component reused: every occurrence marked (case-insensitive).
+		const marks = [...container.querySelectorAll("mark")].map((m) =>
+			(m.textContent ?? "").toLowerCase(),
+		);
+		expect(marks).toEqual(["refund", "refund"]);
+		// Scroll-to-first-hit reused: exactly one scroll, onto the first match.
+		expect(scrollSpy).toHaveBeenCalledTimes(1);
+		const hit = container.querySelector('[data-search-hit="true"]');
+		expect(hit?.textContent).toContain("I want a Refund");
+	});
+
+	it("keeps stick-to-bottom: follows the agent's own reply but not inbound while scrolled up", () => {
+		const base = [
+			msg({ content: "hi", sequence: 1 }),
+			msg({ role: "assistant", content: "hello", sequence: 2 }),
+		];
+		// Re-rendering with a fresh MessageThread in the same DOM position swaps the
+		// messages prop without remounting — exactly like a live inbox refetch.
+		const { container, props, rerender } = renderPanes({
+			hasSelection: true,
+			details: null,
+			threadBody: <MessageThread messages={base} />,
+		});
+		const el = threadScroller(container);
+		const s = mockScroll(el, { scrollHeight: 1000, clientHeight: 400 });
+		s.setTop(0); // agent has scrolled up reading history
+
+		// An inbound visitor message must NOT yank them to the bottom.
+		rerender(
+			<InboxPanes
+				{...props}
+				threadBody={
+					<MessageThread
+						messages={[...base, msg({ content: "ping", sequence: 3 })]}
+					/>
+				}
+			/>,
+		);
+		expect(s.top).toBe(0);
+
+		// The agent's own reply (role admin) DOES follow to the bottom.
+		rerender(
+			<InboxPanes
+				{...props}
+				threadBody={
+					<MessageThread
+						messages={[
+							...base,
+							msg({ role: "admin", content: "on it", sequence: 3 }),
+						]}
+					/>
+				}
+			/>,
+		);
+		expect(s.top).toBe(1000);
+	});
+});

--- a/apps/dashboard/src/app/inbox/_components/InboxPanes.tsx
+++ b/apps/dashboard/src/app/inbox/_components/InboxPanes.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import { ChevronLeft, Info } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+	Sheet,
+	SheetContent,
+	SheetDescription,
+	SheetHeader,
+	SheetTitle,
+} from "@/components/ui/sheet";
+import { cn } from "@/lib/utils";
+
+export interface InboxPanesProps {
+	/** A conversation is open — drives one-pane-at-a-time on mobile. */
+	hasSelection: boolean;
+	/** Return to the list (mobile back button). */
+	onBack: () => void;
+	/** Contact-details sheet (mobile/tablet) open state. */
+	detailsOpen: boolean;
+	onDetailsOpenChange: (open: boolean) => void;
+	/** Conversation list pane (project switcher + list). */
+	list: React.ReactNode;
+	/** Thread header content (avatar / name / subtitle / escalated badge). */
+	threadHeader?: React.ReactNode;
+	/** Thread body — the reused MessageThread, or a loading state. */
+	threadBody?: React.ReactNode;
+	/** Pinned reply composer. */
+	composer?: React.ReactNode;
+	/** Contact-details panel; null when nothing is open. */
+	details?: React.ReactNode;
+	/** Shown in the thread pane on tablet/desktop when nothing is open. */
+	emptyState: React.ReactNode;
+	/** Shown in the details aside on desktop when nothing is open. */
+	detailsEmptyState: React.ReactNode;
+}
+
+/**
+ * Responsive inbox frame — the single source of truth for how the list, thread,
+ * and contact-details panes coexist across breakpoints. No mobile fork: the same
+ * nodes are arranged differently by CSS.
+ *
+ * - mobile (< md): one pane at a time. List full-width; opening a conversation
+ *   swaps to the thread (with a back button); details live in a right Sheet.
+ * - tablet (md–lg): two panes (list + thread); details still in the Sheet.
+ * - desktop (≥ lg): three panes — list + thread + a permanent details aside.
+ *
+ * Both panes stay mounted (visibility is CSS, not conditional rendering), so the
+ * thread keeps its scroll position and the stick-to-bottom hook never
+ * re-initialises on a pane switch.
+ */
+export function InboxPanes({
+	hasSelection,
+	onBack,
+	detailsOpen,
+	onDetailsOpenChange,
+	list,
+	threadHeader,
+	threadBody,
+	composer,
+	details,
+	emptyState,
+	detailsEmptyState,
+}: InboxPanesProps) {
+	return (
+		<div className="flex min-h-0 flex-1">
+			{/* Left — conversation list (full-width on mobile, fixed rail from md) */}
+			<div
+				data-pane="list"
+				className={cn(
+					"min-h-0 flex-col border-r md:w-80 md:shrink-0",
+					hasSelection ? "hidden md:flex" : "flex w-full",
+				)}
+			>
+				{list}
+			</div>
+
+			{/* Center — thread (full-screen on mobile when a conversation is open) */}
+			<section
+				data-pane="thread"
+				className={cn(
+					"min-h-0 min-w-0 flex-1 flex-col",
+					hasSelection ? "flex" : "hidden md:flex",
+				)}
+			>
+				{hasSelection ? (
+					<>
+						<div className="flex items-center gap-2 border-b px-4 py-3 sm:px-6">
+							<Button
+								type="button"
+								variant="ghost"
+								size="icon"
+								className="-ml-1 shrink-0 md:hidden"
+								onClick={onBack}
+								aria-label="Back to conversations"
+							>
+								<ChevronLeft />
+							</Button>
+							<div className="flex min-w-0 flex-1 items-center gap-3">
+								{threadHeader}
+							</div>
+							{details && (
+								<Button
+									type="button"
+									variant="ghost"
+									size="icon"
+									className="shrink-0 lg:hidden"
+									onClick={() => onDetailsOpenChange(true)}
+									aria-label="Conversation details"
+								>
+									<Info />
+								</Button>
+							)}
+						</div>
+						{threadBody}
+						{composer}
+					</>
+				) : (
+					emptyState
+				)}
+			</section>
+
+			{/* Right — details aside (desktop only) */}
+			<aside
+				data-pane="details"
+				className="hidden w-72 shrink-0 border-l lg:flex lg:flex-col"
+			>
+				{details ?? detailsEmptyState}
+			</aside>
+
+			{/* Details as a Sheet on mobile/tablet — never shown on desktop (lg:hidden,
+			    and its trigger is lg:hidden too). */}
+			<Sheet open={detailsOpen} onOpenChange={onDetailsOpenChange}>
+				<SheetContent
+					side="right"
+					className="w-full gap-0 overflow-y-auto p-0 sm:max-w-sm lg:hidden"
+				>
+					<SheetHeader className="sr-only">
+						<SheetTitle>Conversation details</SheetTitle>
+						<SheetDescription>
+							Contact, session, device, and rating for this conversation.
+						</SheetDescription>
+					</SheetHeader>
+					{details}
+				</SheetContent>
+			</Sheet>
+		</div>
+	);
+}

--- a/apps/dashboard/src/app/inbox/page.tsx
+++ b/apps/dashboard/src/app/inbox/page.tsx
@@ -10,6 +10,7 @@ import { api, describeApiError } from "@/lib/api";
 import { resolveOnboardingState } from "@/lib/onboarding";
 import { resolveSelectedId } from "@/lib/selection";
 import { useDebouncedValue } from "@/lib/use-debounced-value";
+import { cn } from "@/lib/utils";
 import { useWorkspace } from "@/lib/workspace";
 import { track, ANALYTICS_EVENTS } from "@/lib/analytics";
 
@@ -17,6 +18,7 @@ import { ConversationList } from "./_components/ConversationList";
 import { ConversationListSkeleton } from "./_components/ConversationListSkeleton";
 import { DetailPanel } from "./_components/DetailPanel";
 import { initials, parseDevice, pluralize } from "./_components/format";
+import { InboxPanes } from "./_components/InboxPanes";
 import { InboxSkeleton } from "./_components/InboxSkeleton";
 import { InboxStats } from "./_components/InboxStats";
 import { InboxToolbar } from "./_components/InboxToolbar";
@@ -39,6 +41,8 @@ export default function InboxPage() {
 	const [reply, setReply] = useState("");
 	const [search, setSearch] = useState("");
 	const [showArchived, setShowArchived] = useState(false);
+	// Contact-details sheet (mobile/tablet); on desktop details are a permanent aside.
+	const [detailsOpen, setDetailsOpen] = useState(false);
 	const [sending, setSending] = useState(false);
 	const [archiving, setArchiving] = useState(false);
 	const [deleting, setDeleting] = useState(false);
@@ -192,6 +196,7 @@ export default function InboxPage() {
 				nextArchived ? "Conversation archived" : "Conversation restored",
 			);
 			setSelectedId(null);
+			setDetailsOpen(false);
 			await conversations.refetch();
 		} catch (e) {
 			toast.error(describeApiError(e, "Failed to update conversation"));
@@ -210,6 +215,7 @@ export default function InboxPage() {
 			});
 			toast.success("Conversation deleted");
 			setSelectedId(null);
+			setDetailsOpen(false);
 			await conversations.refetch();
 		} catch (e) {
 			toast.error(describeApiError(e, "Failed to delete conversation"));
@@ -229,104 +235,115 @@ export default function InboxPage() {
 			.join(" · ") ||
 		(detailConv ? pluralize(detailConv.messageCount, "message") : "");
 
+	// A conversation is open. Drives one-pane-at-a-time on mobile: while open, the
+	// list-scoped header/toolbar give way to the full-screen thread.
+	const threadOpen = Boolean(selectedId && detailConv);
+
 	return (
-		<div className="flex h-[calc(100vh-3.5rem)] flex-col">
-			{/* Header band — title + at-a-glance stats */}
-			<header className="flex flex-wrap items-start justify-between gap-4 border-b px-6 py-4">
-				<div>
-					<h1 className="font-display text-2xl font-semibold tracking-tight-display">
-						Conversations
-					</h1>
-					<p className="mt-0.5 text-sm text-muted-foreground">
-						All visitor conversations in one inbox.
-					</p>
-				</div>
-				<InboxStats conversations={allConversations} />
-			</header>
+		<div className="flex h-[calc(100dvh-3rem)] flex-col md:h-[calc(100vh-3.5rem)]">
+			{/* Header band + toolbar are list-scoped: hidden on mobile while a thread
+			    is open (the thread takes the full screen), always shown from md. */}
+			<div className={cn(threadOpen && "hidden md:block")}>
+				<header className="flex flex-wrap items-start justify-between gap-4 border-b px-6 py-4">
+					<div>
+						<h1 className="font-display text-2xl font-semibold tracking-tight-display">
+							Conversations
+						</h1>
+						<p className="mt-0.5 text-sm text-muted-foreground">
+							All visitor conversations in one inbox.
+						</p>
+					</div>
+					<InboxStats conversations={allConversations} />
+				</header>
 
-			<InboxToolbar
-				search={search}
-				onSearch={setSearch}
-				showArchived={showArchived}
-				onShowArchivedChange={(archived) => {
-					setShowArchived(archived);
-					setSelectedId(null);
-				}}
-			/>
+				<InboxToolbar
+					search={search}
+					onSearch={setSearch}
+					showArchived={showArchived}
+					onShowArchivedChange={(archived) => {
+						setShowArchived(archived);
+						setSelectedId(null);
+					}}
+				/>
+			</div>
 
-			<div className="flex min-h-0 flex-1">
-				{/* Left — list */}
-				<div className="flex w-80 shrink-0 flex-col border-r">
-					<ProjectSwitcher
-						projects={projects.data?.projects ?? []}
-						value={projectId}
-						onChange={handleProjectChange}
-					/>
-					{conversations.isLoading ? (
-						<ConversationListSkeleton />
-					) : (
-						<ConversationList
-							conversations={allConversations}
-							selectedId={selectedId}
-							onSelect={handleSelect}
-							search={debouncedSearch}
-							showArchived={showArchived}
+			<InboxPanes
+				hasSelection={threadOpen}
+				onBack={() => setSelectedId(null)}
+				detailsOpen={detailsOpen}
+				onDetailsOpenChange={setDetailsOpen}
+				list={
+					<>
+						<ProjectSwitcher
+							projects={projects.data?.projects ?? []}
+							value={projectId}
+							onChange={handleProjectChange}
 						/>
-					)}
-				</div>
-
-				{/* Center — thread */}
-				<section className="flex min-w-0 flex-1 flex-col">
-					{selectedId && detailConv ? (
-						<>
-							<div className="flex items-center gap-3 border-b px-6 py-3">
-								<span className="flex size-9 items-center justify-center rounded-full bg-muted text-xs font-semibold text-muted-foreground">
-									{initials(detailConv.name)}
-								</span>
-								<div className="min-w-0 flex-1">
-									<p className="truncate text-sm font-semibold">
-										{detailConv.name ?? "Anonymous"}
-									</p>
-									<p className="truncate text-xs text-muted-foreground">
-										{threadSubtitle}
-									</p>
-								</div>
-								{detailConv.escalatedAt && (
-									<Badge variant="warning">Escalated</Badge>
-								)}
-							</div>
-							{thread.data ? (
-								<MessageThread
-									messages={thread.data.messages}
-									search={debouncedSearch}
-								/>
-							) : (
-								<div className="flex flex-1 items-center justify-center text-sm text-muted-foreground">
-									Loading…
-								</div>
-							)}
-							<ReplyComposer
-								value={reply}
-								onChange={setReply}
-								onSend={handleReply}
-								pending={sending}
-								placeholder={
-									detailConv.email
-										? "Reply (also sent via email)"
-										: "Reply (no email — shows in the widget on next visit)"
-								}
+						{conversations.isLoading ? (
+							<ConversationListSkeleton />
+						) : (
+							<ConversationList
+								conversations={allConversations}
+								selectedId={selectedId}
+								onSelect={handleSelect}
+								search={debouncedSearch}
+								showArchived={showArchived}
 							/>
+						)}
+					</>
+				}
+				threadHeader={
+					detailConv && (
+						<>
+							<span className="flex size-9 shrink-0 items-center justify-center rounded-full bg-muted text-xs font-semibold text-muted-foreground">
+								{initials(detailConv.name)}
+							</span>
+							<div className="min-w-0 flex-1">
+								<p className="truncate text-sm font-semibold">
+									{detailConv.name ?? "Anonymous"}
+								</p>
+								<p className="truncate text-xs text-muted-foreground">
+									{threadSubtitle}
+								</p>
+							</div>
+							{detailConv.escalatedAt && (
+								<Badge variant="warning" className="shrink-0">
+									Escalated
+								</Badge>
+							)}
 						</>
+					)
+				}
+				threadBody={
+					detailConv &&
+					(thread.data ? (
+						<MessageThread
+							messages={thread.data.messages}
+							search={debouncedSearch}
+						/>
 					) : (
 						<div className="flex flex-1 items-center justify-center text-sm text-muted-foreground">
-							Select a conversation
+							Loading…
 						</div>
-					)}
-				</section>
-
-				{/* Right — detail */}
-				<aside className="hidden w-72 shrink-0 border-l xl:flex xl:flex-col">
-					{detailConv ? (
+					))
+				}
+				composer={
+					detailConv && (
+						<ReplyComposer
+							value={reply}
+							onChange={setReply}
+							onSend={handleReply}
+							pending={sending}
+							placeholder={
+								detailConv.email
+									? "Reply (also sent via email)"
+									: "Reply (no email — shows in the widget on next visit)"
+							}
+						/>
+					)
+				}
+				details={
+					detailConv ? (
 						<DetailPanel
 							conversation={detailConv}
 							onArchive={handleArchive}
@@ -334,15 +351,21 @@ export default function InboxPage() {
 							archiving={archiving}
 							deleting={deleting}
 						/>
-					) : (
-						<div className="flex flex-1 flex-col items-center justify-center gap-2 px-6 text-center text-muted-foreground">
-							<p className="text-xs">
-								Select a conversation to see visitor details
-							</p>
-						</div>
-					)}
-				</aside>
-			</div>
+					) : null
+				}
+				emptyState={
+					<div className="flex flex-1 items-center justify-center text-sm text-muted-foreground">
+						Select a conversation
+					</div>
+				}
+				detailsEmptyState={
+					<div className="flex flex-1 flex-col items-center justify-center gap-2 px-6 text-center text-muted-foreground">
+						<p className="text-xs">
+							Select a conversation to see visitor details
+						</p>
+					</div>
+				}
+			/>
 		</div>
 	);
 }


### PR DESCRIPTION
**PR 2 of 3** in the responsive-dashboard series. Scope: make `/inbox` work on phone + tablet. Does **not** touch PR-1 surfaces or onboarding.

## Navigation model
**Local state, not URL routing.** The inbox already drives everything off a local `selectedId` (`null` = list, set = thread) — it keys the thread query, mark-read, and analytics. Reused as-is:
- **list ↔ thread** = pure-CSS visibility keyed on `selectedId`. Both panes stay **mounted** (visibility is CSS, not conditional rendering), so the thread keeps its scroll position and `useStickToBottom` never re-initialises on a pane switch — this is what avoids reintroducing the yank-during-streaming bug.
- **back** = a mobile-only button that sets `selectedId = null`.
- **details** = a separate `detailsOpen` boolean → a right `Sheet` for `< lg`, and the existing permanent aside for `≥ lg`.

Trade-off: browser/hardware back doesn't pop thread→list (no history entry); an explicit in-app back button covers it, keeping the data layer + all reused logic untouched.

## What changed
- **New `InboxPanes`** — a pure, slot-based responsive frame (composition pattern) that only *arranges* existing nodes and owns the back/details affordances. `MessageThread`, `ConversationList`, `ReplyComposer`, `DetailPanel`, toolbar search, and the server-side active/archived filter are **not** touched.
- **Mobile (< md):** one pane at a time. Full-width list → tap → full-screen thread (back button); the list-scoped header/toolbar hide so the thread gets the full screen; details behind a Sheet opened from the thread header; composer pinned at the bottom.
- **Tablet (md–lg):** two panes (list + thread); details in the Sheet.
- **Desktop (≥ lg):** unchanged three panes.
- **Reachability fix:** the details aside (which holds contact details + archive/delete) was gated at `xl`/1280, so those were unreachable between 768–1280. Moved to `lg`/1024 as the spec defines.
- **Mobile height:** `h-[calc(100dvh-3rem)]` accounts for the shell's mobile top bar (and `dvh` for browser chrome) so the composer stays pinned; desktop height unchanged.

## Preserved & verified
Search + snippet/thread highlighting, scroll-to-first-hit, stick-to-bottom auto-scroll (no yank), reply composer, archive/delete, and the active/archived filter all keep working — including: when a search is active and you tap into a thread, the highlight + scroll-to-hit fire in the mobile thread view.

## Tests
New `InboxPanes.test.tsx` (8):
- **Navigation** — no-selection shows list + empty state (no thread chrome/back button); selection reveals thread header/body/composer + back button (list stays mounted); back calls `onBack`.
- **Details toggle** — details button calls `onDetailsOpenChange(true)`; no affordance without a panel; the sheet (a `dialog`) appears only when open.
- **Reuse-proof** — rendering a real `MessageThread` inside the frame still highlights every occurrence, scrolls to the first hit, and keeps stick-to-bottom (follows the agent's own reply, does **not** yank on inbound while scrolled up).

## Gate
- `vitest run` (dashboard): **223 passed / 28 files** (+8 new).
- `next build` + bundle check: ✓ clean.
- Prettier (apps/dashboard): clean. Oxlint: no new warnings.
- Secret-scan: clean.

Layout claims across 360 / 390 / 768 / 1024+ are reasoned from the CSS + verified by the build; final pixel check best done on the preview deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)