### PR TITLE
feat(dashboard): optimistic updates via one shared helper (Phase 0+1)

### DIFF
--- a/apps/dashboard/src/app/inbox/_components/MessageThread.test.tsx
+++ b/apps/dashboard/src/app/inbox/_components/MessageThread.test.tsx
@@ -2,8 +2,9 @@ import { act, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { MessageThread } from "./MessageThread";
+import { appendOptimisticReply } from "./optimistic-updaters";
 
-import type { Message } from "./types";
+import type { Conversation, Message } from "./types";
 
 function msg(overrides: Partial<Message>): Message {
 	return {
@@ -213,6 +214,30 @@ describe("MessageThread auto-scroll (useStickToBottom)", () => {
 				]}
 			/>,
 		);
+		expect(s.top).toBe(1000);
+	});
+
+	it("follows an optimistic reply (built by appendOptimisticReply) even when scrolled up", () => {
+		const base = [
+			msg({ content: "hi", sequence: 1 }),
+			msg({ role: "assistant", content: "hello", sequence: 2 }),
+		];
+		const { el, rerender } = renderThread(base);
+		const s = mockScroll(el, { scrollHeight: 1000, clientHeight: 400 });
+		s.setTop(0); // agent reading history, scrolled up
+
+		// The exact array the inbox's optimistic reply writes into the thread cache.
+		const next = appendOptimisticReply(
+			{ conversation: { id: "c1" } as Conversation, messages: base },
+			{
+				tempId: "temp-1",
+				content: "on it!",
+				createdAt: "2026-06-16T05:00:00.000Z",
+			},
+		) as { messages: Message[] };
+
+		rerender(<MessageThread messages={next.messages} />);
+		// Role "admin" => stick-to-bottom treats it as the agent's own send.
 		expect(s.top).toBe(1000);
 	});
 

--- a/apps/dashboard/src/app/inbox/_components/optimistic-updaters.test.tsx
+++ b/apps/dashboard/src/app/inbox/_components/optimistic-updaters.test.tsx
@@ -1,0 +1,96 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { describe, expect, it } from "vitest";
+
+import { useOptimisticMutation } from "@/lib/optimistic";
+
+import { appendOptimisticReply } from "./optimistic-updaters";
+import type { Conversation, Message } from "./types";
+
+function msg(overrides: Partial<Message>): Message {
+	return {
+		id: crypto.randomUUID(),
+		role: "user",
+		content: "hello",
+		sequence: 1,
+		createdAt: "2026-06-16T05:00:00.000Z",
+		...overrides,
+	};
+}
+
+function thread(messages: Message[]) {
+	return { conversation: { id: "c1" } as Conversation, messages };
+}
+
+const REPLY = {
+	tempId: "temp-1",
+	content: "On it!",
+	createdAt: "2026-06-16T06:00:00.000Z",
+};
+
+describe("appendOptimisticReply", () => {
+	it("appends an admin message with the next sequence, immutably", () => {
+		const prev = thread([
+			msg({ sequence: 1 }),
+			msg({ role: "assistant", sequence: 2 }),
+		]);
+		const next = appendOptimisticReply(prev, REPLY) as ReturnType<
+			typeof thread
+		>;
+
+		expect(next.messages).toHaveLength(3);
+		const added = next.messages[2];
+		expect(added).toMatchObject({
+			id: "temp-1",
+			role: "admin",
+			content: "On it!",
+			sequence: 3,
+		});
+		// Original thread is untouched.
+		expect(prev.messages).toHaveLength(2);
+	});
+
+	it("starts at sequence 1 for an empty thread and is undefined-safe", () => {
+		const next = appendOptimisticReply(thread([]), REPLY) as ReturnType<
+			typeof thread
+		>;
+		expect(next.messages[0].sequence).toBe(1);
+		expect(appendOptimisticReply(undefined, REPLY)).toBeUndefined();
+	});
+});
+
+describe("optimistic reply rollback", () => {
+	it("restores the thread when the send fails", async () => {
+		const client = new QueryClient({
+			defaultOptions: {
+				queries: { retry: false },
+				mutations: { retry: false },
+			},
+		});
+		const key = ["thread", "p1", "c1"];
+		const seed = thread([msg({ content: "hi", sequence: 1 })]);
+		client.setQueryData(key, seed);
+
+		const { result } = renderHook(
+			() =>
+				useOptimisticMutation<typeof REPLY>({
+					queryKey: key,
+					apply: (prev, vars) => appendOptimisticReply(prev, vars),
+					mutationFn: () => Promise.reject(new Error("network down")),
+				}),
+			{
+				wrapper: ({ children }: { children: ReactNode }) =>
+					createElement(QueryClientProvider, { client }, children),
+			},
+		);
+
+		act(() => result.current.mutate(REPLY));
+		await waitFor(() => expect(result.current.isError).toBe(true));
+
+		// The optimistic admin bubble is gone — back to the single seeded message.
+		const data = client.getQueryData(key) as ReturnType<typeof thread>;
+		expect(data.messages).toHaveLength(1);
+		expect(data.messages[0].content).toBe("hi");
+	});
+});

--- a/apps/dashboard/src/app/inbox/_components/optimistic-updaters.ts
+++ b/apps/dashboard/src/app/inbox/_components/optimistic-updaters.ts
@@ -1,0 +1,35 @@
+import type { Conversation, Message } from "./types";
+
+interface ThreadData {
+	conversation: Conversation;
+	messages: Message[];
+}
+
+/**
+ * Build the optimistic admin message appended to a thread the instant an agent
+ * hits send — the same shape the server echoes back, with a temp id so the real
+ * row (a different id) cleanly replaces it on reconcile. Role "admin" is what
+ * makes stick-to-bottom treat the reply as the agent's own send and follow to
+ * the bottom (it never yanks for inbound visitor/bot messages).
+ *
+ * Pure, immutable, and undefined-safe — matches the `apply` contract of
+ * `useOptimisticMutation` so a failed send rolls the thread straight back.
+ */
+export function appendOptimisticReply(
+	prev: unknown,
+	reply: { tempId: string; content: string; createdAt: string },
+): unknown {
+	if (!prev || typeof prev !== "object") return prev;
+	const data = prev as ThreadData;
+	if (!Array.isArray(data.messages)) return prev;
+	const nextSeq = (data.messages.at(-1)?.sequence ?? 0) + 1;
+	const optimistic: Message = {
+		id: reply.tempId,
+		role: "admin",
+		content: reply.content,
+		sequence: nextSeq,
+		createdAt: reply.createdAt,
+		rating: null,
+	};
+	return { ...data, messages: [...data.messages, optimistic] };
+}

--- a/apps/dashboard/src/app/inbox/page.tsx
+++ b/apps/dashboard/src/app/inbox/page.tsx
@@ -8,6 +8,7 @@ import { toast } from "sonner";
 import { Badge } from "@/components/ui/badge";
 import { api, describeApiError } from "@/lib/api";
 import { resolveOnboardingState } from "@/lib/onboarding";
+import { dropById, useOptimisticMutation } from "@/lib/optimistic";
 import { resolveSelectedId } from "@/lib/selection";
 import { useDebouncedValue } from "@/lib/use-debounced-value";
 import { cn } from "@/lib/utils";
@@ -23,6 +24,7 @@ import { InboxSkeleton } from "./_components/InboxSkeleton";
 import { InboxStats } from "./_components/InboxStats";
 import { InboxToolbar } from "./_components/InboxToolbar";
 import { MessageThread } from "./_components/MessageThread";
+import { appendOptimisticReply } from "./_components/optimistic-updaters";
 import { ProjectSwitcher } from "./_components/ProjectSwitcher";
 import { ReplyComposer } from "./_components/ReplyComposer";
 import type { Conversation, Message } from "./_components/types";
@@ -43,9 +45,6 @@ export default function InboxPage() {
 	const [showArchived, setShowArchived] = useState(false);
 	// Contact-details sheet (mobile/tablet); on desktop details are a permanent aside.
 	const [detailsOpen, setDetailsOpen] = useState(false);
-	const [sending, setSending] = useState(false);
-	const [archiving, setArchiving] = useState(false);
-	const [deleting, setDeleting] = useState(false);
 
 	const projects = useQuery({
 		queryKey: ["projects", workspaceId],
@@ -163,65 +162,93 @@ export default function InboxPage() {
 		if (onboardingState === "needs-onboarding") router.replace("/onboarding");
 	}, [onboardingState, router]);
 
-	async function handleReply() {
-		if (!reply.trim() || !projectId || !selectedId || !workspaceId) return;
-		setSending(true);
-		try {
-			await api(
-				`/api/projects/${projectId}/conversations/${selectedId}/reply`,
-				{ method: "POST", body: { content: reply.trim() }, workspaceId },
-			);
+	// Optimistic reply: the agent's message appears in the thread the instant they
+	// hit send (a temp admin bubble that stick-to-bottom follows), then the real
+	// row replaces it on reconcile. A failed send rolls the bubble back and keeps
+	// the typed text so it can be retried.
+	const replyMut = useOptimisticMutation<{
+		tempId: string;
+		content: string;
+		createdAt: string;
+	}>({
+		queryKey: ["thread", projectId, selectedId],
+		apply: (prev, vars) => appendOptimisticReply(prev, vars),
+		mutationFn: (vars) =>
+			api(`/api/projects/${projectId}/conversations/${selectedId}/reply`, {
+				method: "POST",
+				body: { content: vars.content },
+				workspaceId: workspaceId!,
+			}),
+		onSuccess: () => {
 			setReply("");
 			toast.success("Reply sent");
-			await thread.refetch();
-			await conversations.refetch();
-		} catch (e) {
-			toast.error(describeApiError(e, "Failed to send reply"));
-		} finally {
-			setSending(false);
-		}
-	}
+			// The reply bumps updatedAt + the preview, so refresh the list order too.
+			void qc.invalidateQueries({ queryKey: ["conversations", projectId] });
+		},
+		onError: (e) => toast.error(describeApiError(e, "Failed to send reply")),
+	});
 
-	async function handleArchive() {
-		if (!projectId || !detailConv || !workspaceId) return;
-		const nextArchived = !detailConv.archivedAt;
-		setArchiving(true);
-		try {
-			await api(`/api/projects/${projectId}/conversations/${detailConv.id}`, {
+	// Optimistic archive/restore + delete: the row leaves the current list the
+	// instant the action fires; a failure re-inserts it (and toasts).
+	const archiveMut = useOptimisticMutation<{
+		id: string;
+		nextArchived: boolean;
+	}>({
+		queryKey: ["conversations", projectId],
+		apply: (prev, vars) => dropById(prev, "conversations", vars.id),
+		mutationFn: (vars) =>
+			api(`/api/projects/${projectId}/conversations/${vars.id}`, {
 				method: "PATCH",
-				body: { archived: nextArchived },
-				workspaceId,
-			});
+				body: { archived: vars.nextArchived },
+				workspaceId: workspaceId!,
+			}),
+		onSuccess: (_data, vars) =>
 			toast.success(
-				nextArchived ? "Conversation archived" : "Conversation restored",
-			);
-			setSelectedId(null);
-			setDetailsOpen(false);
-			await conversations.refetch();
-		} catch (e) {
-			toast.error(describeApiError(e, "Failed to update conversation"));
-		} finally {
-			setArchiving(false);
-		}
+				vars.nextArchived ? "Conversation archived" : "Conversation restored",
+			),
+		onError: (e) =>
+			toast.error(describeApiError(e, "Failed to update conversation")),
+	});
+
+	const deleteMut = useOptimisticMutation<string>({
+		queryKey: ["conversations", projectId],
+		apply: (prev, id) => dropById(prev, "conversations", id),
+		mutationFn: (id) =>
+			api(`/api/projects/${projectId}/conversations/${id}`, {
+				method: "DELETE",
+				workspaceId: workspaceId!,
+			}),
+		onSuccess: () => toast.success("Conversation deleted"),
+		onError: (e) =>
+			toast.error(describeApiError(e, "Failed to delete conversation")),
+	});
+
+	function handleReply() {
+		const content = reply.trim();
+		if (!content || !projectId || !selectedId || !workspaceId) return;
+		replyMut.mutate({
+			tempId: `temp-${crypto.randomUUID()}`,
+			content,
+			createdAt: new Date().toISOString(),
+		});
 	}
 
-	async function handleDelete() {
+	function handleArchive() {
 		if (!projectId || !detailConv || !workspaceId) return;
-		setDeleting(true);
-		try {
-			await api(`/api/projects/${projectId}/conversations/${detailConv.id}`, {
-				method: "DELETE",
-				workspaceId,
-			});
-			toast.success("Conversation deleted");
-			setSelectedId(null);
-			setDetailsOpen(false);
-			await conversations.refetch();
-		} catch (e) {
-			toast.error(describeApiError(e, "Failed to delete conversation"));
-		} finally {
-			setDeleting(false);
-		}
+		const { id } = detailConv;
+		const nextArchived = !detailConv.archivedAt;
+		// Close the pane optimistically alongside the row removal.
+		setSelectedId(null);
+		setDetailsOpen(false);
+		archiveMut.mutate({ id, nextArchived });
+	}
+
+	function handleDelete() {
+		if (!projectId || !detailConv || !workspaceId) return;
+		const { id } = detailConv;
+		setSelectedId(null);
+		setDetailsOpen(false);
+		deleteMut.mutate(id);
 	}
 
 	// Loading, or redirecting a brand-new account to onboarding.
@@ -333,7 +360,7 @@ export default function InboxPage() {
 							value={reply}
 							onChange={setReply}
 							onSend={handleReply}
-							pending={sending}
+							pending={replyMut.isPending}
 							placeholder={
 								detailConv.email
 									? "Reply (also sent via email)"
@@ -348,8 +375,8 @@ export default function InboxPage() {
 							conversation={detailConv}
 							onArchive={handleArchive}
 							onDelete={handleDelete}
-							archiving={archiving}
-							deleting={deleting}
+							archiving={archiveMut.isPending}
+							deleting={deleteMut.isPending}
 						/>
 					) : null
 				}

--- a/apps/dashboard/src/app/settings/projects/[id]/useProjectMutations.ts
+++ b/apps/dashboard/src/app/settings/projects/[id]/useProjectMutations.ts
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 
 import { api, describeApiError } from "@/lib/api";
+import { dropById, useOptimisticMutation } from "@/lib/optimistic";
 
 import type { Project, Source } from "./types";
 
@@ -71,16 +72,17 @@ export function useProjectMutations(id: string, workspaceId: string | null) {
 			toast.error(describeApiError(e, "Could not refresh source")),
 	});
 
-	const deleteSource = useMutation({
-		mutationFn: (sourceId: string) =>
+	// Optimistic delete: the source leaves the list immediately; a failure rolls
+	// it back and toasts.
+	const deleteSource = useOptimisticMutation<string>({
+		queryKey: ["sources", id],
+		apply: (prev, sourceId) => dropById(prev, "sources", sourceId),
+		mutationFn: (sourceId) =>
 			api(`/api/projects/${id}/sources/${sourceId}`, {
 				method: "DELETE",
 				workspaceId: workspaceId!,
 			}),
-		onSuccess: () => {
-			qc.invalidateQueries({ queryKey: ["sources", id] });
-			toast.success("Source removed");
-		},
+		onSuccess: () => toast.success("Source removed"),
 		onError: (e) => toast.error(describeApiError(e, "Could not remove source")),
 	});
 

--- a/apps/dashboard/src/app/settings/projects/page.tsx
+++ b/apps/dashboard/src/app/settings/projects/page.tsx
@@ -15,6 +15,7 @@ import {
 	EmptyTitle,
 } from "@/components/ui/empty";
 import { api, describeApiError } from "@/lib/api";
+import { dropById, mapById, useOptimisticMutation } from "@/lib/optimistic";
 import { useWorkspace } from "@/lib/workspace";
 import { track, ANALYTICS_EVENTS } from "@/lib/analytics";
 import { RoleGate } from "@/components/role-gate";
@@ -71,15 +72,17 @@ export default function ProjectsPage() {
 			toast.error(describeApiError(e, "Failed to create project")),
 	});
 
-	const remove = useMutation({
-		mutationFn: (id: string) =>
+	// Optimistic delete: the card leaves the grid immediately; a failure rolls it
+	// back and toasts. The confirm dialog closes at the call site (handler below).
+	const remove = useOptimisticMutation<string>({
+		queryKey: ["projects", workspaceId],
+		apply: (prev, id) => dropById(prev, "projects", id),
+		mutationFn: (id) =>
 			api(`/api/projects/${id}`, {
 				method: "DELETE",
 				workspaceId: workspaceId!,
 			}),
 		onSuccess: (_res, id) => {
-			qc.invalidateQueries({ queryKey: ["projects"] });
-			setDeleteId(null);
 			track(ANALYTICS_EVENTS.projectDeleted, { project_id: id });
 			toast.success("Project deleted");
 		},
@@ -87,8 +90,19 @@ export default function ProjectsPage() {
 			toast.error(describeApiError(e, "Failed to delete project")),
 	});
 
-	const toggle = useMutation({
-		mutationFn: (input: { id: string; favorite?: boolean; pinned?: boolean }) =>
+	// Optimistic pin/favorite toggle — the reference call site, now on the shared
+	// helper instead of a hand-rolled onMutate/onError/onSettled.
+	const toggle = useOptimisticMutation<
+		{ id: string; favorite?: boolean; pinned?: boolean },
+		{ project: ProjectListItem }
+	>({
+		queryKey: ["projects", workspaceId],
+		apply: (prev, input) =>
+			mapById<ProjectListItem>(prev, "projects", input.id, (p) => ({
+				...p,
+				...input,
+			})),
+		mutationFn: (input) =>
 			api<{ project: ProjectListItem }>(`/api/projects/${input.id}`, {
 				method: "PATCH",
 				body:
@@ -97,29 +111,6 @@ export default function ProjectsPage() {
 						: { pinned: input.pinned },
 				workspaceId: workspaceId!,
 			}),
-		onMutate: async (input) => {
-			await qc.cancelQueries({ queryKey: ["projects", workspaceId] });
-			const prev = qc.getQueryData<{ projects: ProjectListItem[] }>([
-				"projects",
-				workspaceId,
-			]);
-			qc.setQueryData<{ projects: ProjectListItem[] }>(
-				["projects", workspaceId],
-				(old) =>
-					old && {
-						projects: old.projects.map((p) =>
-							p.id === input.id ? { ...p, ...input } : p,
-						),
-					},
-			);
-			return { prev };
-		},
-		onError: (_e, _v, ctx) => {
-			if (ctx?.prev) qc.setQueryData(["projects", workspaceId], ctx.prev);
-		},
-		onSettled: () => {
-			qc.invalidateQueries({ queryKey: ["projects", workspaceId] });
-		},
 	});
 
 	const list = projects.data?.projects ?? NO_PROJECTS;
@@ -172,7 +163,13 @@ export default function ProjectsPage() {
 			<DeleteProjectDialog
 				open={deleteId !== null}
 				onOpenChange={(open) => !open && setDeleteId(null)}
-				onConfirm={() => deleteId && remove.mutate(deleteId)}
+				onConfirm={() => {
+					if (!deleteId) return;
+					const id = deleteId;
+					// Close the dialog as the card optimistically leaves the grid.
+					setDeleteId(null);
+					remove.mutate(id);
+				}}
 				pending={remove.isPending}
 			/>
 

--- a/apps/dashboard/src/lib/optimistic.test.tsx
+++ b/apps/dashboard/src/lib/optimistic.test.tsx
@@ -1,0 +1,168 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { describe, expect, it } from "vitest";
+
+import { dropById, mapById, useOptimisticMutation } from "./optimistic";
+
+function makeClient() {
+	return new QueryClient({
+		defaultOptions: {
+			queries: { retry: false },
+			mutations: { retry: false },
+		},
+	});
+}
+
+function wrapperFor(client: QueryClient) {
+	return ({ children }: { children: ReactNode }) =>
+		createElement(QueryClientProvider, { client }, children);
+}
+
+describe("dropById / mapById updaters", () => {
+	it("dropById removes by id, leaves the input untouched, and passes undefined through", () => {
+		const prev = { conversations: [{ id: "a" }, { id: "b" }] };
+		const next = dropById(prev, "conversations", "a") as typeof prev;
+		expect(next.conversations).toEqual([{ id: "b" }]);
+		// Immutable: the original array is not mutated.
+		expect(prev.conversations).toHaveLength(2);
+		// Undefined-safe: a never-loaded cache passes straight through.
+		expect(dropById(undefined, "conversations", "a")).toBeUndefined();
+	});
+
+	it("mapById replaces only the matching item, immutably", () => {
+		const prev = {
+			projects: [
+				{ id: "a", pinned: false },
+				{ id: "b", pinned: false },
+			],
+		};
+		const next = mapById<{ id: string; pinned: boolean }>(
+			prev,
+			"projects",
+			"b",
+			(p) => ({ ...p, pinned: true }),
+		) as typeof prev;
+		expect(next.projects).toEqual([
+			{ id: "a", pinned: false },
+			{ id: "b", pinned: true },
+		]);
+		expect(prev.projects[1].pinned).toBe(false);
+		expect(mapById(undefined, "projects", "b", (p) => p)).toBeUndefined();
+	});
+});
+
+describe("useOptimisticMutation", () => {
+	it("applies the optimistic update immediately", async () => {
+		const client = makeClient();
+		const key = ["conversations", "p1", "", false];
+		client.setQueryData(key, { conversations: [{ id: "a" }, { id: "b" }] });
+
+		const { result } = renderHook(
+			() =>
+				useOptimisticMutation<string>({
+					queryKey: ["conversations", "p1"],
+					apply: (prev, id) => dropById(prev, "conversations", id),
+					mutationFn: () => new Promise(() => {}), // never resolves: prove the UI doesn't wait
+				}),
+			{ wrapper: wrapperFor(client) },
+		);
+
+		act(() => result.current.mutate("a"));
+
+		await waitFor(() => {
+			const data = client.getQueryData(key) as {
+				conversations: { id: string }[];
+			};
+			expect(data.conversations).toEqual([{ id: "b" }]);
+		});
+	});
+
+	// Each Phase-1 call site, exercised through the real updater + the helper's
+	// rollback path: an optimistic write that then fails must restore the cache.
+	const ROLLBACK_CASES = [
+		{
+			name: "conversation archive/delete",
+			key: ["conversations", "p1", "", false],
+			partial: ["conversations", "p1"],
+			seed: { conversations: [{ id: "a" }, { id: "b" }] },
+			apply: (prev: unknown) => dropById(prev, "conversations", "a"),
+		},
+		{
+			name: "project delete",
+			key: ["projects", "w1"],
+			partial: ["projects", "w1"],
+			seed: { projects: [{ id: "a" }, { id: "b" }] },
+			apply: (prev: unknown) => dropById(prev, "projects", "a"),
+		},
+		{
+			name: "source delete",
+			key: ["sources", "p1"],
+			partial: ["sources", "p1"],
+			seed: { sources: [{ id: "s1" }, { id: "s2" }] },
+			apply: (prev: unknown) => dropById(prev, "sources", "s1"),
+		},
+		{
+			name: "project pin/star toggle",
+			key: ["projects", "w1"],
+			partial: ["projects", "w1"],
+			seed: { projects: [{ id: "a", pinned: false }] },
+			apply: (prev: unknown) =>
+				mapById<{ id: string; pinned: boolean }>(
+					prev,
+					"projects",
+					"a",
+					(p) => ({ ...p, pinned: true }),
+				),
+		},
+	];
+
+	it.each(ROLLBACK_CASES)("rolls back $name on failure", async (tc) => {
+		const client = makeClient();
+		client.setQueryData(tc.key, tc.seed);
+
+		const { result } = renderHook(
+			() =>
+				useOptimisticMutation({
+					queryKey: tc.partial,
+					apply: tc.apply,
+					mutationFn: () => Promise.reject(new Error("boom")),
+				}),
+			{ wrapper: wrapperFor(client) },
+		);
+
+		act(() => result.current.mutate(undefined));
+		await waitFor(() => expect(result.current.isError).toBe(true));
+		// Cache is byte-for-byte back to the pre-mutation snapshot.
+		expect(client.getQueryData(tc.key)).toEqual(tc.seed);
+	});
+
+	it("rolls back every cached variant of a partial key", async () => {
+		const client = makeClient();
+		const active = ["conversations", "p1", "", false];
+		const searched = ["conversations", "p1", "refund", false];
+		client.setQueryData(active, { conversations: [{ id: "a" }, { id: "b" }] });
+		client.setQueryData(searched, { conversations: [{ id: "a" }] });
+
+		const { result } = renderHook(
+			() =>
+				useOptimisticMutation<string>({
+					queryKey: ["conversations", "p1"],
+					apply: (prev, id) => dropById(prev, "conversations", id),
+					mutationFn: () => Promise.reject(new Error("boom")),
+				}),
+			{ wrapper: wrapperFor(client) },
+		);
+
+		act(() => result.current.mutate("a"));
+		await waitFor(() => expect(result.current.isError).toBe(true));
+
+		// Both list variants are restored — the partial key spans them all.
+		expect(client.getQueryData(active)).toEqual({
+			conversations: [{ id: "a" }, { id: "b" }],
+		});
+		expect(client.getQueryData(searched)).toEqual({
+			conversations: [{ id: "a" }],
+		});
+	});
+});

--- a/apps/dashboard/src/lib/optimistic.ts
+++ b/apps/dashboard/src/lib/optimistic.ts
@@ -1,0 +1,109 @@
+"use client";
+
+import {
+	useMutation,
+	useQueryClient,
+	type QueryKey,
+} from "@tanstack/react-query";
+
+/**
+ * One shared optimistic-mutation primitive so every write that should feel
+ * instant uses the same cancel → snapshot → setQueryData → rollback → invalidate
+ * shape instead of hand-rolling it per call (the pattern the projects pin/star
+ * toggle pioneered).
+ *
+ * `queryKey` is a PARTIAL (prefix) key: the optimistic write — and its rollback —
+ * apply to EVERY cached query that matches. That's deliberate, so removing a
+ * conversation updates its row across every cached list variant (each search
+ * term + the active/archived split are separate cache entries) in one shot, and
+ * a failure restores all of them. On settle the prefix is invalidated to
+ * reconcile the guess with the server's truth.
+ *
+ * `apply` must be PURE and immutable, and pass caches it doesn't change straight
+ * through (return the input unchanged) — never-loaded variants arrive as
+ * `undefined`. Returning a new reference signals "this cache changed"; returning
+ * the same reference leaves that cache untouched.
+ */
+export interface OptimisticMutationOptions<TVars, TData> {
+	queryKey: QueryKey;
+	mutationFn: (vars: TVars) => Promise<TData>;
+	apply: (prev: unknown, vars: TVars) => unknown;
+	onSuccess?: (data: TData, vars: TVars) => void;
+	onError?: (error: unknown, vars: TVars) => void;
+}
+
+interface RollbackContext {
+	snapshot: [QueryKey, unknown][];
+}
+
+export function useOptimisticMutation<TVars, TData = unknown>({
+	queryKey,
+	mutationFn,
+	apply,
+	onSuccess,
+	onError,
+}: OptimisticMutationOptions<TVars, TData>) {
+	const qc = useQueryClient();
+	return useMutation<TData, unknown, TVars, RollbackContext>({
+		mutationFn,
+		onMutate: async (vars) => {
+			// Stop in-flight refetches (e.g. the inbox's 3–5s polls) from landing on
+			// top of — and erasing — the optimistic write before it's reconciled.
+			await qc.cancelQueries({ queryKey });
+			const snapshot = qc.getQueriesData({ queryKey });
+			for (const [key, value] of snapshot) {
+				const next = apply(value, vars);
+				// Only touch caches the updater actually changed; this skips
+				// never-loaded variants (undefined passes straight through).
+				if (next !== value) qc.setQueryData(key, next);
+			}
+			return { snapshot };
+		},
+		onError: (error, vars, ctx) => {
+			ctx?.snapshot.forEach(([key, value]) => qc.setQueryData(key, value));
+			onError?.(error, vars);
+		},
+		onSuccess,
+		onSettled: () => {
+			void qc.invalidateQueries({ queryKey });
+		},
+	});
+}
+
+/**
+ * Optimistic updater: drop the item with `id` from a `{ [field]: T[] }` cache.
+ * Pure, immutable, and undefined-safe (returns the input unchanged when the
+ * cache is empty or the field isn't an array).
+ */
+export function dropById(prev: unknown, field: string, id: string): unknown {
+	if (!prev || typeof prev !== "object") return prev;
+	const rec = prev as Record<string, unknown>;
+	const list = rec[field];
+	if (!Array.isArray(list)) return prev;
+	return {
+		...rec,
+		[field]: list.filter((it) => (it as { id?: string }).id !== id),
+	};
+}
+
+/**
+ * Optimistic updater: replace the item with `id` in a `{ [field]: T[] }` cache
+ * by running `fn` over it. Same purity / undefined-safety as `dropById`.
+ */
+export function mapById<T>(
+	prev: unknown,
+	field: string,
+	id: string,
+	fn: (item: T) => T,
+): unknown {
+	if (!prev || typeof prev !== "object") return prev;
+	const rec = prev as Record<string, unknown>;
+	const list = rec[field];
+	if (!Array.isArray(list)) return prev;
+	return {
+		...rec,
+		[field]: list.map((it) =>
+			(it as { id?: string }).id === id ? fn(it as T) : it,
+		),
+	};
+}


### PR DESCRIPTION
Phase 0 + 1 of the optimistic-updates + pagination plan. Pagination is a separate PR.

## Phase 0 — shared helper
`useOptimisticMutation` (`lib/optimistic.ts`) encapsulates the one pattern: cancel → snapshot → `setQueryData` → rollback → invalidate. `queryKey` is a **partial (prefix) key**, so one optimistic write spans every cached variant of a list (each search term + the active/archived split are separate cache entries) and a failure restores all of them. Ships pure `dropById` / `mapById` updaters. The projects pin/favorite `toggle` — the pattern this generalizes — is migrated onto it (no behavior change).

## Phase 1 — optimistic mutations
| Mutation | Behavior |
|---|---|
| Inbox **reply** | Appends a temp `admin` bubble instantly; stick-to-bottom follows it (it's the agent's own send); real row replaces it on reconcile; failure rolls back **and keeps the typed text** to retry. |
| Inbox **archive / restore** | Row leaves the current list + pane closes instantly; rollback re-inserts. |
| Inbox **delete** | Same; rollback re-inserts. |
| Project **delete** | Card leaves the grid instantly; dialog closes; rollback restores. |
| Source **delete** | Row leaves the list instantly; rollback restores. |

### Deliberately NOT optimistic (documented in the plan)
Billing checkout/portal/plan changes (money — a wrong optimistic state would mislead), source add/refresh (server fetches the URL), project create (server-generated `publicKey`/ids), settings save (the config page already renders the local draft, so edits are already instant), onboarding provisioning.

## Tests
- Each call site **rolls back on failure** — table-driven through the real updaters + the helper's rollback path (conversation archive/delete, project delete, source delete, pin toggle, reply).
- **Multi-variant rollback**: two cached conversation-list variants both restored from one partial key.
- **Optimistic reply cooperates with stick-to-bottom**: the array `appendOptimisticReply` writes follows to the bottom even when the agent has scrolled up.

All 5 packages' suites pass; lint/format clean; no secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)