### PR TITLE
feat(onboarding): stack form + live preview on mobile (PR 3/3)

### DIFF
--- a/apps/dashboard/src/app/onboarding/_components/OnboardingForm.tsx
+++ b/apps/dashboard/src/app/onboarding/_components/OnboardingForm.tsx
@@ -104,7 +104,7 @@ export function OnboardingForm({
 							onValueChange={(value) =>
 								value && onChange({ brandColor: value })
 							}
-							className="justify-start gap-2"
+							className="flex-wrap justify-start gap-2"
 						>
 							{BRAND_CHOICES.map((c) => (
 								<ToggleGroupItem

--- a/apps/dashboard/src/app/onboarding/_components/mobile-view.test.ts
+++ b/apps/dashboard/src/app/onboarding/_components/mobile-view.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+
+import { panelVisibility } from "./mobile-view";
+
+describe("panelVisibility", () => {
+	it("shows the active panel and hides the other on mobile", () => {
+		// Form selected: form shows, preview hides (below lg).
+		expect(panelVisibility("form", "form")).toBe("block");
+		expect(panelVisibility("preview", "form")).toBe("hidden lg:block");
+
+		// Preview selected: the inverse.
+		expect(panelVisibility("preview", "preview")).toBe("block");
+		expect(panelVisibility("form", "preview")).toBe("hidden lg:block");
+	});
+
+	it("always reveals both panels at lg+ regardless of the toggle", () => {
+		// The hidden panel still carries lg:block, so desktop shows both side-by-side.
+		expect(panelVisibility("preview", "form")).toContain("lg:block");
+		expect(panelVisibility("form", "preview")).toContain("lg:block");
+	});
+});

--- a/apps/dashboard/src/app/onboarding/_components/mobile-view.ts
+++ b/apps/dashboard/src/app/onboarding/_components/mobile-view.ts
@@ -1,0 +1,16 @@
+// Pure responsive-visibility rule for the two onboarding panels, kept out of the
+// component so it's unit-tested and can't drift from the markup.
+
+export type MobileView = "form" | "preview";
+
+/**
+ * Show/hide class for one onboarding panel given the active mobile view.
+ *
+ * - below lg: exactly one panel is visible (the one the Setup/Live-preview
+ *   toggle selects) — the other is `hidden`.
+ * - at lg+: both panels are visible side-by-side (`lg:block`), so the toggle is
+ *   irrelevant on desktop.
+ */
+export function panelVisibility(panel: MobileView, active: MobileView): string {
+	return panel === active ? "block" : "hidden lg:block";
+}

--- a/apps/dashboard/src/app/onboarding/page.test.tsx
+++ b/apps/dashboard/src/app/onboarding/page.test.tsx
@@ -168,6 +168,27 @@ describe("OnboardingPage (form redesign)", () => {
 		expect(screen.queryByText(/setup assistant/i)).not.toBeInTheDocument();
 	});
 
+	it("offers a mobile Setup/Live-preview toggle that switches panels without losing form state", async () => {
+		const u = user();
+		renderPage();
+		const nameField = await screen.findByLabelText(/agent name/i);
+		await u.type(nameField, "Acme Tools");
+
+		// The mobile-only toggle is present (desktop shows both panels, so it's
+		// hidden there via CSS — but always rendered). Exact text so it doesn't
+		// match the form's "Set up your agent" title or the preview's caption.
+		const previewTab = screen.getByText("Live preview");
+		const setupTab = screen.getByText("Setup");
+		expect(previewTab).toBeInTheDocument();
+		expect(setupTab).toBeInTheDocument();
+
+		// Flipping to the preview and back must NOT unmount the form: the typed
+		// name survives, proving both panels stay mounted (live binding intact).
+		await u.click(previewTab);
+		await u.click(setupTab);
+		expect(screen.getByLabelText(/agent name/i)).toHaveValue("Acme Tools");
+	});
+
 	it("requires a name before it will provision", async () => {
 		const u = user();
 		renderPage();

--- a/apps/dashboard/src/app/onboarding/page.tsx
+++ b/apps/dashboard/src/app/onboarding/page.tsx
@@ -10,16 +10,19 @@ import { isPaidPlan } from "@llmchat/shared";
 
 import { BrandLogo } from "@/components/brand-logo";
 import { Button } from "@/components/ui/button";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { useSession } from "@/lib/auth-client";
 import { api, isWorkspaceAuthError } from "@/lib/api";
 import { track, ANALYTICS_EVENTS } from "@/lib/analytics";
 import { fetchUsage } from "@/lib/billing";
 import { defaultSystemPrompt } from "@/lib/onboarding";
 import { useOnboardingState } from "@/lib/use-onboarding";
+import { cn } from "@/lib/utils";
 import { useWorkspace } from "@/lib/workspace";
 
 import { initialDraft, type BotDraft } from "./_components/bot-form";
 import { LivePreview } from "./_components/LivePreview";
+import { panelVisibility, type MobileView } from "./_components/mobile-view";
 import { OnboardingForm } from "./_components/OnboardingForm";
 import { OnboardingPaywall } from "./_components/OnboardingPaywall";
 import { OnboardingSkeleton } from "./_components/OnboardingSkeleton";
@@ -50,6 +53,9 @@ function OnboardingFlow() {
 	// effect below then leaves onboarding for that agent's project page.
 	const [createdProjectId, setCreatedProjectId] = useState<string | null>(null);
 	const [failed, setFailed] = useState(false);
+	// Mobile (< lg) shows one panel at a time; desktop shows both side-by-side and
+	// ignores this. Both stay mounted, so the preview keeps updating as you type.
+	const [mobileView, setMobileView] = useState<MobileView>("form");
 
 	// Send unauthenticated visitors to sign-in.
 	useEffect(() => {
@@ -226,33 +232,68 @@ function OnboardingFlow() {
 							</p>
 						</header>
 
-						<div className="grid items-start gap-8 lg:grid-cols-2">
-							<OnboardingForm
-								draft={draft}
-								onChange={(patch) => setDraft((d) => ({ ...d, ...patch }))}
-								onSubmit={handleComplete}
-								busy={busy}
-								primaryLabel={newBot ? "Create this agent" : "Create my agent"}
-							/>
+						<div className="flex flex-col gap-4">
+							{/* Mobile/tablet: flip between the form and the live preview (both
+							    stay mounted, so the preview keeps updating). Hidden on
+							    desktop, where the two panels sit side-by-side. */}
+							<ToggleGroup
+								type="single"
+								value={mobileView}
+								onValueChange={(v) => v && setMobileView(v as MobileView)}
+								variant="outline"
+								aria-label="Switch between the setup form and the live preview"
+								className="w-full lg:hidden"
+							>
+								<ToggleGroupItem value="form" className="flex-1">
+									Setup
+								</ToggleGroupItem>
+								<ToggleGroupItem value="preview" className="flex-1">
+									Live preview
+								</ToggleGroupItem>
+							</ToggleGroup>
 
-							<div className="lg:sticky lg:top-10">
-								<LivePreview
-									name={draft.name}
-									welcomeMessage={draft.welcomeMessage}
-									brandColor={draft.brandColor}
-								/>
-								{failed && (
-									<div className="mt-4 flex flex-col items-center gap-2 text-center">
-										<p className="text-sm text-destructive">
-											Something went wrong creating your agent.
-										</p>
-										<Button variant="outline" onClick={handleComplete}>
-											Try again
-										</Button>
-									</div>
-								)}
+							<div className="grid items-start gap-8 lg:grid-cols-2">
+								<div
+									className={cn("min-w-0", panelVisibility("form", mobileView))}
+								>
+									<OnboardingForm
+										draft={draft}
+										onChange={(patch) => setDraft((d) => ({ ...d, ...patch }))}
+										onSubmit={handleComplete}
+										busy={busy}
+										primaryLabel={
+											newBot ? "Create this agent" : "Create my agent"
+										}
+									/>
+								</div>
+
+								<div
+									className={cn(
+										"min-w-0 lg:sticky lg:top-10",
+										panelVisibility("preview", mobileView),
+									)}
+								>
+									<LivePreview
+										name={draft.name}
+										welcomeMessage={draft.welcomeMessage}
+										brandColor={draft.brandColor}
+									/>
+								</div>
 							</div>
 						</div>
+
+						{/* Retry lives below both panels so it's reachable in either mobile
+						    view (not buried inside the hidden preview column). */}
+						{failed && (
+							<div className="flex flex-col items-center gap-2 text-center">
+								<p className="text-sm text-destructive">
+									Something went wrong creating your agent.
+								</p>
+								<Button variant="outline" onClick={handleComplete}>
+									Try again
+								</Button>
+							</div>
+						)}
 					</>
 				)}
 			</div>


### PR DESCRIPTION
**PR 3 of 3** (final) in the responsive-dashboard series. Scope: make `/onboarding` work on phone + tablet — both first-run and `?new=1`. Does **not** touch PR-1 surfaces or the PR-2 inbox.

## Audit
The layout already collapses to one column below `lg` (`lg:grid-cols-2`), so it *stacks* form-then-preview by default. Two real mobile problems remained:
1. **360 overflow:** the brand-color picker has **5** swatch+label pills in a no-wrap row → horizontal overflow on a 360px phone.
2. **Preview buried:** a 5-field form (~600–700px) pushes the 544px live preview far below the fold — exactly the case the brief says to address with a toggle.

## What changed (reuse + adapt, no fork)
- **Mobile/tablet `Setup | Live preview` toggle** (`lg:hidden`): flips between the two panels, which **both stay mounted** — so the preview keeps updating live as you type, and switching is instant with no scrolling. Desktop (`lg+`) is unchanged: both panels side-by-side, toggle hidden. The show/hide rule is a pure `panelVisibility(panel, active)` helper (`block` vs `hidden lg:block`).
- **Brand swatches wrap** (`flex-wrap`) → no 360 overflow.
- **"Try again" moved below both panels** so it's reachable in either mobile view (was inside the hidden preview column).
- Preview stays the **real, updating WidgetFrame** (untouched), legible full-width on mobile.

## Preserved & verified
Live-preview-as-you-type binding, provisioning, the `resolveOnboardingState` guard, the no-key graceful path, and both first-run and `?new=1` flows ending at the project page — all intact (covered by the existing 12 page tests, still green).

## Tests
- `mobile-view.test.ts` — `panelVisibility` shows exactly one panel on mobile and both at `lg+`.
- `page.test.tsx` (+1) — the mobile toggle renders and flipping Preview→Setup keeps the typed agent name (both panels stay mounted → live binding intact).
- All 12 pre-existing onboarding flow tests unchanged and passing.

## Gate
- `vitest run` (dashboard): **226 passed / 29 files** (+3 new).
- `next build` + bundle check: ✓ clean.
- Prettier (apps/dashboard): clean. Oxlint: no new warnings.
- Secret-scan: clean.

No horizontal overflow at 360 / 390 / 768 / 1024+ (reasoned from the CSS + build); finger-sized toggle/targets; preview legible on mobile. Final pixel check best done on the preview deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)