### PR TITLE
feat(inbox): paginate the message thread — latest-first + load older (Phase 3)

### DIFF
--- a/apps/api/src/routes/conversations.test.ts
+++ b/apps/api/src/routes/conversations.test.ts
@@ -51,6 +51,10 @@ interface State {
 	snippetRows?: { conversationId: string; content: string }[];
 	/** Sequence-1 previews for the firstMessage query. */
 	firstMessages?: { conversationId: string; content: string }[];
+	/** The conversation the thread endpoint resolves (undefined ⇒ 404). */
+	conv?: Row;
+	/** Rows the thread message window query returns (relational findMany). */
+	threadMessages?: Row[];
 }
 
 /** Records the shape of every message-table query so tests can assert the
@@ -122,6 +126,12 @@ function mockDb(state: State) {
 			},
 			project: {
 				findFirst: async () => state.project,
+			},
+			conversation: {
+				findFirst: async () => state.conv,
+			},
+			message: {
+				findMany: async () => state.threadMessages ?? [],
 			},
 		},
 		select: () => builder(false),
@@ -468,6 +478,92 @@ describe("inbox stats aggregate", () => {
 	it("403s a non-member", async () => {
 		mockDb({});
 		const res = await get("/projects/p1/conversations/stats", MEMBER);
+		expect(res.status).toBe(403);
+	});
+});
+
+describe("thread pagination (GET conversations/:id)", () => {
+	const CONV = { id: "cThread", projectId: "p1" };
+
+	it("latest page: returns ascending messages + hasOlder via the limit+1 sentinel", async () => {
+		mockDb({
+			role: "agent",
+			project: PROJECT,
+			conv: CONV,
+			// Server fetches newest-first limit+1; with limit=2 these 3 rows ⇒ older
+			// history exists.
+			threadMessages: [
+				{ id: "m3", sequence: 3 },
+				{ id: "m2", sequence: 2 },
+				{ id: "m1", sequence: 1 },
+			],
+		});
+		const res = await get("/projects/p1/conversations/cThread?limit=2", MEMBER);
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as {
+			messages: { sequence: number }[];
+			hasOlder: boolean;
+			firstHitSequence: number | null;
+		};
+		// `limit` rows, re-sorted ascending (oldest→newest).
+		expect(body.messages.map((m) => m.sequence)).toEqual([2, 3]);
+		expect(body.hasOlder).toBe(true);
+		expect(body.firstHitSequence).toBeNull();
+	});
+
+	it("after=<seq> (poll) never reports hasOlder — newest-only, no sentinel", async () => {
+		mockDb({
+			role: "agent",
+			project: PROJECT,
+			conv: CONV,
+			threadMessages: [{ id: "m9", sequence: 9 }],
+		});
+		const res = await get("/projects/p1/conversations/cThread?after=8", MEMBER);
+		const body = (await res.json()) as {
+			messages: { sequence: number }[];
+			hasOlder: boolean;
+		};
+		expect(body.messages.map((m) => m.sequence)).toEqual([9]);
+		expect(body.hasOlder).toBe(false);
+	});
+
+	it("search reports the first hit's sequence so the client can page to it", async () => {
+		mockDb({
+			role: "agent",
+			project: PROJECT,
+			conv: CONV,
+			threadMessages: [{ id: "m20", sequence: 20 }],
+			// The firstHit lookup (core select) resolves to this.
+			firstMessages: [
+				{ sequence: 7 } as unknown as {
+					conversationId: string;
+					content: string;
+				},
+			],
+		});
+		const res = await get(
+			"/projects/p1/conversations/cThread?search=refund",
+			MEMBER,
+		);
+		const body = (await res.json()) as { firstHitSequence: number | null };
+		expect(body.firstHitSequence).toBe(7);
+	});
+
+	it("404s when the project isn't in the caller's workspace", async () => {
+		mockDb({ role: "owner", project: undefined });
+		const res = await get("/projects/pX/conversations/cThread", MEMBER);
+		expect(res.status).toBe(404);
+	});
+
+	it("404s when the conversation doesn't exist in the project", async () => {
+		mockDb({ role: "agent", project: PROJECT, conv: undefined });
+		const res = await get("/projects/p1/conversations/nope", MEMBER);
+		expect(res.status).toBe(404);
+	});
+
+	it("403s a non-member (no query runs)", async () => {
+		mockDb({});
+		const res = await get("/projects/p1/conversations/cThread", MEMBER);
 		expect(res.status).toBe(403);
 	});
 });

--- a/apps/api/src/routes/conversations.ts
+++ b/apps/api/src/routes/conversations.ts
@@ -279,29 +279,95 @@ export const conversations = new Hono<AppContext>()
 			avgRating: agg?.avgRating ?? null,
 		});
 	})
-	.get("/projects/:projectId/conversations/:id", async (c) => {
-		const { projectId, id } = c.req.param();
-		const workspaceId = c.get("workspaceId");
-		const proj = await db(c.env).query.project.findFirst({
-			where: (pt, { and: a, eq: e }) =>
-				a(e(pt.id, projectId), e(pt.workspaceId, workspaceId)),
-		});
-		if (!proj) {
-			return c.json({ error: "not found" }, 404);
-		}
-		const conv = await db(c.env).query.conversation.findFirst({
-			where: (ct, { and: a, eq: e }) =>
-				a(e(ct.id, id), e(ct.projectId, projectId)),
-		});
-		if (!conv) {
-			return c.json({ error: "not found" }, 404);
-		}
-		const messages = await db(c.env).query.message.findMany({
-			where: (mt, { eq: e }) => e(mt.conversationId, id),
-			orderBy: (mt, ops) => ops.asc(mt.sequence),
-		});
-		return c.json({ conversation: conv, messages });
-	})
+	.get(
+		"/projects/:projectId/conversations/:id",
+		zValidator(
+			"query",
+			z.object({
+				limit: z.coerce.number().int().min(1).max(100).default(50),
+				// Keyset on `sequence` (monotonic per conversation). `before` loads the
+				// older page above; `after` is the newest-only poll; neither ⇒ the
+				// latest page. `search` reports where the first hit is so the client can
+				// page to it.
+				before: z.coerce.number().int().optional(),
+				after: z.coerce.number().int().optional(),
+				search: z.string().optional(),
+			}),
+		),
+		async (c) => {
+			const { projectId, id } = c.req.param();
+			const { limit, before, after, search } = c.req.valid("query");
+			const workspaceId = c.get("workspaceId");
+			const proj = await db(c.env).query.project.findFirst({
+				where: (pt, { and: a, eq: e }) =>
+					a(e(pt.id, projectId), e(pt.workspaceId, workspaceId)),
+			});
+			if (!proj) {
+				return c.json({ error: "not found" }, 404);
+			}
+			const conv = await db(c.env).query.conversation.findFirst({
+				where: (ct, { and: a, eq: e }) =>
+					a(e(ct.id, id), e(ct.projectId, projectId)),
+			});
+			if (!conv) {
+				return c.json({ error: "not found" }, 404);
+			}
+
+			let messages;
+			let hasOlder = false;
+			if (after !== undefined) {
+				// Poll: only messages newer than what the client holds. Bounded so a
+				// long-idle tab can't pull an unbounded backlog in one go.
+				messages = await db(c.env).query.message.findMany({
+					where: (mt, { and: a, eq: e, gt }) =>
+						a(e(mt.conversationId, id), gt(mt.sequence, after)),
+					orderBy: (mt, { asc: ascOp }) => ascOp(mt.sequence),
+					limit: 200,
+				});
+			} else {
+				// Latest page (no cursor) or the older page above `before`. Fetch
+				// limit+1 newest-first to detect more history without trusting sequence
+				// to start at 1, then return `limit` rows ascending.
+				const desc = await db(c.env).query.message.findMany({
+					where: (mt, { and: a, eq: e, lt }) =>
+						before === undefined
+							? e(mt.conversationId, id)
+							: a(e(mt.conversationId, id), lt(mt.sequence, before)),
+					orderBy: (mt, { desc: descOp }) => descOp(mt.sequence),
+					limit: limit + 1,
+				});
+				hasOlder = desc.length > limit;
+				messages = desc.slice(0, limit).reverse();
+			}
+
+			// Tell the client the sequence of the FIRST (oldest) message matching the
+			// search term, so it can page older until that message is loaded and then
+			// scroll to it — a hit in an unloaded page would otherwise be invisible.
+			let firstHitSequence: number | null = null;
+			const term = search?.trim();
+			if (term) {
+				const [hit] = await db(c.env)
+					.select({ sequence: messageTable.sequence })
+					.from(messageTable)
+					.where(
+						and(
+							eq(messageTable.conversationId, id),
+							likeContains(messageTable.content, term),
+						),
+					)
+					.orderBy(asc(messageTable.sequence))
+					.limit(1);
+				firstHitSequence = hit?.sequence ?? null;
+			}
+
+			return c.json({
+				conversation: conv,
+				messages,
+				hasOlder,
+				firstHitSequence,
+			});
+		},
+	)
 	.post(
 		"/projects/:projectId/conversations/:id/reply",
 		zValidator("json", z.object({ content: z.string().min(1) })),

--- a/apps/dashboard/src/app/inbox/_components/MessageThread.test.tsx
+++ b/apps/dashboard/src/app/inbox/_components/MessageThread.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { MessageThread } from "./MessageThread";
@@ -252,6 +252,87 @@ describe("MessageThread auto-scroll (useStickToBottom)", () => {
 		expect(
 			container.querySelector('[aria-label="Scroll to latest message"]'),
 		).toBeInTheDocument();
+	});
+});
+
+describe("MessageThread pagination (load older)", () => {
+	function olderThenNewer() {
+		return {
+			base: [
+				msg({ id: "n1", content: "newer 1", sequence: 51 }),
+				msg({ id: "n2", content: "newer 2", sequence: 52 }),
+			],
+			prepended: [
+				// Older history paged in ABOVE — the last (newest) message is unchanged.
+				msg({ id: "o1", content: "older 1", sequence: 49 }),
+				msg({ id: "o2", content: "older 2", sequence: 50 }),
+				msg({ id: "n1", content: "newer 1", sequence: 51 }),
+				msg({ id: "n2", content: "newer 2", sequence: 52 }),
+			],
+		};
+	}
+
+	it("does NOT yank to the bottom when older history is prepended", () => {
+		const { base, prepended } = olderThenNewer();
+		const { el, rerender } = renderThread(base);
+		const s = mockScroll(el, { scrollHeight: 1000, clientHeight: 400 });
+		s.setTop(0); // reading the top of the loaded window
+
+		rerender(<MessageThread messages={prepended} />);
+		// The newest-message id is unchanged, so stick-to-bottom never fires.
+		expect(s.top).not.toBe(1000);
+		expect(s.top).toBe(0);
+	});
+
+	it("anchors the viewport: scrollTop shifts down by the prepended height", () => {
+		const { base, prepended } = olderThenNewer();
+		const { el, rerender } = renderThread(base);
+
+		// Dynamic scrollHeight: prepending older content grows the scroll area.
+		let height = 1000;
+		let top = 0;
+		Object.defineProperty(el, "scrollHeight", {
+			configurable: true,
+			get: () => height,
+		});
+		Object.defineProperty(el, "clientHeight", {
+			configurable: true,
+			get: () => 400,
+		});
+		Object.defineProperty(el, "scrollTop", {
+			configurable: true,
+			get: () => top,
+			set: (v: number) => {
+				top = v;
+			},
+		});
+		act(() => el.dispatchEvent(new Event("scroll"))); // commit initial metrics
+
+		height = 1300; // 300px of older messages added on top
+		rerender(<MessageThread messages={prepended} />);
+		// Anchored: the message the user was viewing stays put, pushed down by 300.
+		expect(top).toBe(300);
+	});
+
+	it("shows a Load-older control only when hasOlder, and fires onLoadOlder", () => {
+		const onLoadOlder = vi.fn();
+		const { rerender } = render(
+			<MessageThread messages={[msg({ content: "hi", sequence: 1 })]} />,
+		);
+		expect(
+			screen.queryByRole("button", { name: /load older/i }),
+		).not.toBeInTheDocument();
+
+		rerender(
+			<MessageThread
+				messages={[msg({ content: "hi", sequence: 1 })]}
+				hasOlder
+				onLoadOlder={onLoadOlder}
+			/>,
+		);
+		const btn = screen.getByRole("button", { name: /load older/i });
+		fireEvent.click(btn);
+		expect(onLoadOlder).toHaveBeenCalledTimes(1);
 	});
 });
 

--- a/apps/dashboard/src/app/inbox/_components/MessageThread.tsx
+++ b/apps/dashboard/src/app/inbox/_components/MessageThread.tsx
@@ -2,8 +2,9 @@
 
 import { useStickToBottom } from "@llmchat/widget/chat";
 import { ArrowDown, Headset, ThumbsDown, ThumbsUp } from "lucide-react";
-import { useEffect, useMemo } from "react";
+import { useEffect, useLayoutEffect, useMemo, useRef } from "react";
 
+import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
 import { formatMessageTime } from "./format";
@@ -101,24 +102,92 @@ function MessageBubble({
 	);
 }
 
+/** Top-of-thread loader: an intersection sentinel that pages in older history
+ * as it scrolls into view, with an explicit button fallback (and the affordance
+ * where IntersectionObserver is absent, e.g. tests). */
+function LoadOlder({
+	onLoadOlder,
+	loading,
+	scrollRef,
+}: {
+	onLoadOlder?: () => void;
+	loading: boolean;
+	scrollRef: React.RefObject<HTMLDivElement | null>;
+}) {
+	const ref = useRef<HTMLDivElement>(null);
+	useEffect(() => {
+		const el = ref.current;
+		if (!el || !onLoadOlder || typeof IntersectionObserver === "undefined")
+			return;
+		const io = new IntersectionObserver(
+			(entries) => {
+				if (entries.some((e) => e.isIntersecting) && !loading) onLoadOlder();
+			},
+			{ root: scrollRef.current, rootMargin: "150px" },
+		);
+		io.observe(el);
+		return () => io.disconnect();
+	}, [onLoadOlder, loading, scrollRef]);
+	return (
+		<div ref={ref} className="flex justify-center py-1">
+			<Button
+				variant="ghost"
+				size="sm"
+				onClick={onLoadOlder}
+				disabled={loading}
+			>
+				{loading ? "Loading…" : "Load older messages"}
+			</Button>
+		</div>
+	);
+}
+
 export function MessageThread({
 	messages,
 	search = "",
+	hasOlder = false,
+	onLoadOlder,
+	loadingOlder = false,
 }: {
 	messages: Message[];
 	/** Active inbox search term. When set, every occurrence is highlighted in the
 	 * thread and the first matching message is scrolled into view on open. */
 	search?: string;
+	/** True when older history can be paged in above the loaded window. */
+	hasOlder?: boolean;
+	/** Load the page of older messages above the current window. */
+	onLoadOlder?: () => void;
+	/** True while an older page is being fetched. */
+	loadingOlder?: boolean;
 }) {
 	const { containerRef, atBottom, scrollToBottom } =
 		useStickToBottom<HTMLDivElement>({
-			// New messages (inbound or replies) — the inbox doesn't token-stream,
-			// so message count is the growth signal.
-			contentKey: messages.length,
+			// Growth signal = the NEWEST message's identity, not the count. Appending
+			// a message changes it (→ stick if pinned); prepending older history
+			// leaves it unchanged, so paging in history never reads as new content
+			// and never yanks to the bottom.
+			contentKey: messages.at(-1)?.id ?? messages.length,
 			// The agent's own sends are role "admin"; following those is expected.
 			// Inbound visitor/bot messages instead obey the near-bottom rule.
 			sendKey: messages.reduce((id, m) => (m.role === "admin" ? m.id : id), ""),
 		});
+
+	// Scroll anchoring for prepended history: when the FIRST message changes (an
+	// older page loaded above), keep the viewport on what the user was reading by
+	// pushing scrollTop down by exactly the height that was added on top. Appends
+	// at the bottom leave the first id unchanged, so this is a no-op for them.
+	const firstId = messages[0]?.id;
+	const prevFirstId = useRef(firstId);
+	const prevScrollHeight = useRef(0);
+	useLayoutEffect(() => {
+		const el = containerRef.current;
+		if (!el) return;
+		if (prevFirstId.current !== firstId && prevScrollHeight.current > 0) {
+			el.scrollTop += el.scrollHeight - prevScrollHeight.current;
+		}
+		prevFirstId.current = firstId;
+		prevScrollHeight.current = el.scrollHeight;
+	});
 
 	// The first message (in order) containing the term — the scroll target. A
 	// stable id, so the scroll effect below fires once per open/term-change, not
@@ -146,6 +215,13 @@ export function MessageThread({
 			ref={containerRef}
 			className="relative flex flex-1 flex-col gap-4 overflow-y-auto px-6 py-4"
 		>
+			{hasOlder && (
+				<LoadOlder
+					onLoadOlder={onLoadOlder}
+					loading={loadingOlder}
+					scrollRef={containerRef}
+				/>
+			)}
 			{messages.map((m) =>
 				m.role === "system" ? (
 					<div

--- a/apps/dashboard/src/app/inbox/_components/thread-window.test.ts
+++ b/apps/dashboard/src/app/inbox/_components/thread-window.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	appendNewer,
+	maxSequence,
+	minSequence,
+	prependOlder,
+	threadParams,
+	toWindow,
+	type ThreadResponse,
+	type ThreadWindow,
+} from "./thread-window";
+
+import type { Conversation, Message } from "./types";
+
+function msg(seq: number, overrides: Partial<Message> = {}): Message {
+	return {
+		id: `m${seq}`,
+		role: "user",
+		content: `line ${seq}`,
+		sequence: seq,
+		createdAt: "2026-06-16T05:00:00.000Z",
+		...overrides,
+	};
+}
+
+const CONV = { id: "c1", csatRating: null } as Conversation;
+
+function res(
+	messages: Message[],
+	extra: Partial<ThreadResponse> = {},
+): ThreadResponse {
+	return { conversation: CONV, messages, hasOlder: false, ...extra };
+}
+
+function window(
+	messages: Message[],
+	extra: Partial<ThreadWindow> = {},
+): ThreadWindow {
+	return {
+		conversation: CONV,
+		messages,
+		hasOlder: false,
+		firstHitSequence: null,
+		...extra,
+	};
+}
+
+describe("threadParams", () => {
+	it("poll (after) requests NEWEST-ONLY — no limit/before/search", () => {
+		expect(threadParams({ after: 42 })).toBe("after=42");
+	});
+
+	it("older page sends before + limit", () => {
+		const p = new URLSearchParams(threadParams({ before: 51, limit: 50 }));
+		expect(p.get("before")).toBe("51");
+		expect(p.get("limit")).toBe("50");
+		expect(p.get("after")).toBeNull();
+	});
+
+	it("latest page sends just the limit; search adds the term", () => {
+		expect(threadParams({})).toBe("limit=50");
+		const p = new URLSearchParams(threadParams({ search: "refund" }));
+		expect(p.get("search")).toBe("refund");
+		expect(p.get("before")).toBeNull();
+	});
+});
+
+describe("min/max sequence", () => {
+	it("reads the ends of an ascending window", () => {
+		const m = [msg(3), msg(7), msg(9)];
+		expect(minSequence(m)).toBe(3);
+		expect(maxSequence(m)).toBe(9);
+		expect(minSequence([])).toBeNull();
+		expect(maxSequence([])).toBeNull();
+	});
+});
+
+describe("appendNewer (poll merge)", () => {
+	it("appends newer messages, refreshes the conversation, keeps order + no dupes", () => {
+		const prev = window([msg(1), msg(2)], {
+			hasOlder: true,
+			firstHitSequence: 1,
+		});
+		const next = appendNewer(
+			prev,
+			res([msg(2), msg(3)], { conversation: { ...CONV, csatRating: 5 } }),
+		)!;
+		// 2 is deduped; 3 appended; ascending.
+		expect(next.messages.map((m) => m.sequence)).toEqual([1, 2, 3]);
+		// Conversation refreshed (csat now set), but window edges untouched.
+		expect(next.conversation.csatRating).toBe(5);
+		expect(next.hasOlder).toBe(true);
+		expect(next.firstHitSequence).toBe(1);
+	});
+
+	it("is undefined-safe", () => {
+		expect(appendNewer(undefined, res([msg(1)]))).toBeUndefined();
+	});
+});
+
+describe("prependOlder (load-older merge)", () => {
+	it("prepends older messages and adopts the page's hasOlder; keeps the newest id", () => {
+		const prev = window([msg(51), msg(52)], {
+			hasOlder: true,
+			firstHitSequence: 10,
+		});
+		const next = prependOlder(
+			prev,
+			res([msg(49), msg(50)], { hasOlder: false }),
+		)!;
+		expect(next.messages.map((m) => m.sequence)).toEqual([49, 50, 51, 52]);
+		// The last (newest) message is unchanged — so stick-to-bottom won't react.
+		expect(next.messages.at(-1)!.id).toBe("m52");
+		expect(next.hasOlder).toBe(false);
+		expect(next.firstHitSequence).toBe(10);
+	});
+});
+
+describe("toWindow", () => {
+	it("sorts and carries hasOlder + firstHitSequence", () => {
+		const w = toWindow(
+			res([msg(3), msg(1), msg(2)], { hasOlder: true, firstHitSequence: 2 }),
+		);
+		expect(w.messages.map((m) => m.sequence)).toEqual([1, 2, 3]);
+		expect(w.hasOlder).toBe(true);
+		expect(w.firstHitSequence).toBe(2);
+	});
+});

--- a/apps/dashboard/src/app/inbox/_components/thread-window.ts
+++ b/apps/dashboard/src/app/inbox/_components/thread-window.ts
@@ -1,0 +1,107 @@
+import type { Conversation, Message } from "./types";
+
+/** Page size for the message thread. Also the threshold: a conversation with
+ * this many messages or fewer loads in one shot (hasOlder=false) and behaves
+ * exactly as the pre-pagination thread did. */
+export const THREAD_PAGE_SIZE = 50;
+
+/** The server's thread response (latest page, an older `before` page, or the
+ * newest-only `after` poll). `firstHitSequence` is present only on a search
+ * fetch — the sequence of the oldest message matching the term. */
+export interface ThreadResponse {
+	conversation: Conversation;
+	messages: Message[];
+	hasOlder: boolean;
+	firstHitSequence?: number | null;
+}
+
+/** The contiguous window the inbox holds for the open conversation. */
+export interface ThreadWindow {
+	conversation: Conversation;
+	messages: Message[];
+	hasOlder: boolean;
+	/** Sequence of the first search hit (null = none / not searching). Preserved
+	 * across poll/load-older merges; only a fresh search fetch updates it. */
+	firstHitSequence: number | null;
+}
+
+function sortBySequence(messages: Message[]): Message[] {
+	return [...messages].sort((a, b) => a.sequence - b.sequence);
+}
+
+/** Union two message lists by id, ascending by sequence. Append (poll) and
+ * prepend (older) never overlap in practice, but dedup keeps it safe. */
+function unionById(a: Message[], b: Message[]): Message[] {
+	const seen = new Set(a.map((m) => m.id));
+	return sortBySequence([...a, ...b.filter((m) => !seen.has(m.id))]);
+}
+
+export function minSequence(messages: Message[]): number | null {
+	return messages.length ? messages[0].sequence : null;
+}
+
+export function maxSequence(messages: Message[]): number | null {
+	return messages.length ? messages[messages.length - 1].sequence : null;
+}
+
+/** Build the latest window from a fresh fetch (initial open or search). */
+export function toWindow(res: ThreadResponse): ThreadWindow {
+	return {
+		conversation: res.conversation,
+		messages: sortBySequence(res.messages),
+		hasOlder: res.hasOlder,
+		firstHitSequence: res.firstHitSequence ?? null,
+	};
+}
+
+/**
+ * Poll merge: append newer messages and refresh the conversation (status, csat),
+ * leaving `hasOlder` and `firstHitSequence` untouched. Undefined-safe.
+ */
+export function appendNewer(
+	prev: ThreadWindow | undefined,
+	res: ThreadResponse,
+): ThreadWindow | undefined {
+	if (!prev) return prev;
+	return {
+		...prev,
+		conversation: res.conversation,
+		messages: unionById(prev.messages, res.messages),
+	};
+}
+
+/**
+ * Load-older merge: prepend the older page and adopt its `hasOlder`. The newest
+ * message (last id) is unchanged, so stick-to-bottom never treats this as new
+ * content. Undefined-safe.
+ */
+export function prependOlder(
+	prev: ThreadWindow | undefined,
+	res: ThreadResponse,
+): ThreadWindow | undefined {
+	if (!prev) return prev;
+	return {
+		...prev,
+		messages: unionById(res.messages, prev.messages),
+		hasOlder: res.hasOlder,
+	};
+}
+
+/** Query string for a thread fetch. `after` = poll (newest only); `before` =
+ * older page; neither = latest page. `search` asks for firstHitSequence. */
+export function threadParams(opts: {
+	limit?: number;
+	before?: number;
+	after?: number;
+	search?: string;
+}): string {
+	const params = new URLSearchParams();
+	if (opts.after !== undefined) {
+		params.set("after", String(opts.after));
+		return params.toString();
+	}
+	params.set("limit", String(opts.limit ?? THREAD_PAGE_SIZE));
+	if (opts.before !== undefined) params.set("before", String(opts.before));
+	if (opts.search) params.set("search", opts.search);
+	return params.toString();
+}

--- a/apps/dashboard/src/app/inbox/_components/useThreadMessages.test.tsx
+++ b/apps/dashboard/src/app/inbox/_components/useThreadMessages.test.tsx
@@ -1,0 +1,138 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { api } from "@/lib/api";
+
+import { useThreadMessages } from "./useThreadMessages";
+
+import type { Message } from "./types";
+
+vi.mock("@/lib/api", () => ({ api: vi.fn() }));
+
+function range(from: number, to: number): Message[] {
+	const out: Message[] = [];
+	for (let s = from; s <= to; s++) {
+		out.push({
+			id: `m${s}`,
+			role: "user",
+			content: `line ${s}`,
+			sequence: s,
+			createdAt: "2026-06-16T05:00:00.000Z",
+		});
+	}
+	return out;
+}
+
+const CONV = { id: "c1" };
+
+function wrapper() {
+	const client = new QueryClient({
+		defaultOptions: { queries: { retry: false } },
+	});
+	return ({ children }: { children: ReactNode }) =>
+		createElement(QueryClientProvider, { client }, children);
+}
+
+function paramsOf(url: string) {
+	return new URLSearchParams(url.split("?")[1] ?? "");
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("useThreadMessages", () => {
+	it("auto-loads older pages until the search hit is in the window", async () => {
+		// Latest page = seq 11..20, but the first hit is at seq 3 (an older page).
+		vi.mocked(api).mockImplementation((url: string) => {
+			const q = paramsOf(url);
+			if (q.has("after")) {
+				return Promise.resolve({
+					conversation: CONV,
+					messages: [],
+					hasOlder: false,
+				});
+			}
+			if (q.has("before")) {
+				// The older page that contains the hit; nothing older remains.
+				return Promise.resolve({
+					conversation: CONV,
+					messages: range(1, 10),
+					hasOlder: false,
+				});
+			}
+			// Latest page (opened with the search term).
+			return Promise.resolve({
+				conversation: CONV,
+				messages: range(11, 20),
+				hasOlder: true,
+				firstHitSequence: 3,
+			});
+		});
+
+		const { result } = renderHook(
+			() =>
+				useThreadMessages({
+					projectId: "p1",
+					conversationId: "c1",
+					workspaceId: "w1",
+					search: "refund",
+				}),
+			{ wrapper: wrapper() },
+		);
+
+		// The hook pages older on its own until seq 3 (the hit) is loaded.
+		await waitFor(() =>
+			expect(result.current.messages.some((m) => m.sequence === 3)).toBe(true),
+		);
+		expect(result.current.messages[0].sequence).toBe(1);
+		expect(result.current.messages.at(-1)!.sequence).toBe(20);
+		// It stopped once history was exhausted (no infinite loop).
+		expect(result.current.hasOlder).toBe(false);
+
+		// It actually fetched an older page via the `before` cursor.
+		const calledBefore = vi
+			.mocked(api)
+			.mock.calls.some(([u]) => paramsOf(u as string).has("before"));
+		expect(calledBefore).toBe(true);
+	});
+
+	it("leaves a short thread whole — no older page, no load-older", async () => {
+		vi.mocked(api).mockImplementation((url: string) => {
+			const q = paramsOf(url);
+			if (q.has("after")) {
+				return Promise.resolve({
+					conversation: CONV,
+					messages: [],
+					hasOlder: false,
+				});
+			}
+			// The whole thread fits in the latest page.
+			return Promise.resolve({
+				conversation: CONV,
+				messages: range(1, 5),
+				hasOlder: false,
+				firstHitSequence: null,
+			});
+		});
+
+		const { result } = renderHook(
+			() =>
+				useThreadMessages({
+					projectId: "p1",
+					conversationId: "c1",
+					workspaceId: "w1",
+					search: "",
+				}),
+			{ wrapper: wrapper() },
+		);
+
+		await waitFor(() => expect(result.current.messages).toHaveLength(5));
+		expect(result.current.hasOlder).toBe(false);
+		// Never paged older.
+		const calledBefore = vi
+			.mocked(api)
+			.mock.calls.some(([u]) => paramsOf(u as string).has("before"));
+		expect(calledBefore).toBe(false);
+	});
+});

--- a/apps/dashboard/src/app/inbox/_components/useThreadMessages.ts
+++ b/apps/dashboard/src/app/inbox/_components/useThreadMessages.ts
@@ -1,0 +1,159 @@
+"use client";
+
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { api } from "@/lib/api";
+
+import {
+	appendNewer,
+	maxSequence,
+	minSequence,
+	prependOlder,
+	threadParams,
+	toWindow,
+	type ThreadResponse,
+	type ThreadWindow,
+} from "./thread-window";
+
+const POLL_MS = 3_000;
+
+/**
+ * Windowed message thread for the open conversation. The window is held in the
+ * `["thread", projectId, conversationId]` react-query cache (so the Phase-1
+ * optimistic reply keeps appending to it and its onSettled invalidate still
+ * reconciles temp→real). On top of that single query this hook adds:
+ *
+ * - latest-page-first load (server returns the newest THREAD_PAGE_SIZE), so a
+ *   thread at/under the threshold loads whole and behaves exactly as before;
+ * - a 3s poll that fetches NEWEST-ONLY (`after=maxSeq`) and appends — never a
+ *   refetch of loaded pages;
+ * - `loadOlder()` that prepends the page above (`before=minSeq`);
+ * - search: the latest fetch reports `firstHitSequence`, and the hook auto-loads
+ *   older pages until that hit is in the window, so scroll-to-hit can fire.
+ */
+export function useThreadMessages({
+	projectId,
+	conversationId,
+	workspaceId,
+	search,
+}: {
+	projectId: string | null;
+	conversationId: string | null;
+	workspaceId: string | null;
+	search: string;
+}) {
+	const qc = useQueryClient();
+	const enabled = !!projectId && !!conversationId && !!workspaceId;
+	// Stable key (no search) so the Phase-1 reply mutation — which targets
+	// ["thread", projectId, conversationId] — still hits the active query.
+	const key = ["thread", projectId, conversationId] as const;
+
+	// `search` is read by the queryFn via a ref so it doesn't churn the key; a
+	// debounced-search change invalidates the query (effect below) to refetch.
+	const searchRef = useRef(search);
+	searchRef.current = search;
+
+	const query = useQuery({
+		queryKey: key,
+		enabled,
+		// Polling is handled by the effect below (newest-only); the base query must
+		// not refetch the whole window on an interval.
+		refetchInterval: false,
+		queryFn: () =>
+			api<ThreadResponse>(
+				`/api/projects/${projectId}/conversations/${conversationId}?${threadParams(
+					{ search: searchRef.current.trim() || undefined },
+				)}`,
+				{ workspaceId: workspaceId! },
+			).then(toWindow),
+	});
+
+	// A debounced-search change refetches the latest page WITH the term, so
+	// firstHitSequence updates (and the auto-load-to-hit effect can run).
+	useEffect(() => {
+		if (enabled) void qc.invalidateQueries({ queryKey: key });
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [search]);
+
+	// 3s poll: newest-only. Reads the live window from cache each tick, fetches
+	// after the max loaded sequence, and appends — loaded pages are never
+	// refetched. Also refreshes the conversation (status/csat).
+	useEffect(() => {
+		if (!enabled) return;
+		let inFlight = false;
+		const tick = async () => {
+			if (inFlight) return;
+			const cur = qc.getQueryData<ThreadWindow>(key);
+			if (!cur) return;
+			inFlight = true;
+			try {
+				const res = await api<ThreadResponse>(
+					`/api/projects/${projectId}/conversations/${conversationId}?${threadParams(
+						{ after: maxSequence(cur.messages) ?? 0 },
+					)}`,
+					{ workspaceId: workspaceId! },
+				);
+				qc.setQueryData<ThreadWindow>(key, (old) => appendNewer(old, res));
+			} catch {
+				/* transient — next tick retries */
+			} finally {
+				inFlight = false;
+			}
+		};
+		const handle = setInterval(tick, POLL_MS);
+		return () => clearInterval(handle);
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [enabled, projectId, conversationId, workspaceId]);
+
+	const [loadingOlder, setLoadingOlder] = useState(false);
+	const loadingOlderRef = useRef(false);
+
+	const loadOlder = useCallback(async () => {
+		const cur = qc.getQueryData<ThreadWindow>(key);
+		if (!cur || !cur.hasOlder || loadingOlderRef.current) return;
+		loadingOlderRef.current = true;
+		setLoadingOlder(true);
+		try {
+			const res = await api<ThreadResponse>(
+				`/api/projects/${projectId}/conversations/${conversationId}?${threadParams(
+					{ before: minSequence(cur.messages) ?? 0 },
+				)}`,
+				{ workspaceId: workspaceId! },
+			);
+			qc.setQueryData<ThreadWindow>(key, (old) => prependOlder(old, res));
+		} catch {
+			/* leave the affordance so the user can retry */
+		} finally {
+			loadingOlderRef.current = false;
+			setLoadingOlder(false);
+		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [qc, projectId, conversationId, workspaceId]);
+
+	// Search auto-load: keep loading older pages until the first hit is inside the
+	// window, so scroll-to-first-hit (in MessageThread) has the message to scroll
+	// to. Terminates when the hit is reached or there's no more history.
+	const data = query.data;
+	useEffect(() => {
+		if (!data || data.firstHitSequence == null) return;
+		const min = minSequence(data.messages);
+		if (
+			min !== null &&
+			data.firstHitSequence < min &&
+			data.hasOlder &&
+			!loadingOlder
+		) {
+			void loadOlder();
+		}
+	}, [data, loadingOlder, loadOlder]);
+
+	return {
+		conversation: data?.conversation ?? null,
+		messages: data?.messages ?? [],
+		hasOlder: data?.hasOlder ?? false,
+		loadOlder,
+		loadingOlder,
+		isLoading: query.isLoading,
+	};
+}

--- a/apps/dashboard/src/app/inbox/page.tsx
+++ b/apps/dashboard/src/app/inbox/page.tsx
@@ -39,11 +39,8 @@ import { MessageThread } from "./_components/MessageThread";
 import { appendOptimisticReply } from "./_components/optimistic-updaters";
 import { ProjectSwitcher } from "./_components/ProjectSwitcher";
 import { ReplyComposer } from "./_components/ReplyComposer";
-import type {
-	Conversation,
-	ConversationStats,
-	Message,
-} from "./_components/types";
+import { useThreadMessages } from "./_components/useThreadMessages";
+import type { ConversationStats } from "./_components/types";
 import type { ProjectOption } from "./_components/ProjectSwitcher";
 
 const PAGE_SIZE = 30;
@@ -160,15 +157,14 @@ export default function InboxPage() {
 			}),
 	});
 
-	const thread = useQuery({
-		queryKey: ["thread", projectId, selectedId],
-		enabled: !!projectId && !!selectedId && !!workspaceId,
-		refetchInterval: 3_000,
-		queryFn: () =>
-			api<{ conversation: Conversation; messages: Message[] }>(
-				`/api/projects/${projectId}/conversations/${selectedId}`,
-				{ workspaceId: workspaceId! },
-			),
+	// Windowed thread: latest page first, page older on scroll-up, poll newest
+	// only. Stays in the ["thread", projectId, selectedId] cache so the optimistic
+	// reply below keeps working unchanged.
+	const thread = useThreadMessages({
+		projectId,
+		conversationId: selectedId,
+		workspaceId,
+		search: debouncedSearch,
 	});
 
 	// Render set = the polled head merged with the loaded pages, deduped by id
@@ -185,7 +181,7 @@ export default function InboxPage() {
 	);
 
 	const selectedConv = allConversations.find((c) => c.id === selectedId);
-	const detailConv = thread.data?.conversation ?? selectedConv ?? null;
+	const detailConv = thread.conversation ?? selectedConv ?? null;
 
 	// Mark a conversation read for this user. Optimistically clears the unread dot
 	// in-cache across the head + loaded pages (so a row deep in a loaded page
@@ -222,7 +218,7 @@ export default function InboxPage() {
 
 	// Keep it read as new messages stream in while the thread is open. Keyed on
 	// the loaded message count so it fires on new messages, not every poll.
-	const loadedMessageCount = thread.data?.messages.length;
+	const loadedMessageCount = thread.messages.length;
 	useEffect(() => {
 		if (selectedId && loadedMessageCount !== undefined) {
 			void markRead(selectedId);
@@ -438,15 +434,18 @@ export default function InboxPage() {
 				}
 				threadBody={
 					detailConv &&
-					(thread.data ? (
-						<MessageThread
-							messages={thread.data.messages}
-							search={debouncedSearch}
-						/>
-					) : (
+					(thread.isLoading && thread.messages.length === 0 ? (
 						<div className="flex flex-1 items-center justify-center text-sm text-muted-foreground">
 							Loading…
 						</div>
+					) : (
+						<MessageThread
+							messages={thread.messages}
+							search={debouncedSearch}
+							hasOlder={thread.hasOlder}
+							onLoadOlder={thread.loadOlder}
+							loadingOlder={thread.loadingOlder}
+						/>
 					))
 				}
 				composer={


### PR DESCRIPTION
Phase 3 (final) of the optimistic-updates + pagination plan. Paginates the message thread; gated so short threads are byte-for-byte unchanged.

## Server — `GET /conversations/:id`
Was `findMany` (all messages). Now keyset on `sequence`:
- **no cursor** → latest page (newest `limit`, ascending) + `hasOlder` via a `limit+1` sentinel;
- **`before=<seq>`** → the older page above;
- **`after=<seq>`** → newest-only (the poll);
- **`search=<term>`** → returns `firstHitSequence` (oldest matching message) so the client can page to it.

Same 404/403 ownership gate.

## Client — `useThreadMessages` hook
Holds the window in the existing `["thread", projectId, conversationId]` cache, **so the Phase-1 optimistic reply keeps appending + reconciling unchanged**. On top it adds:
- **Latest-page-first**; **threshold = page size (50)** — a thread at/under it loads whole, `hasOlder=false`, no affordance → identical to today.
- **3s poll = `after=maxSeq`** → appends, never refetches loaded pages.
- **`loadOlder()`** prepends the page above on scroll-up (intersection sentinel + button).
- **Search auto-load**: pages older until `firstHitSequence` is in the window, then the existing scroll-to-hit fires.

## The three collisions (handled explicitly)
1. **Stick-to-bottom append vs prepend** — `contentKey` moves from `messages.length` → `messages.at(-1)?.id`, so a prepend leaves it unchanged (no yank); a `useLayoutEffect` anchor shifts `scrollTop` by the prepended height so the viewport stays on what the user was reading.
2. **Search scroll-to-first-hit across pages** — `firstHitSequence` + auto-`loadOlder` guarantees the hit is loaded before scroll-to-hit runs.
3. **3s poll** — newest-only via `after`.

## Tests
Prepend **doesn't yank** + **anchors** (scrollTop shifts by the added height); **hit in an older page auto-loads then scrolls**; poll requests **newest-only** and appends without dupes; **short thread unchanged** (no older page / control); server `before`/`after`/`limit` + `hasOlder` sentinel + `firstHitSequence` + 404/403.

All 5 packages pass (API 174, dashboard 269); lint/format clean; no secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)