### PR TITLE
feat(inbox): keyset-paginate the conversation list + server-aggregate stats (Phase 2)

### DIFF
--- a/apps/api/src/lib/cursor.test.ts
+++ b/apps/api/src/lib/cursor.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import { decodeCursor, encodeCursor } from "./cursor";
+
+describe("conversation cursor", () => {
+	it("round-trips a keyset position", () => {
+		const cursor = { updatedAt: 1_700_000_000, id: "abc-123" };
+		const decoded = decodeCursor(encodeCursor(cursor));
+		expect(decoded).toEqual(cursor);
+	});
+
+	it("survives ids containing the separator char", () => {
+		const cursor = { updatedAt: 42, id: "weird|id|with|pipes" };
+		expect(decodeCursor(encodeCursor(cursor))).toEqual(cursor);
+	});
+
+	it("produces a url-safe token (no +, /, or = padding)", () => {
+		const token = encodeCursor({ updatedAt: 1_700_000_000, id: "a/b+c==" });
+		expect(token).not.toMatch(/[+/=]/);
+	});
+
+	it("decodes garbage to null (caller falls back to page 1, never a 400)", () => {
+		expect(decodeCursor(undefined)).toBeNull();
+		expect(decodeCursor("")).toBeNull();
+		expect(decodeCursor("!!!not base64!!!")).toBeNull();
+		// Valid base64 but no separator / non-integer timestamp / empty id.
+		expect(decodeCursor(encodeNoSep("noseparator"))).toBeNull();
+		expect(decodeCursor(encodeRaw("notanumber|x"))).toBeNull();
+		expect(decodeCursor(encodeRaw("123|"))).toBeNull();
+		expect(decodeCursor(encodeRaw("-5|x"))).toBeNull();
+	});
+});
+
+/** Encode an arbitrary string the same way the cursor does, to forge malformed
+ * (but well-base64'd) tokens. */
+function encodeRaw(raw: string): string {
+	return btoa(raw).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+function encodeNoSep(raw: string): string {
+	return encodeRaw(raw);
+}

--- a/apps/api/src/lib/cursor.ts
+++ b/apps/api/src/lib/cursor.ts
@@ -1,0 +1,57 @@
+/**
+ * Opaque keyset cursor for the conversation feed, ordered by
+ * `(updatedAt DESC, id DESC)`. The token encodes the last row's sort key —
+ * `updatedAt` as unix **seconds** (how the column is stored) plus the `id`
+ * tiebreaker — so the next page resumes exactly after it, stable under inserts
+ * (unlike OFFSET, which shifts when a new row lands at the top).
+ *
+ * The token is base64url of `"<epochSeconds>|<id>"`. It's opaque to clients:
+ * decode is defensive and returns `null` for anything malformed, so a garbage
+ * cursor just serves the first page rather than erroring mid-scroll.
+ */
+export interface ConversationCursor {
+	/** unix seconds — matches the stored `updatedAt` integer. */
+	updatedAt: number;
+	id: string;
+}
+
+function toBase64Url(input: string): string {
+	return btoa(input).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function fromBase64Url(input: string): string {
+	const padded = input
+		.replace(/-/g, "+")
+		.replace(/_/g, "/")
+		.padEnd(Math.ceil(input.length / 4) * 4, "=");
+	return atob(padded);
+}
+
+export function encodeCursor(cursor: ConversationCursor): string {
+	return toBase64Url(`${cursor.updatedAt}|${cursor.id}`);
+}
+
+/**
+ * Decode a cursor token. Returns `null` for any malformed input (bad base64,
+ * missing separator, non-integer timestamp, empty id) so the caller can fall
+ * back to the first page instead of 400-ing.
+ */
+export function decodeCursor(
+	token: string | undefined,
+): ConversationCursor | null {
+	if (!token) return null;
+	let raw: string;
+	try {
+		raw = fromBase64Url(token);
+	} catch {
+		return null;
+	}
+	const sep = raw.indexOf("|");
+	if (sep === -1) return null;
+	const updatedAt = Number(raw.slice(0, sep));
+	const id = raw.slice(sep + 1);
+	if (!Number.isInteger(updatedAt) || updatedAt < 0 || id.length === 0) {
+		return null;
+	}
+	return { updatedAt, id };
+}

--- a/apps/api/src/routes/conversations.test.ts
+++ b/apps/api/src/routes/conversations.test.ts
@@ -1,6 +1,7 @@
 import { SQLiteSyncDialect } from "drizzle-orm/sqlite-core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { decodeCursor, encodeCursor } from "@/lib/cursor";
 import { db } from "@/lib/db";
 
 import { conversation, message, readStatus } from "@llmchat/db";
@@ -334,5 +335,139 @@ describe("inbox archived filter", () => {
 		const res = await get("/projects/p1/conversations?archived=true", MEMBER);
 		expect(res.status).toBe(403);
 		expect(lastConversationWhere).toBeNull();
+	});
+});
+
+describe("inbox keyset pagination", () => {
+	// A conversation row shaped for the list query: the route reads updatedAt as a
+	// Date to mint the next cursor, plus id/messageCount for the row payload.
+	function row(id: string, updatedAtSec: number): Record<string, unknown> {
+		return {
+			id,
+			name: null,
+			email: null,
+			messageCount: 1,
+			updatedAt: new Date(updatedAtSec * 1000),
+		};
+	}
+
+	it("returns nextCursor only when another page exists (limit+1 overflow)", async () => {
+		// limit=2 but 3 rows come back ⇒ there IS a next page.
+		mockDb({
+			role: "agent",
+			project: PROJECT,
+			conversationRows: [row("cA", 300), row("cB", 200), row("cC", 100)],
+		});
+		const res = await get("/projects/p1/conversations?limit=2", MEMBER);
+		const body = (await res.json()) as {
+			conversations: { id: string }[];
+			nextCursor: string | null;
+		};
+		// Only `limit` rows are returned; the sentinel row is dropped.
+		expect(body.conversations.map((c) => c.id)).toEqual(["cA", "cB"]);
+		// The cursor points at the LAST returned row (cB), so the next page resumes
+		// after it.
+		expect(decodeCursor(body.nextCursor ?? undefined)).toEqual({
+			updatedAt: 200,
+			id: "cB",
+		});
+	});
+
+	it("returns nextCursor null on the last page (no overflow)", async () => {
+		mockDb({
+			role: "agent",
+			project: PROJECT,
+			conversationRows: [row("cA", 300), row("cB", 200)],
+		});
+		const res = await get("/projects/p1/conversations?limit=2", MEMBER);
+		const body = (await res.json()) as { nextCursor: string | null };
+		expect(body.nextCursor).toBeNull();
+	});
+
+	it("a cursor adds the keyset predicate, still project-scoped", async () => {
+		mockDb({ role: "agent", project: PROJECT, conversationRows: [] });
+		const cursor = encodeCursor({ updatedAt: 250, id: "cMid" });
+		await get(`/projects/p1/conversations?cursor=${cursor}`, MEMBER);
+		const sql = whereSql();
+		// Keyset on (updatedAt desc, id desc): resume strictly after the cursor.
+		expect(sql).toContain('"updated_at" <');
+		expect(sql).toContain('"id" <');
+		// Never drops the project scope.
+		expect(sql).toContain('"project_id"');
+	});
+
+	it("search spans pages: the search OR-group AND the keyset predicate coexist", async () => {
+		mockDb({
+			role: "agent",
+			project: PROJECT,
+			conversationRows: [],
+			bodyMatchIds: ["cZ"],
+		});
+		const cursor = encodeCursor({ updatedAt: 250, id: "cMid" });
+		await get(
+			`/projects/p1/conversations?search=refund&cursor=${cursor}`,
+			MEMBER,
+		);
+		const sql = whereSql();
+		// The matched set is pre-resolved (LIKE) AND paging continues within it.
+		expect(sql).toContain("like");
+		expect(sql).toContain('"updated_at" <');
+		expect(sql).toContain('"project_id"');
+	});
+
+	it("archived filter composes with the cursor", async () => {
+		mockDb({ role: "agent", project: PROJECT, conversationRows: [] });
+		const cursor = encodeCursor({ updatedAt: 250, id: "cMid" });
+		await get(
+			`/projects/p1/conversations?archived=true&cursor=${cursor}`,
+			MEMBER,
+		);
+		const sql = whereSql();
+		expect(sql).toContain('"archived_at" is not null');
+		expect(sql).toContain('"updated_at" <');
+	});
+
+	it("a garbage cursor is ignored (serves page 1, no keyset predicate, no error)", async () => {
+		mockDb({ role: "agent", project: PROJECT, conversationRows: [] });
+		const res = await get(
+			"/projects/p1/conversations?cursor=!!!garbage!!!",
+			MEMBER,
+		);
+		expect(res.status).toBe(200);
+		expect(whereSql()).not.toContain('"updated_at" <');
+	});
+});
+
+describe("inbox stats aggregate", () => {
+	it("returns true project-wide totals (not loaded-page counts)", async () => {
+		mockDb({
+			role: "agent",
+			project: PROJECT,
+			// The fake select() returns this verbatim as the single aggregate row.
+			conversationRows: [
+				{ total: 4210, escalated: 37, resolved: 1200, avgRating: 4.3 },
+			],
+		});
+		const res = await get("/projects/p1/conversations/stats", MEMBER);
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body).toEqual({
+			total: 4210,
+			escalated: 37,
+			resolved: 1200,
+			avgRating: 4.3,
+		});
+	});
+
+	it("404s when the project isn't in the caller's workspace", async () => {
+		mockDb({ role: "owner", project: undefined });
+		const res = await get("/projects/pX/conversations/stats", MEMBER);
+		expect(res.status).toBe(404);
+	});
+
+	it("403s a non-member", async () => {
+		mockDb({});
+		const res = await get("/projects/p1/conversations/stats", MEMBER);
+		expect(res.status).toBe(403);
 	});
 });

--- a/apps/api/src/routes/conversations.ts
+++ b/apps/api/src/routes/conversations.ts
@@ -2,6 +2,7 @@ import { zValidator } from "@hono/zod-validator";
 import { Hono } from "hono";
 import { z } from "zod";
 
+import { decodeCursor, encodeCursor } from "@/lib/cursor";
 import { db } from "@/lib/db";
 import { buildReplyToAddress, escapeHtml, sendEmail } from "@/lib/email";
 import {
@@ -20,6 +21,7 @@ import {
 	and,
 	asc,
 	conversation,
+	count,
 	desc,
 	eq,
 	inArray,
@@ -28,6 +30,7 @@ import {
 	message as messageTable,
 	or,
 	readStatus,
+	sql,
 } from "@llmchat/db";
 
 import type { AppContext } from "@/env";
@@ -45,13 +48,15 @@ export const conversations = new Hono<AppContext>()
 			z.object({
 				search: z.string().optional(),
 				archived: z.enum(["true", "false"]).optional(),
-				limit: z.coerce.number().int().min(1).max(100).default(50),
-				offset: z.coerce.number().int().min(0).default(0),
+				limit: z.coerce.number().int().min(1).max(100).default(30),
+				// Opaque keyset cursor (see lib/cursor). A garbage value decodes to
+				// null below and just serves the first page — never a 400.
+				cursor: z.string().optional(),
 			}),
 		),
 		async (c) => {
 			const { projectId } = c.req.param();
-			const { search, archived, limit, offset } = c.req.valid("query");
+			const { search, archived, limit, cursor } = c.req.valid("query");
 			const workspaceId = c.get("workspaceId");
 			const userId = c.get("userId");
 
@@ -108,13 +113,37 @@ export const conversations = new Hono<AppContext>()
 				conditions.push(or(...orParts)!);
 			}
 
-			const rows = await db(c.env)
+			// Keyset pagination on (updatedAt DESC, id DESC): resume strictly after
+			// the cursor row. Raw SQL compares against the stored unix-seconds integer
+			// directly, sidestepping the timestamp custom-type's driver mapping. ANDed
+			// alongside the project scope, archived filter, and search OR-group — so it
+			// composes with all of them. A garbage cursor decoded to null = page 1.
+			const cur = decodeCursor(cursor);
+			if (cur) {
+				conditions.push(
+					sql`(${conversation.updatedAt} < ${cur.updatedAt} OR (${conversation.updatedAt} = ${cur.updatedAt} AND ${conversation.id} < ${cur.id}))`,
+				);
+			}
+
+			// Fetch one extra row to know whether another page exists without a
+			// second COUNT query.
+			const page = await db(c.env)
 				.select()
 				.from(conversation)
 				.where(and(...conditions))
-				.orderBy(desc(conversation.updatedAt))
-				.limit(limit)
-				.offset(offset);
+				.orderBy(desc(conversation.updatedAt), desc(conversation.id))
+				.limit(limit + 1);
+
+			const hasMore = page.length > limit;
+			const rows = hasMore ? page.slice(0, limit) : page;
+			const last = rows.at(-1);
+			const nextCursor =
+				hasMore && last
+					? encodeCursor({
+							updatedAt: Math.floor(last.updatedAt.getTime() / 1000),
+							id: last.id,
+						})
+					: null;
 
 			// Attach the first visitor message (sequence 1) as a list preview —
 			// one bounded query keyed on the page of conversations we're returning.
@@ -212,9 +241,44 @@ export const conversations = new Hono<AppContext>()
 					unread: (readByConv.get(r.id) ?? 0) < r.messageCount,
 					match: matchFor(r),
 				})),
+				nextCursor,
 			});
 		},
 	)
+	.get("/projects/:projectId/conversations/stats", async (c) => {
+		// True project-wide totals for the inbox header — independent of the
+		// search term and the active/archived toggle, so the header is honest
+		// even though the list itself paginates (loaded-page counts would read
+		// as "so far"). One aggregate row, same ownership chain as the list.
+		const { projectId } = c.req.param();
+		const workspaceId = c.get("workspaceId");
+		const proj = await db(c.env).query.project.findFirst({
+			where: (pt, { and: a, eq: e }) =>
+				a(e(pt.id, projectId), e(pt.workspaceId, workspaceId)),
+		});
+		if (!proj) {
+			return c.json({ error: "not found" }, 404);
+		}
+
+		const [agg] = await db(c.env)
+			.select({
+				total: count(),
+				escalated: sql<number>`sum(case when ${conversation.escalatedAt} is not null then 1 else 0 end)`,
+				// "Resolved" == archived (the app's only closed state).
+				resolved: sql<number>`sum(case when ${conversation.archivedAt} is not null then 1 else 0 end)`,
+				// avg() ignores NULL csat, and is NULL when nothing is rated.
+				avgRating: sql<number | null>`avg(${conversation.csatRating})`,
+			})
+			.from(conversation)
+			.where(eq(conversation.projectId, projectId));
+
+		return c.json({
+			total: agg?.total ?? 0,
+			escalated: Number(agg?.escalated ?? 0),
+			resolved: Number(agg?.resolved ?? 0),
+			avgRating: agg?.avgRating ?? null,
+		});
+	})
 	.get("/projects/:projectId/conversations/:id", async (c) => {
 		const { projectId, id } = c.req.param();
 		const workspaceId = c.get("workspaceId");

--- a/apps/dashboard/src/app/inbox/_components/InboxStats.test.tsx
+++ b/apps/dashboard/src/app/inbox/_components/InboxStats.test.tsx
@@ -3,67 +3,53 @@ import { describe, expect, it } from "vitest";
 
 import { InboxStats } from "./InboxStats";
 
-import type { Conversation } from "./types";
+import type { ConversationStats } from "./types";
 
-function conv(overrides: Partial<Conversation> = {}): Conversation {
-	return {
-		id: crypto.randomUUID(),
-		clientId: "c",
-		name: null,
-		email: null,
-		ipAddress: null,
-		userAgent: null,
-		messageCount: 2,
-		escalatedAt: null,
-		archivedAt: null,
-		createdAt: "2026-06-16T05:00:00.000Z",
-		updatedAt: "2026-06-16T05:00:00.000Z",
-		csatRating: null,
-		...overrides,
-	};
+function stats(overrides: Partial<ConversationStats> = {}): ConversationStats {
+	return { total: 0, escalated: 0, resolved: 0, avgRating: null, ...overrides };
 }
 
-/** The avg rating card is the only stat labelled "Avg rating". */
-function avgValue(): string | null {
-	const label = screen.getByText("Avg rating");
-	// StatCard renders [value][label] as sibling divs; value is the previous one.
-	return label.previousElementSibling?.textContent ?? null;
+/** Read the value rendered above a given stat label. StatCard renders
+ * [value][label] as sibling divs. */
+function valueFor(label: string): string | null {
+	return screen.getByText(label).previousElementSibling?.textContent ?? null;
 }
 
-describe("InboxStats avg rating", () => {
-	it("averages only the rated conversations", () => {
+describe("InboxStats (server aggregate)", () => {
+	it("renders the true server totals verbatim — not loaded-page counts", () => {
 		render(
 			<InboxStats
-				conversations={[
-					conv({ csatRating: 5 }),
-					conv({ csatRating: 3 }),
-					conv({ csatRating: null }), // unrated: excluded from the average
-				]}
+				stats={stats({
+					total: 4210,
+					escalated: 37,
+					resolved: 1200,
+					avgRating: 4.3,
+				})}
 			/>,
 		);
-		expect(avgValue()).toBe("4.0");
+		// These exceed any single loaded page (30) — proving they come from the
+		// aggregate, not the rendered rows.
+		expect(valueFor("Conversations")).toBe("4210");
+		expect(valueFor("Escalated")).toBe("37");
+		expect(valueFor("Resolved")).toBe("1200");
+		expect(valueFor("Avg rating")).toBe("4.3");
 	});
 
-	it("shows a dash (no NaN) when nothing is rated", () => {
-		render(<InboxStats conversations={[conv({ csatRating: null }), conv()]} />);
-		expect(avgValue()).toBe("—");
+	it("shows a dash for avg rating (no NaN) when nothing is rated", () => {
+		render(<InboxStats stats={stats({ total: 5, avgRating: null })} />);
+		expect(valueFor("Avg rating")).toBe("—");
 	});
 
-	it("is safe with an empty conversation set", () => {
-		render(<InboxStats conversations={[]} />);
-		expect(avgValue()).toBe("—");
+	it("renders all dashes while the aggregate is still loading (undefined)", () => {
+		render(<InboxStats stats={undefined} />);
+		expect(valueFor("Conversations")).toBe("—");
+		expect(valueFor("Escalated")).toBe("—");
+		expect(valueFor("Resolved")).toBe("—");
+		expect(valueFor("Avg rating")).toBe("—");
 	});
 
 	it("rounds the average to one decimal", () => {
-		render(
-			<InboxStats
-				conversations={[
-					conv({ csatRating: 5 }),
-					conv({ csatRating: 4 }),
-					conv({ csatRating: 4 }),
-				]}
-			/>,
-		);
-		expect(avgValue()).toBe("4.3");
+		render(<InboxStats stats={stats({ total: 3, avgRating: 4.333333 })} />);
+		expect(valueFor("Avg rating")).toBe("4.3");
 	});
 });

--- a/apps/dashboard/src/app/inbox/_components/InboxStats.tsx
+++ b/apps/dashboard/src/app/inbox/_components/InboxStats.tsx
@@ -4,7 +4,7 @@ import { Star } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 
-import type { Conversation } from "./types";
+import type { ConversationStats } from "./types";
 
 function StatCard({
 	value,
@@ -34,32 +34,25 @@ function StatCard({
 }
 
 /**
- * Header stat cards derived from the loaded conversation set. "Resolved" is
- * backed by the archived count — archiving is this app's only "closed" state;
- * there is no separate resolved status. The avg rating is the mean CSAT across
- * rated conversations only, shown as "—" when none are rated (never NaN or a
- * fabricated number).
+ * Header stat cards from a TRUE server-side aggregate over the whole project —
+ * not the loaded page (which paginates, so loaded-page counts would read as
+ * "so far" and mislead). "Resolved" is backed by the archived count — archiving
+ * is this app's only "closed" state. The avg rating is the mean CSAT across
+ * rated conversations only, shown as "—" when none are rated (never NaN). While
+ * the aggregate is loading, values render as "—".
  */
-export function InboxStats({
-	conversations,
-}: {
-	conversations: Conversation[];
-}) {
-	const total = conversations.length;
-	const escalated = conversations.filter((c) => c.escalatedAt).length;
-	const resolved = conversations.filter((c) => c.archivedAt).length;
-
-	const rated = conversations.filter((c) => c.csatRating != null);
-	const avgRating =
-		rated.length > 0
-			? rated.reduce((sum, c) => sum + (c.csatRating ?? 0), 0) / rated.length
-			: null;
+export function InboxStats({ stats }: { stats?: ConversationStats }) {
+	const avgRating = stats?.avgRating ?? null;
 
 	return (
 		<div className="flex flex-wrap items-stretch gap-2">
-			<StatCard value={total} label="Conversations" />
-			<StatCard value={escalated} label="Escalated" tone="amber" />
-			<StatCard value={resolved} label="Resolved" />
+			<StatCard value={stats?.total ?? "—"} label="Conversations" />
+			<StatCard
+				value={stats?.escalated ?? "—"}
+				label="Escalated"
+				tone="amber"
+			/>
+			<StatCard value={stats?.resolved ?? "—"} label="Resolved" />
 			<StatCard
 				value={avgRating != null ? avgRating.toFixed(1) : "—"}
 				label="Avg rating"

--- a/apps/dashboard/src/app/inbox/_components/LoadMore.test.tsx
+++ b/apps/dashboard/src/app/inbox/_components/LoadMore.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { LoadMore } from "./LoadMore";
+
+describe("LoadMore", () => {
+	it("fires onLoadMore when the button is clicked", async () => {
+		const onLoadMore = vi.fn();
+		render(<LoadMore onLoadMore={onLoadMore} loading={false} />);
+		await userEvent.click(screen.getByRole("button", { name: /load more/i }));
+		expect(onLoadMore).toHaveBeenCalledTimes(1);
+	});
+
+	it("disables the button and shows a loading label while fetching", () => {
+		render(<LoadMore onLoadMore={vi.fn()} loading={true} />);
+		const btn = screen.getByRole("button");
+		expect(btn).toBeDisabled();
+		expect(btn).toHaveTextContent(/loading/i);
+	});
+});

--- a/apps/dashboard/src/app/inbox/_components/LoadMore.tsx
+++ b/apps/dashboard/src/app/inbox/_components/LoadMore.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+import { Button } from "@/components/ui/button";
+
+/**
+ * Footer for the paginated conversation list: an intersection sentinel that
+ * auto-loads the next page as it scrolls into view, with an explicit "Load more"
+ * button as the accessible fallback (and the affordance in environments without
+ * IntersectionObserver, e.g. tests). Rendered only when another page exists.
+ */
+export function LoadMore({
+	onLoadMore,
+	loading,
+}: {
+	onLoadMore: () => void;
+	loading: boolean;
+}) {
+	const ref = useRef<HTMLDivElement>(null);
+
+	useEffect(() => {
+		const el = ref.current;
+		if (!el || typeof IntersectionObserver === "undefined") return;
+		const io = new IntersectionObserver(
+			(entries) => {
+				if (entries.some((e) => e.isIntersecting) && !loading) onLoadMore();
+			},
+			{ rootMargin: "200px" },
+		);
+		io.observe(el);
+		return () => io.disconnect();
+	}, [onLoadMore, loading]);
+
+	return (
+		<div ref={ref} className="px-3 py-3">
+			<Button
+				variant="outline"
+				size="sm"
+				className="w-full"
+				onClick={onLoadMore}
+				disabled={loading}
+			>
+				{loading ? "Loading…" : "Load more"}
+			</Button>
+		</div>
+	);
+}

--- a/apps/dashboard/src/app/inbox/_components/conversation-list.test.ts
+++ b/apps/dashboard/src/app/inbox/_components/conversation-list.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	dropConversationFromCache,
+	flattenPages,
+	mergeConversationPages,
+	setConversationRead,
+	type ConversationPage,
+} from "./conversation-list";
+
+import type { Conversation } from "./types";
+
+function conv(overrides: Partial<Conversation> & { id: string }): Conversation {
+	return {
+		clientId: "c",
+		name: null,
+		email: null,
+		ipAddress: null,
+		userAgent: null,
+		messageCount: 1,
+		escalatedAt: null,
+		archivedAt: null,
+		createdAt: "2026-06-16T05:00:00.000Z",
+		updatedAt: "2026-06-16T05:00:00.000Z",
+		csatRating: null,
+		...overrides,
+	};
+}
+
+function page(conversations: Conversation[]): ConversationPage {
+	return { conversations, nextCursor: null };
+}
+
+function infinite(pages: ConversationPage[]) {
+	return { pages, pageParams: [] as unknown[] };
+}
+
+describe("mergeConversationPages", () => {
+	it("dedupes the head/page overlap (head wins) — no duplicate rows", () => {
+		const head = [
+			conv({ id: "a", updatedAt: "2026-06-16T10:00:00.000Z", unread: false }),
+			conv({ id: "b", updatedAt: "2026-06-16T09:00:00.000Z" }),
+		];
+		// Page 1 overlaps the head and carries a STALE copy of "a" (still unread).
+		const pageRows = [
+			conv({ id: "a", updatedAt: "2026-06-16T08:00:00.000Z", unread: true }),
+			conv({ id: "b", updatedAt: "2026-06-16T09:00:00.000Z" }),
+			conv({ id: "c", updatedAt: "2026-06-16T07:00:00.000Z" }),
+		];
+		const merged = mergeConversationPages([head, pageRows]);
+		// Each id appears exactly once.
+		expect(merged.map((c) => c.id)).toEqual(["a", "b", "c"]);
+		// The head's fresher "a" (read + newer updatedAt) wins over the stale page copy.
+		expect(merged[0]).toMatchObject({ id: "a", unread: false });
+	});
+
+	it("sorts by (updatedAt desc, id desc) regardless of input order", () => {
+		const rows = [
+			conv({ id: "x", updatedAt: "2026-06-16T01:00:00.000Z" }),
+			conv({ id: "z", updatedAt: "2026-06-16T03:00:00.000Z" }),
+			// Same timestamp as z → id desc breaks the tie (z before y).
+			conv({ id: "y", updatedAt: "2026-06-16T03:00:00.000Z" }),
+		];
+		expect(mergeConversationPages([rows]).map((c) => c.id)).toEqual([
+			"z",
+			"y",
+			"x",
+		]);
+	});
+
+	it("ignores undefined sources (head not loaded yet)", () => {
+		const pageRows = [conv({ id: "a" })];
+		expect(
+			mergeConversationPages([undefined, pageRows]).map((c) => c.id),
+		).toEqual(["a"]);
+	});
+});
+
+describe("flattenPages", () => {
+	it("flattens an infinite cache's pages into one list", () => {
+		const data = infinite([
+			page([conv({ id: "a" }), conv({ id: "b" })]),
+			page([conv({ id: "c" })]),
+		]);
+		expect(flattenPages(data).map((c) => c.id)).toEqual(["a", "b", "c"]);
+		expect(flattenPages(undefined)).toEqual([]);
+	});
+});
+
+describe("dropConversationFromCache (shape-aware)", () => {
+	it("removes from the head cache shape ({ conversations })", () => {
+		const prev = page([conv({ id: "a" }), conv({ id: "b" })]);
+		const next = dropConversationFromCache(prev, "a") as ConversationPage;
+		expect(next.conversations.map((c) => c.id)).toEqual(["b"]);
+	});
+
+	it("removes from EVERY page of the infinite cache shape ({ pages })", () => {
+		const prev = infinite([
+			page([conv({ id: "a" }), conv({ id: "b" })]),
+			page([conv({ id: "a" }), conv({ id: "c" })]), // dup id across pages
+		]);
+		const next = dropConversationFromCache(prev, "a") as ReturnType<
+			typeof infinite
+		>;
+		expect(next.pages[0].conversations.map((c) => c.id)).toEqual(["b"]);
+		expect(next.pages[1].conversations.map((c) => c.id)).toEqual(["c"]);
+	});
+
+	it("passes unknown shapes / undefined through unchanged", () => {
+		expect(dropConversationFromCache(undefined, "a")).toBeUndefined();
+		expect(dropConversationFromCache({ nope: 1 }, "a")).toEqual({ nope: 1 });
+	});
+});
+
+describe("setConversationRead (shape-aware)", () => {
+	it("clears unread for one id across both cache shapes", () => {
+		const head = page([
+			conv({ id: "a", unread: true }),
+			conv({ id: "b", unread: true }),
+		]);
+		const nextHead = setConversationRead(head, "a") as ConversationPage;
+		expect(nextHead.conversations[0]).toMatchObject({ id: "a", unread: false });
+		expect(nextHead.conversations[1]).toMatchObject({ id: "b", unread: true });
+
+		const inf = infinite([page([conv({ id: "a", unread: true })])]);
+		const nextInf = setConversationRead(inf, "a") as ReturnType<
+			typeof infinite
+		>;
+		expect(nextInf.pages[0].conversations[0]).toMatchObject({
+			id: "a",
+			unread: false,
+		});
+	});
+});

--- a/apps/dashboard/src/app/inbox/_components/conversation-list.ts
+++ b/apps/dashboard/src/app/inbox/_components/conversation-list.ts
@@ -1,0 +1,97 @@
+import type { Conversation } from "./types";
+
+/** A single list page from the API. */
+export interface ConversationPage {
+	conversations: Conversation[];
+	nextCursor: string | null;
+}
+
+/** react-query's `useInfiniteQuery` cache shape. */
+interface InfiniteCache {
+	pages: ConversationPage[];
+	pageParams: unknown[];
+}
+
+/**
+ * Sort comparator matching the server keyset: (updatedAt DESC, id DESC). Applied
+ * client-side after merging the polled head with the loaded pages, so a freshly
+ * bumped conversation lands in the right slot regardless of which source it came
+ * from.
+ */
+function byRecency(a: Conversation, b: Conversation): number {
+	if (a.updatedAt !== b.updatedAt) return a.updatedAt < b.updatedAt ? 1 : -1;
+	return a.id < b.id ? 1 : -1;
+}
+
+/**
+ * Merge the polled head page with the infinite query's loaded pages into the
+ * single ordered list the inbox renders. Deduped by id with the FIRST occurrence
+ * winning — callers pass the head first, so its fresher copy (newer updatedAt,
+ * cleared unread) supersedes a stale copy still sitting in a loaded page. This is
+ * what lets the 5s head poll surface new/bumped conversations without the
+ * infinite query refetching every page, and without duplicate rows.
+ */
+export function mergeConversationPages(
+	lists: (Conversation[] | undefined)[],
+): Conversation[] {
+	const seen = new Set<string>();
+	const merged: Conversation[] = [];
+	for (const list of lists) {
+		if (!list) continue;
+		for (const c of list) {
+			if (seen.has(c.id)) continue;
+			seen.add(c.id);
+			merged.push(c);
+		}
+	}
+	return merged.sort(byRecency);
+}
+
+/** Flatten an infinite-query cache's pages into a single conversation list. */
+export function flattenPages(data: InfiniteCache | undefined): Conversation[] {
+	return data ? data.pages.flatMap((p) => p.conversations) : [];
+}
+
+/**
+ * Apply `fn` to the conversation arrays inside whichever cache shape `prev` is —
+ * the head query's `{ conversations }` or the infinite query's `{ pages: [...] }`.
+ * Pure, immutable, undefined-safe (returns the input unchanged when it's neither
+ * shape). One updater drives both caches so a single optimistic write spans them.
+ */
+function mapConversationsInCache(
+	prev: unknown,
+	fn: (list: Conversation[]) => Conversation[],
+): unknown {
+	if (!prev || typeof prev !== "object") return prev;
+	if ("pages" in prev && Array.isArray((prev as InfiniteCache).pages)) {
+		const cache = prev as InfiniteCache;
+		return {
+			...cache,
+			pages: cache.pages.map((page) => ({
+				...page,
+				conversations: fn(page.conversations),
+			})),
+		};
+	}
+	if ("conversations" in prev) {
+		const cache = prev as { conversations: Conversation[] };
+		if (!Array.isArray(cache.conversations)) return prev;
+		return { ...cache, conversations: fn(cache.conversations) };
+	}
+	return prev;
+}
+
+/** Optimistic updater: remove a conversation by id from head + infinite caches. */
+export function dropConversationFromCache(prev: unknown, id: string): unknown {
+	return mapConversationsInCache(prev, (list) =>
+		list.filter((c) => c.id !== id),
+	);
+}
+
+/** Optimistic updater: mark a conversation read (clear its unread dot) across
+ * head + infinite caches, so a deep-in-a-page row clears without a refetch. */
+export function setConversationRead(prev: unknown, id: string): unknown {
+	return mapConversationsInCache(prev, (list) =>
+		list.map((c) => (c.id === id ? { ...c, unread: false } : c)),
+	);
+}

--- a/apps/dashboard/src/app/inbox/_components/types.ts
+++ b/apps/dashboard/src/app/inbox/_components/types.ts
@@ -29,6 +29,15 @@ export interface SearchMatch {
 	snippet: string;
 }
 
+/** True project-wide totals for the inbox header (server aggregate, not
+ * loaded-page counts). `avgRating` is null when no conversation is rated. */
+export interface ConversationStats {
+	total: number;
+	escalated: number;
+	resolved: number;
+	avgRating: number | null;
+}
+
 export interface Message {
 	id: string;
 	role: "user" | "assistant" | "admin" | "system";

--- a/apps/dashboard/src/app/inbox/page.tsx
+++ b/apps/dashboard/src/app/inbox/page.tsx
@@ -1,6 +1,10 @@
 "use client";
 
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+	useInfiniteQuery,
+	useQuery,
+	useQueryClient,
+} from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
@@ -8,7 +12,7 @@ import { toast } from "sonner";
 import { Badge } from "@/components/ui/badge";
 import { api, describeApiError } from "@/lib/api";
 import { resolveOnboardingState } from "@/lib/onboarding";
-import { dropById, useOptimisticMutation } from "@/lib/optimistic";
+import { useOptimisticMutation } from "@/lib/optimistic";
 import { resolveSelectedId } from "@/lib/selection";
 import { useDebouncedValue } from "@/lib/use-debounced-value";
 import { cn } from "@/lib/utils";
@@ -17,18 +21,32 @@ import { track, ANALYTICS_EVENTS } from "@/lib/analytics";
 
 import { ConversationList } from "./_components/ConversationList";
 import { ConversationListSkeleton } from "./_components/ConversationListSkeleton";
+import {
+	dropConversationFromCache,
+	flattenPages,
+	mergeConversationPages,
+	setConversationRead,
+	type ConversationPage,
+} from "./_components/conversation-list";
 import { DetailPanel } from "./_components/DetailPanel";
 import { initials, parseDevice, pluralize } from "./_components/format";
 import { InboxPanes } from "./_components/InboxPanes";
 import { InboxSkeleton } from "./_components/InboxSkeleton";
 import { InboxStats } from "./_components/InboxStats";
 import { InboxToolbar } from "./_components/InboxToolbar";
+import { LoadMore } from "./_components/LoadMore";
 import { MessageThread } from "./_components/MessageThread";
 import { appendOptimisticReply } from "./_components/optimistic-updaters";
 import { ProjectSwitcher } from "./_components/ProjectSwitcher";
 import { ReplyComposer } from "./_components/ReplyComposer";
-import type { Conversation, Message } from "./_components/types";
+import type {
+	Conversation,
+	ConversationStats,
+	Message,
+} from "./_components/types";
 import type { ProjectOption } from "./_components/ProjectSwitcher";
+
+const PAGE_SIZE = 30;
 
 export default function InboxPage() {
 	const {
@@ -75,19 +93,71 @@ export default function InboxPage() {
 	// and drives the conversation list + the per-row match snippets.
 	const debouncedSearch = useDebouncedValue(search.trim(), 250);
 
-	const conversations = useQuery({
-		queryKey: ["conversations", projectId, debouncedSearch, showArchived],
-		enabled: !!projectId && !!workspaceId,
-		refetchInterval: 5_000,
-		queryFn: () => {
-			const params = new URLSearchParams({ limit: "100" });
+	// Build the list query string for a given cursor. Search + archived go to the
+	// server (pre-resolved before LIMIT), so they compose with keyset paging.
+	const listParams = useCallback(
+		(cursor?: string) => {
+			const params = new URLSearchParams({ limit: String(PAGE_SIZE) });
 			if (debouncedSearch) params.set("search", debouncedSearch);
 			if (showArchived) params.set("archived", "true");
-			return api<{ conversations: Conversation[] }>(
-				`/api/projects/${projectId}/conversations?${params.toString()}`,
-				{ workspaceId: workspaceId! },
-			);
+			if (cursor) params.set("cursor", cursor);
+			return params.toString();
 		},
+		[debouncedSearch, showArchived],
+	);
+
+	// The paginated list: keyset cursor, NO polling (a background refetch of an
+	// infinite query re-pulls every loaded page). It only fetches on mount and on
+	// fetchNextPage.
+	const listQuery = useInfiniteQuery({
+		queryKey: [
+			"conversations",
+			projectId,
+			"list",
+			debouncedSearch,
+			showArchived,
+		],
+		enabled: !!projectId && !!workspaceId,
+		initialPageParam: undefined as string | undefined,
+		queryFn: ({ pageParam }) =>
+			api<ConversationPage>(
+				`/api/projects/${projectId}/conversations?${listParams(pageParam)}`,
+				{ workspaceId: workspaceId! },
+			),
+		getNextPageParam: (last) => last.nextCursor ?? undefined,
+	});
+
+	// The poll lives on a separate HEAD query — just the newest page, every 5s.
+	// One O(1) request regardless of how many pages are loaded, so paging never
+	// multiplies poll traffic. Merged with the loaded pages at render time.
+	const headQuery = useQuery({
+		queryKey: [
+			"conversations",
+			projectId,
+			"head",
+			debouncedSearch,
+			showArchived,
+		],
+		enabled: !!projectId && !!workspaceId,
+		refetchInterval: 5_000,
+		queryFn: () =>
+			api<ConversationPage>(
+				`/api/projects/${projectId}/conversations?${listParams()}`,
+				{ workspaceId: workspaceId! },
+			),
+	});
+
+	// True project-wide totals for the header — a server aggregate, independent of
+	// the loaded pages / search / archived filter, so the stats never read as
+	// "loaded so far".
+	const statsQuery = useQuery({
+		queryKey: ["conversation-stats", projectId],
+		enabled: !!projectId && !!workspaceId,
+		refetchInterval: 10_000,
+		queryFn: () =>
+			api<ConversationStats>(`/api/projects/${projectId}/conversations/stats`, {
+				workspaceId: workspaceId!,
+			}),
 	});
 
 	const thread = useQuery({
@@ -101,30 +171,38 @@ export default function InboxPage() {
 			),
 	});
 
-	// Both filters are server-side now: text search (name/email/message body) and
-	// the active-vs-archived split. The returned rows are exactly what the list
-	// should show, so there's no client-side filtering left to do.
+	// Render set = the polled head merged with the loaded pages, deduped by id
+	// (head wins → freshest copy) and re-sorted by (updatedAt desc, id desc). New
+	// or bumped conversations arrive via the head poll and slot in correctly
+	// without the infinite query refetching, and without duplicate rows.
 	const allConversations = useMemo(
-		() => conversations.data?.conversations ?? [],
-		[conversations.data],
+		() =>
+			mergeConversationPages([
+				headQuery.data?.conversations,
+				flattenPages(listQuery.data),
+			]),
+		[headQuery.data, listQuery.data],
 	);
 
 	const selectedConv = allConversations.find((c) => c.id === selectedId);
 	const detailConv = thread.data?.conversation ?? selectedConv ?? null;
 
-	// Mark a conversation read for this user (existing readStatus PATCH), then
-	// refresh the list so its unread dot clears. Best-effort: a failure just
-	// leaves the dot.
+	// Mark a conversation read for this user. Optimistically clears the unread dot
+	// in-cache across the head + loaded pages (so a row deep in a loaded page
+	// clears instantly without any refetch), then PATCHes. Best-effort: on failure
+	// the next head poll restores the true unread state.
 	const markRead = useCallback(
 		async (id: string) => {
 			if (!projectId || !workspaceId) return;
+			qc.setQueriesData({ queryKey: ["conversations", projectId] }, (prev) =>
+				setConversationRead(prev, id),
+			);
 			try {
 				await api(`/api/projects/${projectId}/conversations/${id}`, {
 					method: "PATCH",
 					body: { read: true },
 					workspaceId,
 				});
-				await qc.invalidateQueries({ queryKey: ["conversations", projectId] });
 			} catch {
 				/* non-critical */
 			}
@@ -182,8 +260,12 @@ export default function InboxPage() {
 		onSuccess: () => {
 			setReply("");
 			toast.success("Reply sent");
-			// The reply bumps updatedAt + the preview, so refresh the list order too.
-			void qc.invalidateQueries({ queryKey: ["conversations", projectId] });
+			// The reply bumps updatedAt + the preview. Revalidate the HEAD only (not
+			// the whole paginated list): the conversation jumps to the newest page,
+			// and the render merge re-sorts it to the top from there.
+			void qc.invalidateQueries({
+				queryKey: ["conversations", projectId, "head"],
+			});
 		},
 		onError: (e) => toast.error(describeApiError(e, "Failed to send reply")),
 	});
@@ -194,8 +276,12 @@ export default function InboxPage() {
 		id: string;
 		nextArchived: boolean;
 	}>({
+		// Optimistically drop the row from BOTH the head and every loaded page
+		// (wide key), but only revalidate the head on settle — never an all-pages
+		// refetch of the infinite list.
 		queryKey: ["conversations", projectId],
-		apply: (prev, vars) => dropById(prev, "conversations", vars.id),
+		invalidateKey: ["conversations", projectId, "head"],
+		apply: (prev, vars) => dropConversationFromCache(prev, vars.id),
 		mutationFn: (vars) =>
 			api(`/api/projects/${projectId}/conversations/${vars.id}`, {
 				method: "PATCH",
@@ -212,7 +298,8 @@ export default function InboxPage() {
 
 	const deleteMut = useOptimisticMutation<string>({
 		queryKey: ["conversations", projectId],
-		apply: (prev, id) => dropById(prev, "conversations", id),
+		invalidateKey: ["conversations", projectId, "head"],
+		apply: (prev, id) => dropConversationFromCache(prev, id),
 		mutationFn: (id) =>
 			api(`/api/projects/${projectId}/conversations/${id}`, {
 				method: "DELETE",
@@ -280,7 +367,7 @@ export default function InboxPage() {
 							All visitor conversations in one inbox.
 						</p>
 					</div>
-					<InboxStats conversations={allConversations} />
+					<InboxStats stats={statsQuery.data} />
 				</header>
 
 				<InboxToolbar
@@ -306,16 +393,24 @@ export default function InboxPage() {
 							value={projectId}
 							onChange={handleProjectChange}
 						/>
-						{conversations.isLoading ? (
+						{listQuery.isLoading ? (
 							<ConversationListSkeleton />
 						) : (
-							<ConversationList
-								conversations={allConversations}
-								selectedId={selectedId}
-								onSelect={handleSelect}
-								search={debouncedSearch}
-								showArchived={showArchived}
-							/>
+							<>
+								<ConversationList
+									conversations={allConversations}
+									selectedId={selectedId}
+									onSelect={handleSelect}
+									search={debouncedSearch}
+									showArchived={showArchived}
+								/>
+								{listQuery.hasNextPage && (
+									<LoadMore
+										onLoadMore={() => void listQuery.fetchNextPage()}
+										loading={listQuery.isFetchingNextPage}
+									/>
+								)}
+							</>
 						)}
 					</>
 				}

--- a/apps/dashboard/src/lib/optimistic.test.tsx
+++ b/apps/dashboard/src/lib/optimistic.test.tsx
@@ -1,7 +1,7 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { createElement, type ReactNode } from "react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { dropById, mapById, useOptimisticMutation } from "./optimistic";
 
@@ -135,6 +135,35 @@ describe("useOptimisticMutation", () => {
 		await waitFor(() => expect(result.current.isError).toBe(true));
 		// Cache is byte-for-byte back to the pre-mutation snapshot.
 		expect(client.getQueryData(tc.key)).toEqual(tc.seed);
+	});
+
+	it("invalidates only invalidateKey when narrower than queryKey", async () => {
+		// The conversation list optimistically updates the wide key (head + every
+		// loaded page) but must revalidate ONLY the head — never refetch all pages.
+		const client = makeClient();
+		const spy = vi.spyOn(client, "invalidateQueries");
+		client.setQueryData(["conversations", "p1", "head"], {
+			conversations: [{ id: "a" }],
+		});
+
+		const { result } = renderHook(
+			() =>
+				useOptimisticMutation<string>({
+					queryKey: ["conversations", "p1"],
+					invalidateKey: ["conversations", "p1", "head"],
+					apply: (prev, id) => dropById(prev, "conversations", id),
+					mutationFn: () => Promise.resolve({ ok: true }),
+				}),
+			{ wrapper: wrapperFor(client) },
+		);
+
+		act(() => result.current.mutate("a"));
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+		const invalidatedKeys = spy.mock.calls.map((c) => c[0]?.queryKey);
+		expect(invalidatedKeys).toContainEqual(["conversations", "p1", "head"]);
+		// The wide key (which would refetch the paginated "list") is never invalidated.
+		expect(invalidatedKeys).not.toContainEqual(["conversations", "p1"]);
 	});
 
 	it("rolls back every cached variant of a partial key", async () => {

--- a/apps/dashboard/src/lib/optimistic.ts
+++ b/apps/dashboard/src/lib/optimistic.ts
@@ -30,6 +30,14 @@ export interface OptimisticMutationOptions<TVars, TData> {
 	apply: (prev: unknown, vars: TVars) => unknown;
 	onSuccess?: (data: TData, vars: TVars) => void;
 	onError?: (error: unknown, vars: TVars) => void;
+	/**
+	 * Key to invalidate on settle, when it must be NARROWER than `queryKey`.
+	 * Defaults to `queryKey`. The conversation list uses this to optimistically
+	 * update both the head + paginated caches (the wide `queryKey`) while only
+	 * revalidating the head — so a mutation never triggers an all-pages refetch
+	 * of the infinite query.
+	 */
+	invalidateKey?: QueryKey;
 }
 
 interface RollbackContext {
@@ -42,6 +50,7 @@ export function useOptimisticMutation<TVars, TData = unknown>({
 	apply,
 	onSuccess,
 	onError,
+	invalidateKey,
 }: OptimisticMutationOptions<TVars, TData>) {
 	const qc = useQueryClient();
 	return useMutation<TData, unknown, TVars, RollbackContext>({
@@ -65,7 +74,7 @@ export function useOptimisticMutation<TVars, TData = unknown>({
 		},
 		onSuccess,
 		onSettled: () => {
-			void qc.invalidateQueries({ queryKey });
+			void qc.invalidateQueries({ queryKey: invalidateKey ?? queryKey });
 		},
 	});
 }


### PR DESCRIPTION
Phase 2 of the optimistic-updates + pagination plan. Paginates the inbox conversation list and makes the header stats honest. (Phase 3 — message-thread pagination — stays deferred.)

## Server
- **Keyset cursor.** The list query moves OFFSET → keyset on `(updatedAt DESC, id DESC)` for a stable feed under inserts. Opaque base64url cursor (`lib/cursor.ts`); a garbage token decodes to `null` → serves page 1 (never a 400 mid-scroll). Fetches `limit + 1` to emit `nextCursor` only when another page exists. **Composes** with the existing project scope, the `archivedAt` filter, and the **pre-resolved search match-set** — so search spans pages. RBAC/scoping unchanged.
- **Stats aggregate.** New `GET /projects/:id/conversations/stats` (registered before `/:id` so "stats" isn't parsed as an id): one query of **true project-wide totals** — `count`, escalated, resolved (= archived), `avg(csat)` — independent of the search term and archived toggle. Same ownership chain (404/403 gated).

## Client
- `useInfiniteQuery` + an IntersectionObserver **"Load more"** footer.
- **Poll stays page-1-only.** A separate 5s **head** query (no cursor) carries the poll; the infinite list itself never refetches its pages. Render = `mergeConversationPages(head, loadedPages)` → **deduped by id (head wins), re-sorted** → new/bumped conversations appear with **no duplicate rows** and no all-pages refetch.
- **InboxStats** now consumes the server aggregate (was loaded-page counts — the data-honesty fix).
- **Composes with Phase 1:** optimistic archive/delete updaters are now shape-aware (head `{conversations}` + infinite `{pages}`); added `invalidateKey` to `useOptimisticMutation` so they (and reply) revalidate **only the head** — never an all-pages refetch. `markRead` clears the unread dot in-cache (no network).

## Tests
Cursor round-trip + garbage→null; route keyset predicate (project-scoped), `nextCursor` only on overflow, **search-spans-pages**, **archived composes with cursor**, garbage-cursor-ignored; **stats true totals** + 404/403; **merge dedupe+sort (no dupes)**; shape-aware drop/markRead updaters; `invalidateKey` scoping (list never invalidated); LoadMore.

All 5 packages' suites pass (API 168, dashboard 256); lint/format clean; no secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)