### PR TITLE
feat(knowledge): promote an inbox reply into a Q&A source the agent learns from

### DIFF
--- a/apps/api/migrations/0012_source_qa_kind.sql
+++ b/apps/api/migrations/0012_source_qa_kind.sql
@@ -1,0 +1,39 @@
+-- Source kinds: a source is no longer URL-only. Add `kind` (url|text|qa), make
+-- `url` nullable (text/qa sources have none), and add `question`/`answer` (qa
+-- display/edit) + `source_message_id` (provenance + dedupe for replies promoted
+-- into knowledge).
+--
+-- Additive + backfill: existing rows are all fetched web pages, so they take
+-- kind='url' (the column default) and keep their non-null url untouched. Making
+-- a column nullable can't be done with ALTER in SQLite, so the table is
+-- recreated with the same copy/drop/rename dance drizzle emits — scoped to this
+-- one table to stay incremental like 0003–0011. Ploy's ledger applies each file
+-- once (in filename order, so this runs after 0011), on `ploy dev` and on deploy.
+PRAGMA foreign_keys=OFF;
+--> statement-breakpoint
+CREATE TABLE `__new_source` (
+	`id` text PRIMARY KEY NOT NULL,
+	`project_id` text NOT NULL,
+	`kind` text DEFAULT 'url' NOT NULL,
+	`url` text,
+	`title` text DEFAULT '' NOT NULL,
+	`content` text DEFAULT '' NOT NULL,
+	`question` text,
+	`answer` text,
+	`source_message_id` text,
+	`active` integer DEFAULT 1 NOT NULL,
+	`last_fetched_at` integer,
+	`last_error` text,
+	`created_at` integer DEFAULT (unixepoch()) NOT NULL,
+	`updated_at` integer DEFAULT (unixepoch()) NOT NULL,
+	FOREIGN KEY (`project_id`) REFERENCES `project`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+INSERT INTO `__new_source`("id", "project_id", "url", "title", "content", "active", "last_fetched_at", "last_error", "created_at", "updated_at") SELECT "id", "project_id", "url", "title", "content", "active", "last_fetched_at", "last_error", "created_at", "updated_at" FROM `source`;--> statement-breakpoint
+DROP TABLE `source`;--> statement-breakpoint
+ALTER TABLE `__new_source` RENAME TO `source`;--> statement-breakpoint
+PRAGMA foreign_keys=ON;--> statement-breakpoint
+CREATE INDEX `source_project` ON `source` (`project_id`);--> statement-breakpoint
+-- Belt-and-braces backfill: every carried-over row is a fetched URL source. The
+-- column default already sets this on recreate; this makes it explicit/idempotent.
+UPDATE `source` SET `kind` = 'url' WHERE `kind` IS NULL OR `kind` NOT IN ('url', 'text', 'qa');

--- a/apps/api/src/lib/llm.test.ts
+++ b/apps/api/src/lib/llm.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+
+import { buildSystem } from "./llm";
+
+describe("buildSystem — source assembly (retrieval)", () => {
+	it("includes a promoted Q&A source's content in the assembled prompt", async () => {
+		// A qa source as produced by /sources/promote: no url, content is the Q/A blob.
+		const prompt = buildSystem("You are a support agent.", "", [
+			{
+				title: "How do I reset my password?",
+				url: "",
+				content: "Q: How do I reset my password?\nA: Click reset in Settings.",
+			},
+		]);
+		expect(prompt).toContain("Q: How do I reset my password?");
+		expect(prompt).toContain("A: Click reset in Settings.");
+		expect(prompt).toContain("# Reference sources");
+	});
+
+	it("omits the URL line for url-less (qa/text) sources", async () => {
+		const prompt = buildSystem("sys", "", [
+			{ title: "Promoted answer", url: "", content: "Q: x\nA: y" },
+		]);
+		// The source still renders, but no dangling "URL: " line.
+		expect(prompt).toContain("Promoted answer");
+		expect(prompt).not.toContain("URL:");
+	});
+
+	it("still renders the URL line for fetched url sources", async () => {
+		const prompt = buildSystem("sys", "", [
+			{
+				title: "Docs",
+				url: "https://acme.com/docs",
+				content: "Some docs content.",
+			},
+		]);
+		expect(prompt).toContain("URL: https://acme.com/docs");
+		expect(prompt).toContain("Some docs content.");
+	});
+
+	it("skips sources with empty content", async () => {
+		const prompt = buildSystem("sys", "", [
+			{ title: "Empty", url: "", content: "   " },
+		]);
+		expect(prompt).not.toContain("# Reference sources");
+	});
+});

--- a/apps/api/src/lib/llm.ts
+++ b/apps/api/src/lib/llm.ts
@@ -39,11 +39,16 @@ export function buildSystem(
 					s.content.length > perSource
 						? `${s.content.slice(0, perSource)}…`
 						: s.content;
-				return `## Source ${i + 1}: ${s.title}\nURL: ${s.url}\n\n${body}`;
+				// URL-less sources (manual text, promoted Q&A) omit the URL line
+				// rather than printing "URL: " — the title is their handle.
+				const head = s.url
+					? `## Source ${i + 1}: ${s.title}\nURL: ${s.url}`
+					: `## Source ${i + 1}: ${s.title}`;
+				return `${head}\n\n${body}`;
 			})
 			.join("\n\n");
 		parts.push(
-			`# Reference sources\n\nThe following content was fetched from URLs the operator marked as active sources. Cite the source title or URL when you use information from them.\n\n${rendered}`,
+			`# Reference sources\n\nThe following content comes from sources the operator marked active — fetched web pages and Q&A the team promoted from past conversations. Cite the source title or URL when you use information from them.\n\n${rendered}`,
 		);
 	}
 	return parts.join("\n\n");

--- a/apps/api/src/routes/chat.ts
+++ b/apps/api/src/routes/chat.ts
@@ -230,8 +230,10 @@ export const chat = new Hono<AppContext>()
 				systemPrompt: activePromptContent,
 				knowledgeText: project.knowledgeText,
 				sources: activeSources.map((s) => ({
-					title: s.title || s.url,
-					url: s.url,
+					// qa/text sources have no url; fall back to the title for the label
+					// and pass "" for the (now-optional) url so buildSystem omits it.
+					title: s.title || s.url || "",
+					url: s.url ?? "",
 					content: s.content,
 				})),
 				messages: messages as UIMessage[],

--- a/apps/api/src/routes/sources.test.ts
+++ b/apps/api/src/routes/sources.test.ts
@@ -1,0 +1,303 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { db } from "@/lib/db";
+
+import { sources } from "./sources";
+
+// Header-driven fake session (matches projects.test.ts): `x-test-user` ⇒ signed
+// in; the membership role drives requireRole.
+vi.mock("@/auth", () => ({
+	createAuth: () => ({
+		api: {
+			getSession: async ({ headers }: { headers: Headers }) => {
+				const id = headers.get("x-test-user");
+				return id ? { user: { id } } : null;
+			},
+		},
+	}),
+}));
+
+vi.mock("@/lib/db", () => ({ db: vi.fn() }));
+
+// fetch-url is only hit by the URL-source routes, never by promote — stub it so
+// an accidental network call can't leak into these tests.
+vi.mock("@/lib/fetch-url", () => ({
+	fetchUrlContent: vi.fn(async () => ({ title: "", content: "" })),
+}));
+
+const ENV = { vars: {}, DB: {} } as unknown as Parameters<
+	typeof sources.request
+>[2];
+
+interface State {
+	role?: "owner" | "admin" | "agent";
+	/** ensureProject result (project ∈ workspace). undefined ⇒ 404. */
+	project?: Record<string, unknown>;
+	/** First message.findFirst (the message being promoted). */
+	message?: Record<string, unknown>;
+	/** conversation.findFirst result. */
+	conversation?: Record<string, unknown>;
+	/** Existing qa source with this sourceMessageId (dedupe). */
+	existingSource?: Record<string, unknown>;
+	/** Second message.findFirst (nearest preceding visitor message). */
+	precedingVisitor?: Record<string, unknown>;
+}
+
+let insertSpy: ReturnType<typeof vi.fn>;
+/** The values object handed to insert(source).values(...) on the last promote. */
+let lastInsert: Record<string, unknown> | null;
+
+function mockDb(state: State) {
+	lastInsert = null;
+	insertSpy = vi.fn(() => ({
+		values: (data: Record<string, unknown>) => {
+			lastInsert = data;
+			return { returning: async () => [{ id: "src_new", ...data }] };
+		},
+	}));
+	// message.findFirst is called up to twice: first the target message, then the
+	// preceding visitor message (only when no question override was sent).
+	let msgCall = 0;
+	const fake = {
+		query: {
+			member: {
+				findFirst: async () => (state.role ? { role: state.role } : undefined),
+			},
+			project: {
+				findFirst: async () => state.project,
+			},
+			message: {
+				findFirst: async () => {
+					msgCall += 1;
+					return msgCall === 1 ? state.message : state.precedingVisitor;
+				},
+			},
+			conversation: {
+				findFirst: async () => state.conversation,
+			},
+			source: {
+				findFirst: async () => state.existingSource,
+				findMany: async () => [],
+			},
+		},
+		insert: insertSpy,
+	};
+	vi.mocked(db).mockReturnValue(fake as unknown as ReturnType<typeof db>);
+	return state;
+}
+
+function promote(body: unknown, headers: Record<string, string> = {}) {
+	return sources.request(
+		"/projects/p1/sources/promote",
+		{
+			method: "POST",
+			headers: {
+				"x-test-user": "u1",
+				"x-workspace-id": "ws_1",
+				"content-type": "application/json",
+				...headers,
+			},
+			body: JSON.stringify(body),
+		},
+		ENV,
+	);
+}
+
+// A conversation that belongs to project p1 (the happy-path tenant chain).
+const okState: State = {
+	role: "agent",
+	project: { id: "p1", workspaceId: "ws_1" },
+	message: {
+		id: "m2",
+		conversationId: "c1",
+		role: "admin",
+		content: "Click the reset link in settings.",
+		sequence: 4,
+	},
+	conversation: { id: "c1", projectId: "p1" },
+	precedingVisitor: {
+		id: "m1",
+		conversationId: "c1",
+		role: "user",
+		content: "How do I reset my password?",
+		sequence: 3,
+	},
+};
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("POST /sources/promote — happy path", () => {
+	it("promotes a reply into a qa source (kind=qa, url=null, provenance set)", async () => {
+		mockDb(okState);
+		const res = await promote({ messageId: "m2" });
+		expect(res.status).toBe(200);
+		const json = (await res.json()) as { source: Record<string, unknown> };
+		expect(json.source).toMatchObject({ kind: "qa", url: null });
+		expect(lastInsert).toMatchObject({
+			projectId: "p1",
+			kind: "qa",
+			url: null,
+			sourceMessageId: "m2",
+			active: true,
+			question: "How do I reset my password?",
+			answer: "Click the reset link in settings.",
+			content:
+				"Q: How do I reset my password?\nA: Click the reset link in settings.",
+		});
+		// Title is the first chars of the question.
+		expect(lastInsert?.title).toBe("How do I reset my password?");
+	});
+
+	it("derives the answer from the message body when no override is sent", async () => {
+		mockDb(okState);
+		await promote({ messageId: "m2" });
+		expect(lastInsert?.answer).toBe("Click the reset link in settings.");
+	});
+
+	it("honors question + answer overrides", async () => {
+		mockDb(okState);
+		await promote({
+			messageId: "m2",
+			question: "Reset password?",
+			answer: "Go to Settings → Security → Reset.",
+		});
+		expect(lastInsert).toMatchObject({
+			question: "Reset password?",
+			answer: "Go to Settings → Security → Reset.",
+			content: "Q: Reset password?\nA: Go to Settings → Security → Reset.",
+		});
+	});
+});
+
+describe("POST /sources/promote — tenant isolation", () => {
+	it("404s a messageId whose conversation is in another project; never inserts", async () => {
+		// Cross-tenant: caller owns p1, message m2 belongs to conversation in p_other.
+		mockDb({
+			...okState,
+			conversation: { id: "c1", projectId: "p_other" },
+		});
+		const res = await promote({ messageId: "m2" });
+		expect(res.status).toBe(404);
+		expect(insertSpy).not.toHaveBeenCalled();
+	});
+
+	it("404s when the project isn't in the caller's workspace; never inserts", async () => {
+		mockDb({ ...okState, project: undefined });
+		const res = await promote({ messageId: "m2" });
+		expect(res.status).toBe(404);
+		expect(insertSpy).not.toHaveBeenCalled();
+	});
+
+	it("404s when the message doesn't exist; never inserts", async () => {
+		mockDb({ ...okState, message: undefined });
+		const res = await promote({ messageId: "missing" });
+		expect(res.status).toBe(404);
+		expect(insertSpy).not.toHaveBeenCalled();
+	});
+});
+
+describe("POST /sources/promote — RBAC", () => {
+	it("allows an agent (minimum role)", async () => {
+		mockDb({ ...okState, role: "agent" });
+		const res = await promote({ messageId: "m2" });
+		expect(res.status).toBe(200);
+		expect(insertSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it("403s a non-member; never inserts", async () => {
+		mockDb({ ...okState, role: undefined });
+		const res = await promote({ messageId: "m2" });
+		expect(res.status).toBe(403);
+		expect(insertSpy).not.toHaveBeenCalled();
+	});
+
+	it("400s when no workspace is selected", async () => {
+		mockDb(okState);
+		const res = await sources.request(
+			"/projects/p1/sources/promote",
+			{
+				method: "POST",
+				headers: { "x-test-user": "u1", "content-type": "application/json" },
+				body: JSON.stringify({ messageId: "m2" }),
+			},
+			ENV,
+		);
+		expect(res.status).toBe(400);
+	});
+});
+
+describe("POST /sources/promote — defaults & validation", () => {
+	it("handles a conversation with no preceding visitor message (empty question)", async () => {
+		mockDb({ ...okState, precedingVisitor: undefined });
+		const res = await promote({ messageId: "m2" });
+		expect(res.status).toBe(200);
+		expect(lastInsert?.question).toBe("");
+		expect(lastInsert?.content).toBe(
+			"Q: \nA: Click the reset link in settings.",
+		);
+		// Title falls back to the answer when the question is empty.
+		expect(lastInsert?.title).toBe("Click the reset link in settings.");
+	});
+
+	it("400s a whitespace-only answer override; never inserts", async () => {
+		mockDb(okState);
+		const res = await promote({ messageId: "m2", answer: "   " });
+		expect(res.status).toBe(400);
+		expect(insertSpy).not.toHaveBeenCalled();
+	});
+
+	it("400s when the derived answer (empty message body) is blank; never inserts", async () => {
+		mockDb({
+			...okState,
+			message: {
+				id: "m2",
+				conversationId: "c1",
+				role: "admin",
+				content: "   ",
+				sequence: 4,
+			},
+		});
+		const res = await promote({ messageId: "m2" });
+		expect(res.status).toBe(400);
+		expect(insertSpy).not.toHaveBeenCalled();
+	});
+
+	it("400s an over-length question (schema cap); never inserts", async () => {
+		mockDb(okState);
+		const res = await promote({ messageId: "m2", question: "x".repeat(2001) });
+		expect(res.status).toBe(400);
+		expect(insertSpy).not.toHaveBeenCalled();
+	});
+
+	it("400s an over-length answer (schema cap); never inserts", async () => {
+		mockDb(okState);
+		const res = await promote({ messageId: "m2", answer: "x".repeat(8001) });
+		expect(res.status).toBe(400);
+		expect(insertSpy).not.toHaveBeenCalled();
+	});
+
+	it("400s a missing messageId (required field); never inserts", async () => {
+		mockDb(okState);
+		const res = await promote({});
+		expect(res.status).toBe(400);
+		expect(insertSpy).not.toHaveBeenCalled();
+	});
+});
+
+describe("POST /sources/promote — dedupe", () => {
+	it("returns the existing source and does NOT insert a duplicate", async () => {
+		mockDb({
+			...okState,
+			existingSource: { id: "src_old", kind: "qa", sourceMessageId: "m2" },
+		});
+		const res = await promote({ messageId: "m2" });
+		expect(res.status).toBe(200);
+		const json = (await res.json()) as {
+			source: { id: string };
+			deduped?: boolean;
+		};
+		expect(json.source.id).toBe("src_old");
+		expect(json.deduped).toBe(true);
+		expect(insertSpy).not.toHaveBeenCalled();
+	});
+});

--- a/apps/api/src/routes/sources.ts
+++ b/apps/api/src/routes/sources.ts
@@ -26,6 +26,25 @@ const updateInput = z.object({
 	active: z.boolean().optional(),
 });
 
+// Length caps for a promoted Q&A. Answers can be a real support reply, so the
+// budget is generous; questions are a single visitor turn, so tighter. Both are
+// also defensively re-clamped server-side for the DERIVED defaults (an absent
+// override isn't validated by the schema).
+const QUESTION_MAX = 2_000;
+const ANSWER_MAX = 8_000;
+const TITLE_LEN = 60;
+
+// Promote-a-reply input. A purpose-built CREATE schema with the required key
+// (`messageId`) — NOT a `.partial()` of some other schema, and with NO
+// `.default()` anywhere (the Zod-v4 footgun where a default fires on an absent
+// key under `.partial()` and clobbers siblings). `question`/`answer` are honest
+// optionals: absent ⇒ derive the default server-side; present ⇒ override.
+const promoteInput = z.object({
+	messageId: z.string().min(1),
+	question: z.string().max(QUESTION_MAX).optional(),
+	answer: z.string().max(ANSWER_MAX).optional(),
+});
+
 async function ensureProject(
 	env: AppContext["Bindings"],
 	projectId: string,
@@ -50,6 +69,99 @@ export const sources = new Hono<AppContext>()
 		});
 		return c.json({ sources: rows });
 	})
+	// Promote an inbox reply into a Q&A knowledge source the agent learns from.
+	// Minimum role `agent` (any workspace member): handling conversations is an
+	// agent's job, so turning a good reply into knowledge is too — deliberately
+	// looser than the admin-only URL-source mutations above.
+	.post(
+		"/projects/:projectId/sources/promote",
+		requireRole("agent"),
+		zValidator("json", promoteInput),
+		async (c) => {
+			const { projectId } = c.req.param();
+			const workspaceId = c.get("workspaceId");
+			const { messageId, question, answer } = c.req.valid("json");
+
+			// Tenant isolation (deliberate, step by step — we've shipped a
+			// cross-tenant bug before): the project must belong to the caller's
+			// workspace, the message must exist, and its conversation must belong to
+			// THIS project. Any miss ⇒ 404 (never reveal another tenant's data, and
+			// never let a foreign messageId be promoted into this project).
+			const proj = await ensureProject(c.env, projectId, workspaceId);
+			if (!proj) return c.json({ error: "not found" }, 404);
+
+			const msg = await db(c.env).query.message.findFirst({
+				where: (mt, { eq: e }) => e(mt.id, messageId),
+			});
+			if (!msg) return c.json({ error: "not found" }, 404);
+
+			const conv = await db(c.env).query.conversation.findFirst({
+				where: (ct, { eq: e }) => e(ct.id, msg.conversationId),
+			});
+			if (!conv || conv.projectId !== projectId) {
+				return c.json({ error: "not found" }, 404);
+			}
+
+			// Dedupe on provenance: re-promoting the same reply is a no-op (return the
+			// existing source) rather than a duplicate Q&A in the knowledge base.
+			const existing = await db(c.env).query.source.findFirst({
+				where: (s, { and: a, eq: e }) =>
+					a(e(s.projectId, projectId), e(s.sourceMessageId, messageId)),
+			});
+			if (existing) {
+				return c.json({ source: existing, deduped: true });
+			}
+
+			// Answer: the override (if any), else the message body. Required non-empty
+			// — a blank answer carries no knowledge. Clamp the derived default too
+			// (an absent override skips the schema's max).
+			const finalAnswer = (answer ?? msg.content).trim().slice(0, ANSWER_MAX);
+			if (!finalAnswer) {
+				return c.json({ error: "answer required" }, 400);
+			}
+
+			// Question: the override if the field was sent at all (empty allowed),
+			// else the nearest preceding visitor message in this conversation. A
+			// conversation that opens with the bot (no earlier visitor turn) yields an
+			// empty question — that's fine, the answer still teaches.
+			let finalQuestion: string;
+			if (question !== undefined) {
+				finalQuestion = question.trim().slice(0, QUESTION_MAX);
+			} else {
+				const prev = await db(c.env).query.message.findFirst({
+					where: (mt, { and: a, eq: e, lt }) =>
+						a(
+							e(mt.conversationId, msg.conversationId),
+							e(mt.role, "user"),
+							lt(mt.sequence, msg.sequence),
+						),
+					orderBy: (mt, { desc: d }) => d(mt.sequence),
+				});
+				finalQuestion = (prev?.content ?? "").trim().slice(0, QUESTION_MAX);
+			}
+
+			const content = `Q: ${finalQuestion}\nA: ${finalAnswer}`;
+			// Title from the question (the human-readable handle); fall back to the
+			// answer when there's no question, so a qa row is never blank-titled.
+			const title = (finalQuestion || finalAnswer).slice(0, TITLE_LEN);
+
+			const [created] = await db(c.env)
+				.insert(source)
+				.values({
+					projectId,
+					kind: "qa",
+					url: null,
+					title,
+					content,
+					question: finalQuestion,
+					answer: finalAnswer,
+					sourceMessageId: messageId,
+					active: true,
+				})
+				.returning();
+			return c.json({ source: created });
+		},
+	)
 	.post(
 		"/projects/:projectId/sources",
 		requireRole("admin"),
@@ -152,6 +264,10 @@ export const sources = new Hono<AppContext>()
 					a(e(s.id, id), e(s.projectId, projectId)),
 			});
 			if (!existing) return c.json({ error: "not found" }, 404);
+			// Only URL sources can be recrawled; qa/text sources have no url to fetch.
+			if (!existing.url) {
+				return c.json({ error: "source has no url to refresh" }, 400);
+			}
 
 			const fetched = await tryFetch(existing.url);
 			const [updated] = await db(c.env)

--- a/apps/dashboard/src/app/inbox/_components/MessageThread.tsx
+++ b/apps/dashboard/src/app/inbox/_components/MessageThread.tsx
@@ -9,7 +9,16 @@ import { cn } from "@/lib/utils";
 
 import { formatMessageTime } from "./format";
 import { Highlighted } from "./highlight";
+import { PromoteToKnowledge } from "./PromoteToKnowledge";
 import type { Message } from "./types";
+
+/** Context for the "Add to knowledge" action on admin replies. Absent (e.g. in
+ * tests, or before a project/workspace resolves) ⇒ the action isn't rendered. */
+export interface KnowledgeContext {
+	projectId: string;
+	projectName: string;
+	workspaceId: string;
+}
 
 /** Case-insensitive "does this message contain the term" — used to find the
  * first hit to scroll to. Mirrors the (case-insensitive) highlight matching. */
@@ -59,12 +68,18 @@ function MessageBubble({
 	message,
 	search,
 	firstHit,
+	knowledge,
+	knowledgeQuestion,
 }: {
 	message: Message;
 	/** Active search term; occurrences are highlighted via the shared component. */
 	search: string;
 	/** True for the first message in the thread that matches — the scroll target. */
 	firstHit: boolean;
+	/** When set (and this is an admin reply), shows the "Add to knowledge" action. */
+	knowledge?: KnowledgeContext;
+	/** Nearest preceding visitor message — the default question for this reply. */
+	knowledgeQuestion: string;
 }) {
 	const { side, label, labelClass } =
 		ROLE[message.role as keyof typeof ROLE] ?? ROLE.user;
@@ -97,6 +112,16 @@ function MessageBubble({
 			</span>
 			{message.role === "assistant" && (
 				<RatingIndicator rating={message.rating} />
+			)}
+			{message.role === "admin" && knowledge && (
+				<PromoteToKnowledge
+					projectId={knowledge.projectId}
+					projectName={knowledge.projectName}
+					workspaceId={knowledge.workspaceId}
+					messageId={message.id}
+					defaultQuestion={knowledgeQuestion}
+					defaultAnswer={message.content}
+				/>
 			)}
 		</div>
 	);
@@ -148,6 +173,7 @@ export function MessageThread({
 	hasOlder = false,
 	onLoadOlder,
 	loadingOlder = false,
+	knowledge,
 }: {
 	messages: Message[];
 	/** Active inbox search term. When set, every occurrence is highlighted in the
@@ -159,6 +185,8 @@ export function MessageThread({
 	onLoadOlder?: () => void;
 	/** True while an older page is being fetched. */
 	loadingOlder?: boolean;
+	/** Enables the "Add to knowledge" action on admin replies. */
+	knowledge?: KnowledgeContext;
 }) {
 	const { containerRef, atBottom, scrollToBottom } =
 		useStickToBottom<HTMLDivElement>({
@@ -188,6 +216,20 @@ export function MessageThread({
 		prevFirstId.current = firstId;
 		prevScrollHeight.current = el.scrollHeight;
 	});
+
+	// For each admin reply, the nearest preceding visitor message in the loaded
+	// window — the default question when promoting it to knowledge. (The server
+	// independently derives this from the DB when the field is left blank, so a
+	// reply whose question is in an unloaded older page is still handled.)
+	const questionByAdminId = useMemo(() => {
+		const map = new Map<string, string>();
+		let lastVisitor = "";
+		for (const m of messages) {
+			if (m.role === "user") lastVisitor = m.content;
+			else if (m.role === "admin") map.set(m.id, lastVisitor);
+		}
+		return map;
+	}, [messages]);
 
 	// The first message (in order) containing the term — the scroll target. A
 	// stable id, so the scroll effect below fires once per open/term-change, not
@@ -243,6 +285,8 @@ export function MessageThread({
 						message={m}
 						search={search}
 						firstHit={m.id === firstHitId}
+						knowledge={knowledge}
+						knowledgeQuestion={questionByAdminId.get(m.id) ?? ""}
 					/>
 				),
 			)}

--- a/apps/dashboard/src/app/inbox/_components/PromoteToKnowledge.test.tsx
+++ b/apps/dashboard/src/app/inbox/_components/PromoteToKnowledge.test.tsx
@@ -1,0 +1,199 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { MessageThread, type KnowledgeContext } from "./MessageThread";
+import type { Message } from "./types";
+
+const toastSuccess = vi.fn();
+const toastError = vi.fn();
+vi.mock("sonner", () => ({
+	toast: {
+		success: (m: string) => toastSuccess(m),
+		error: (m: string) => toastError(m),
+	},
+}));
+
+function msg(overrides: Partial<Message>): Message {
+	return {
+		id: crypto.randomUUID(),
+		role: "user",
+		content: "hello",
+		sequence: 1,
+		createdAt: "2026-06-16T05:00:00.000Z",
+		...overrides,
+	};
+}
+
+const knowledge: KnowledgeContext = {
+	projectId: "p1",
+	projectName: "Acme Support",
+	workspaceId: "ws_1",
+};
+
+function renderThread(messages: Message[], k?: KnowledgeContext) {
+	const qc = new QueryClient({
+		defaultOptions: { mutations: { retry: false }, queries: { retry: false } },
+	});
+	return render(
+		<QueryClientProvider client={qc}>
+			<MessageThread messages={messages} knowledge={k} />
+		</QueryClientProvider>,
+	);
+}
+
+let fetchMock: ReturnType<typeof vi.fn>;
+beforeEach(() => {
+	toastSuccess.mockClear();
+	toastError.mockClear();
+	fetchMock = vi.fn(async () => ({
+		ok: true,
+		status: 200,
+		json: async () => ({ source: { id: "src_new", kind: "qa" } }),
+		text: async () => "",
+	}));
+	vi.stubGlobal("fetch", fetchMock);
+});
+afterEach(() => vi.unstubAllGlobals());
+
+const addBtn = () =>
+	screen.queryByRole("button", { name: /add to knowledge/i });
+
+describe("Add to knowledge action", () => {
+	it("shows the action only on admin replies, and only when knowledge is provided", () => {
+		const messages = [
+			msg({
+				role: "user",
+				content: "How do I reset my password?",
+				sequence: 1,
+			}),
+			msg({ role: "assistant", content: "I can help with that.", sequence: 2 }),
+			msg({ role: "admin", content: "Go to Settings → Reset.", sequence: 3 }),
+		];
+		// Without knowledge context: no action anywhere.
+		const { unmount } = renderThread(messages);
+		expect(addBtn()).not.toBeInTheDocument();
+		unmount();
+
+		// With knowledge: exactly one action (on the single admin reply).
+		renderThread(messages, knowledge);
+		expect(
+			screen.getAllByRole("button", { name: /add to knowledge/i }),
+		).toHaveLength(1);
+	});
+
+	it("opens a dialog prefilled with the preceding visitor question + the reply", async () => {
+		const user = userEvent.setup();
+		renderThread(
+			[
+				msg({
+					role: "user",
+					content: "How do I reset my password?",
+					sequence: 1,
+				}),
+				msg({ role: "admin", content: "Go to Settings → Reset.", sequence: 2 }),
+			],
+			knowledge,
+		);
+		await user.click(addBtn()!);
+
+		expect(screen.getByLabelText("Question")).toHaveValue(
+			"How do I reset my password?",
+		);
+		expect(screen.getByLabelText("Answer")).toHaveValue(
+			"Go to Settings → Reset.",
+		);
+		// Notes which agent it adds to (positioning: "agent", never "chatbot").
+		expect(screen.getByText("Acme Support")).toBeInTheDocument();
+	});
+
+	it("promotes on confirm: POSTs the right body, toasts, and shows the badge", async () => {
+		const user = userEvent.setup();
+		renderThread(
+			[
+				msg({
+					role: "user",
+					content: "How do I reset my password?",
+					sequence: 1,
+				}),
+				msg({ role: "admin", content: "Go to Settings → Reset.", sequence: 2 }),
+			],
+			knowledge,
+		);
+		await user.click(addBtn()!);
+		await user.click(
+			screen.getByRole("button", { name: /^add to knowledge$/i }),
+		);
+
+		await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+		const [url, init] = fetchMock.mock.calls[0];
+		expect(String(url)).toContain("/api/projects/p1/sources/promote");
+		expect(init.method).toBe("POST");
+		expect(JSON.parse(init.body)).toEqual({
+			messageId: expect.any(String),
+			question: "How do I reset my password?",
+			answer: "Go to Settings → Reset.",
+		});
+		expect(init.headers["x-workspace-id"]).toBe("ws_1");
+
+		await waitFor(() =>
+			expect(toastSuccess).toHaveBeenCalledWith(
+				"Added to your agent's knowledge",
+			),
+		);
+		// The action collapses into a quiet confirmation badge.
+		await screen.findByText("In knowledge");
+		expect(addBtn()).not.toBeInTheDocument();
+	});
+
+	it("omits a blank question so the server derives it", async () => {
+		const user = userEvent.setup();
+		// Admin reply with NO preceding visitor message → empty default question.
+		renderThread(
+			[
+				msg({
+					role: "admin",
+					content: "Welcome! Ask me anything.",
+					sequence: 1,
+				}),
+			],
+			knowledge,
+		);
+		await user.click(addBtn()!);
+		expect(screen.getByLabelText("Question")).toHaveValue("");
+		await user.click(
+			screen.getByRole("button", { name: /^add to knowledge$/i }),
+		);
+
+		await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+		const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+		expect(body).toEqual({
+			messageId: expect.any(String),
+			answer: "Welcome! Ask me anything.",
+		});
+		expect(body).not.toHaveProperty("question");
+	});
+
+	it("keeps the dialog open and toasts on failure", async () => {
+		fetchMock.mockResolvedValueOnce({
+			ok: false,
+			status: 500,
+			json: async () => ({ error: "boom" }),
+			text: async () => '{"error":"boom"}',
+		});
+		const user = userEvent.setup();
+		renderThread(
+			[msg({ role: "admin", content: "Try this.", sequence: 1 })],
+			knowledge,
+		);
+		await user.click(addBtn()!);
+		await user.click(
+			screen.getByRole("button", { name: /^add to knowledge$/i }),
+		);
+
+		await waitFor(() => expect(toastError).toHaveBeenCalled());
+		// No badge — still promotable.
+		expect(screen.queryByText("In knowledge")).not.toBeInTheDocument();
+	});
+});

--- a/apps/dashboard/src/app/inbox/_components/PromoteToKnowledge.tsx
+++ b/apps/dashboard/src/app/inbox/_components/PromoteToKnowledge.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import { useMutation } from "@tanstack/react-query";
+import { BookCheck, BookPlus } from "lucide-react";
+import { useState } from "react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { api, describeApiError } from "@/lib/api";
+
+export interface PromoteToKnowledgeProps {
+	projectId: string;
+	projectName: string;
+	workspaceId: string;
+	messageId: string;
+	/** Nearest preceding visitor message — the editable default question. */
+	defaultQuestion: string;
+	/** The agent's reply body — the editable default answer. */
+	defaultAnswer: string;
+}
+
+/**
+ * "Add to knowledge" affordance on a human (admin) reply: turns the reply into a
+ * Q&A source the agent learns from. A standard (non-optimistic) mutation —
+ * creating a knowledge source is deliberately excluded from the optimistic lib,
+ * so the row only appears once the server confirms it. Owns its own `promoted`
+ * flag, keyed by message id in the thread, so the "In knowledge" badge survives
+ * the 3s poll re-render and resets naturally when the conversation changes.
+ */
+export function PromoteToKnowledge({
+	projectId,
+	projectName,
+	workspaceId,
+	messageId,
+	defaultQuestion,
+	defaultAnswer,
+}: PromoteToKnowledgeProps) {
+	const [open, setOpen] = useState(false);
+	const [promoted, setPromoted] = useState(false);
+	const [question, setQuestion] = useState(defaultQuestion);
+	const [answer, setAnswer] = useState(defaultAnswer);
+
+	const mutation = useMutation({
+		mutationFn: () =>
+			api(`/api/projects/${projectId}/sources/promote`, {
+				method: "POST",
+				// Omit a blank question so the server derives the nearest preceding
+				// visitor message; always send the (required, non-blank) answer.
+				body: {
+					messageId,
+					question: question.trim() || undefined,
+					answer: answer.trim(),
+				},
+				workspaceId,
+			}),
+		onSuccess: () => {
+			setPromoted(true);
+			setOpen(false);
+			toast.success("Added to your agent's knowledge");
+		},
+		onError: (e) =>
+			toast.error(describeApiError(e, "Couldn't add to knowledge")),
+	});
+
+	// Once promoted, the action becomes a quiet confirmation badge.
+	if (promoted) {
+		return (
+			<span className="flex items-center gap-1 px-1 text-[11px] font-medium text-emerald-600 dark:text-emerald-400">
+				<BookCheck className="size-3" />
+				In knowledge
+			</span>
+		);
+	}
+
+	function openDialog() {
+		// Re-seed the fields from the latest reply each time it's opened.
+		setQuestion(defaultQuestion);
+		setAnswer(defaultAnswer);
+		setOpen(true);
+	}
+
+	return (
+		<>
+			<Button
+				type="button"
+				variant="ghost"
+				size="sm"
+				onClick={openDialog}
+				className="h-6 gap-1 px-1.5 text-[11px] font-medium text-muted-foreground/70 hover:text-foreground"
+			>
+				<BookPlus className="size-3" />
+				Add to knowledge
+			</Button>
+
+			<Dialog open={open} onOpenChange={setOpen}>
+				<DialogContent>
+					<DialogHeader>
+						<DialogTitle>Add to your agent&apos;s knowledge</DialogTitle>
+						<DialogDescription>
+							Save this as a Q&amp;A so your agent can answer similar questions
+							on its own. Adds to{" "}
+							<span className="font-medium text-foreground">{projectName}</span>
+							.
+						</DialogDescription>
+					</DialogHeader>
+					<form
+						onSubmit={(e) => {
+							e.preventDefault();
+							if (answer.trim()) mutation.mutate();
+						}}
+						className="flex flex-col gap-4"
+					>
+						<div className="flex flex-col gap-1.5">
+							<Label htmlFor="promote-question">Question</Label>
+							<Textarea
+								id="promote-question"
+								rows={2}
+								placeholder="What the visitor asked (optional)"
+								value={question}
+								onChange={(e) => setQuestion(e.target.value)}
+							/>
+						</div>
+						<div className="flex flex-col gap-1.5">
+							<Label htmlFor="promote-answer">Answer</Label>
+							<Textarea
+								id="promote-answer"
+								rows={4}
+								required
+								placeholder="The answer your agent should give"
+								value={answer}
+								onChange={(e) => setAnswer(e.target.value)}
+							/>
+						</div>
+						<DialogFooter>
+							<Button
+								type="button"
+								variant="ghost"
+								onClick={() => setOpen(false)}
+							>
+								Cancel
+							</Button>
+							<Button
+								type="submit"
+								disabled={mutation.isPending || !answer.trim()}
+							>
+								{mutation.isPending ? "Adding…" : "Add to knowledge"}
+							</Button>
+						</DialogFooter>
+					</form>
+				</DialogContent>
+			</Dialog>
+		</>
+	);
+}

--- a/apps/dashboard/src/app/inbox/page.tsx
+++ b/apps/dashboard/src/app/inbox/page.tsx
@@ -183,6 +183,16 @@ export default function InboxPage() {
 	const selectedConv = allConversations.find((c) => c.id === selectedId);
 	const detailConv = thread.conversation ?? selectedConv ?? null;
 
+	// Context for the "Add to knowledge" action on admin replies — only once a
+	// project + workspace are resolved.
+	const projectName =
+		projects.data?.projects.find((p) => p.id === projectId)?.name ??
+		"this agent";
+	const knowledge =
+		projectId && workspaceId
+			? { projectId, projectName, workspaceId }
+			: undefined;
+
 	// Mark a conversation read for this user. Optimistically clears the unread dot
 	// in-cache across the head + loaded pages (so a row deep in a loaded page
 	// clears instantly without any refetch), then PATCHes. Best-effort: on failure
@@ -445,6 +455,7 @@ export default function InboxPage() {
 							hasOlder={thread.hasOlder}
 							onLoadOlder={thread.loadOlder}
 							loadingOlder={thread.loadingOlder}
+							knowledge={knowledge}
 						/>
 					))
 				}

--- a/apps/dashboard/src/app/settings/projects/[id]/SourcesCard.test.tsx
+++ b/apps/dashboard/src/app/settings/projects/[id]/SourcesCard.test.tsx
@@ -3,8 +3,29 @@ import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
 import { SourcesCard } from "./SourcesCard";
+import type { Source } from "./types";
 
 vi.mock("sonner", () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
+
+function makeSource(overrides: Partial<Source>): Source {
+	return {
+		id: "s1",
+		projectId: "p1",
+		kind: "url",
+		url: "https://example.com",
+		title: "",
+		content: "",
+		question: null,
+		answer: null,
+		sourceMessageId: null,
+		active: true,
+		lastFetchedAt: "2026-06-16T05:00:00.000Z",
+		lastError: null,
+		createdAt: "2026-06-16T05:00:00.000Z",
+		updatedAt: "2026-06-16T05:00:00.000Z",
+		...overrides,
+	};
+}
 
 function setup(onAdd = vi.fn()) {
 	render(
@@ -50,5 +71,53 @@ describe("<SourcesCard /> add flow", () => {
 		await user.type(input, "https://docs.example.com{Enter}");
 
 		expect(onAdd).toHaveBeenCalledWith("https://docs.example.com");
+	});
+});
+
+describe("<SourcesCard /> tolerates url-less (qa/text) sources", () => {
+	function renderWith(source: Source) {
+		render(
+			<SourcesCard
+				sources={[source]}
+				isLoading={false}
+				onAdd={vi.fn()}
+				onRefresh={vi.fn()}
+				onDelete={vi.fn()}
+				addPending={false}
+				refreshingId={null}
+			/>,
+		);
+	}
+
+	it("renders a promoted Q&A row by title (no url) with a Q&A badge and no recrawl", () => {
+		renderWith(
+			makeSource({
+				id: "qa1",
+				kind: "qa",
+				url: null,
+				title: "How do I reset my password?",
+				content: "Q: How do I reset my password?\nA: Go to Settings.",
+				question: "How do I reset my password?",
+				answer: "Go to Settings.",
+				sourceMessageId: "m1",
+				lastFetchedAt: null,
+			}),
+		);
+		// Title is the primary line (there is no URL to show).
+		expect(screen.getByText("How do I reset my password?")).toBeInTheDocument();
+		expect(screen.getByText("Q&A")).toBeInTheDocument();
+		// A Q&A source can't be recrawled — no recrawl control, but delete remains.
+		expect(
+			screen.queryByRole("button", { name: /recrawl/i }),
+		).not.toBeInTheDocument();
+		expect(screen.getByRole("button", { name: /delete/i })).toBeInTheDocument();
+	});
+
+	it("still shows the URL and a recrawl control for url sources", () => {
+		renderWith(makeSource({ url: "https://acme.com/docs", title: "Docs" }));
+		expect(screen.getByText("https://acme.com/docs")).toBeInTheDocument();
+		expect(
+			screen.getByRole("button", { name: /recrawl/i }),
+		).toBeInTheDocument();
 	});
 });

--- a/apps/dashboard/src/app/settings/projects/[id]/SourcesCard.tsx
+++ b/apps/dashboard/src/app/settings/projects/[id]/SourcesCard.tsx
@@ -43,6 +43,15 @@ function sourceStatus(s: Source): {
 			className: "border-border bg-muted text-muted-foreground",
 		};
 	}
+	// Non-URL sources (Q&A promoted from a reply, or manual text) aren't crawled,
+	// so the fetch-based states below don't apply — show what they are instead.
+	if (s.kind !== "url") {
+		return {
+			label: s.kind === "qa" ? "Q&A" : "Text",
+			className:
+				"border-indigo-500/30 bg-indigo-500/10 text-indigo-600 dark:text-indigo-400",
+		};
+	}
 	if (!s.lastFetchedAt) {
 		return {
 			label: "Pending",
@@ -167,10 +176,12 @@ export function SourcesCard({
 									<Globe className="size-4" />
 								</span>
 								<div className="min-w-0 flex-1">
+									{/* url sources lead with the URL (title as subline); url-less
+									    qa/text sources have no URL, so the title leads. */}
 									<p className="truncate text-sm font-medium text-foreground">
-										{s.url}
+										{s.url ?? s.title}
 									</p>
-									{s.title && (
+									{s.url && s.title && (
 										<p className="truncate text-xs text-muted-foreground">
 											{s.title}
 										</p>
@@ -188,25 +199,28 @@ export function SourcesCard({
 									</span>
 								)}
 								<div className="flex shrink-0 items-center gap-1">
-									<Button
-										type="button"
-										variant="ghost"
-										size="icon"
-										className="size-8 text-muted-foreground hover:text-foreground"
-										onClick={() => onRefresh(s.id)}
-										disabled={refreshing}
-										aria-label={`Recrawl ${s.url}`}
-										title="Recrawl"
-									>
-										<RefreshCw className={cn(refreshing && "animate-spin")} />
-									</Button>
+									{/* Only URL sources can be recrawled; qa/text have no URL. */}
+									{s.url && (
+										<Button
+											type="button"
+											variant="ghost"
+											size="icon"
+											className="size-8 text-muted-foreground hover:text-foreground"
+											onClick={() => onRefresh(s.id)}
+											disabled={refreshing}
+											aria-label={`Recrawl ${s.url}`}
+											title="Recrawl"
+										>
+											<RefreshCw className={cn(refreshing && "animate-spin")} />
+										</Button>
+									)}
 									<Button
 										type="button"
 										variant="ghost"
 										size="icon"
 										className="size-8 text-muted-foreground hover:bg-red-500/10 hover:text-red-600 dark:hover:text-red-400"
 										onClick={() => onDelete(s.id)}
-										aria-label={`Delete ${s.url}`}
+										aria-label={`Delete ${s.url ?? s.title}`}
 										title="Delete"
 									>
 										<Trash2 />

--- a/apps/dashboard/src/app/settings/projects/[id]/types.ts
+++ b/apps/dashboard/src/app/settings/projects/[id]/types.ts
@@ -16,9 +16,17 @@ export interface Project {
 export interface Source {
 	id: string;
 	projectId: string;
-	url: string;
+	/** "url" — fetched web page; "text" — manual text; "qa" — promoted reply. */
+	kind: "url" | "text" | "qa";
+	/** Null for text/qa sources (only url sources have a URL). */
+	url: string | null;
 	title: string;
 	content: string;
+	/** For qa sources: the question/answer kept apart from the rendered content. */
+	question: string | null;
+	answer: string | null;
+	/** The inbox message a qa source was promoted from (provenance/dedupe). */
+	sourceMessageId: string | null;
 	active: boolean;
 	lastFetchedAt: string | null;
 	lastError: string | null;

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -218,9 +218,25 @@ export const source = sqliteTable(
 		projectId: text()
 			.notNull()
 			.references(() => project.id, { onDelete: "cascade" }),
-		url: text().notNull(),
+		// How this source was created / what it holds:
+		//   "url"  — a fetched web page (the original v1 source; keeps a non-null url)
+		//   "text" — manually-entered free text (no url)
+		//   "qa"   — a Q&A pair promoted from an inbox reply (no url; see question/answer)
+		// Default "url" so every pre-existing row backfills to the original kind.
+		kind: text({ enum: ["url", "text", "qa"] })
+			.notNull()
+			.default("url"),
+		// Nullable now: only "url" sources have a URL. text/qa sources have none.
+		url: text(),
 		title: text().notNull().default(""),
 		content: text().notNull().default(""),
+		// For "qa" sources: the question/answer kept separately from `content` so the
+		// pair can be displayed/edited later without re-parsing the "Q:/A:" blob.
+		question: text(),
+		answer: text(),
+		// Provenance + dedupe for promoted Q&A: the message this was promoted from.
+		// Lets a repeated promote of the same reply no-op instead of duplicating.
+		sourceMessageId: text(),
 		active: integer({ mode: "boolean" }).notNull().default(true),
 		lastFetchedAt: timestamp(),
 		lastError: text(),


### PR DESCRIPTION
## What

Adds a **text/manual source path** and lets an agent turn a good human reply in the inbox into a **Q&A source the agent learns from** — one click in the thread, an editable confirm dialog, and the pair is added to the project's knowledge.

Anchored to today's reality (per the prior audit): sources were URL-only, ingestion is a single synchronous fetch, and retrieval just concatenates every active source's content into the system prompt (~80k cap). This introduces a non-URL source kind that flows through that same retrieval path.

## Schema + migration ⚠️

`source` gains `kind` (`url` | `text` | `qa`, **NOT NULL default `url`**), `url` becomes **nullable** (text/qa have none), plus nullable `question`, `answer`, `sourceMessageId` (provenance + dedupe).

- **Migration:** `apps/api/migrations/0012_source_qa_kind.sql` — hand-authored (the repo's drizzle journal is frozen at `0000`; `0003`–`0011` are hand-managed, and `drizzle-kit generate` re-diffs the whole schema, so it can't be used here). Recreates `source` with the copy/drop/rename dance (required to drop `url`'s NOT NULL in SQLite), carrying every existing row over and **backfilling `kind='url'`** (column default + an explicit belt-and-braces `UPDATE`).
- **Prod application:** ship the file — **Ploy auto-applies pending migrations from its own ledger** (keyed by filename, applied once, in filename order) on deploy, so `0012` runs after `0011` against prod D1. No manual step. Validated on a scratch SQLite: existing row keeps its URL + gets `kind='url'`; `url` now accepts NULL.

## API

`POST /projects/:projectId/sources/promote` — body `{ messageId, question?, answer? }`, **minimum role `agent`**.

- **Tenant isolation** (deliberate, we've shipped a cross-tenant bug before): project ∈ caller's workspace → message exists → its conversation belongs to **this** project; any miss ⇒ 404. A foreign `messageId` can't be promoted.
- **Derived defaults:** `answer` = override or the message body (required non-empty, else 400); `question` = override (empty allowed) or the **nearest preceding visitor message**.
- **Create-only validator** with `messageId` required and **no `.default()`/`.partial()`** (avoids the Zod-v4 footgun that reset siblings — the create/update split elsewhere stays intact).
- **Dedupe** by `sourceMessageId` (re-promote = no-op, returns the existing source).
- Source is `kind='qa'`, `url=null`, `content="Q: …\nA: …"`, `active=true`, title from the question.

**Retrieval:** the active-sources query already doesn't filter on `url`, so qa/text are included; `buildSystem` now omits the `URL:` line for url-less sources. Test asserts a promoted Q&A's content reaches the assembled prompt.

## UI (inbox thread)

Subtle **"Add to knowledge"** action on admin (human) replies → a shadcn `Dialog` pre-filled with editable **Question** (nearest preceding visitor message) and **Answer** (the reply), noting which project it adds to. Confirm → **standard mutation + toast** ("Added to your agent's knowledge"), loading state, and a small **"In knowledge"** badge after success. Deliberately **not** the optimistic lib (source creation is excluded). Positioning: "your agent", never "chatbot".

The Sources settings list now tolerates a `url=null` row (shows the title, a `Q&A` badge, hides recrawl) — **no redesign**, that's a later PR.

## Tests (all green)

API **206** (+20): cross-workspace `messageId` → 404 (nothing created); agent allowed / non-member 403; no preceding visitor → empty question; whitespace/empty answer → 400; over-length question/answer caps → 400; dedupe → no dup; promoted Q&A reaches the prompt; url sources unchanged. Dashboard **276** (+10): action only on admin replies & only with context; prefill; confirm POSTs the right body + toast + badge; blank-question omitted; failure keeps the dialog open; Sources list renders a null-url row + hides recrawl. The projects PATCH no-clobber regression remains green.

Gates: `pnpm build` (typecheck, 5/5), `pnpm test`, `pnpm lint`, prettier `--check`, secret scan — all clean. Unrelated drift (`.agents/*`, `skills-lock.json`, `consent.ts`) left unstaged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)