### PR TITLE
feat(inbox): tags/labels on conversations (chips, picker, filter)

### DIFF
--- a/apps/api/migrations/0013_conversation_tags.sql
+++ b/apps/api/migrations/0013_conversation_tags.sql
@@ -1,0 +1,34 @@
+-- Conversation tags/labels. Purely additive: two new tables + indexes, NO
+-- rewrite of any existing/populated table (unlike 0012, which had to recreate
+-- `source`), so this is low-risk. drizzle-kit generate is unusable here (the
+-- journal is frozen → it tries to drop/recreate project/workspace), so this is
+-- hand-authored and scoped to only the new tables, like 0012. Ploy's ledger
+-- applies each migrations/*.sql once, in filename order (so this runs after
+-- 0012), each file in a transaction.
+CREATE TABLE `tag` (
+	`id` text PRIMARY KEY NOT NULL,
+	`workspace_id` text NOT NULL,
+	`name` text NOT NULL,
+	`color` text,
+	`created_at` integer DEFAULT (unixepoch()) NOT NULL,
+	FOREIGN KEY (`workspace_id`) REFERENCES `workspace`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+-- Case-insensitive uniqueness per workspace: "Billing" and "billing" can't both
+-- exist. NOCASE folds ASCII case only; the API also dedupes via lower(name).
+CREATE UNIQUE INDEX `tag_workspace_name` ON `tag` (`workspace_id`, `name` COLLATE NOCASE);
+--> statement-breakpoint
+CREATE TABLE `conversation_tag` (
+	`id` text PRIMARY KEY NOT NULL,
+	`conversation_id` text NOT NULL,
+	`tag_id` text NOT NULL,
+	`created_at` integer DEFAULT (unixepoch()) NOT NULL,
+	FOREIGN KEY (`conversation_id`) REFERENCES `conversation`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`tag_id`) REFERENCES `tag`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+-- One association per (conversation, tag): makes attach idempotent at the DB level.
+CREATE UNIQUE INDEX `conversation_tag_unique` ON `conversation_tag` (`conversation_id`, `tag_id`);
+--> statement-breakpoint
+-- Index the tag side for the list's tagIds filter (tag → conversations).
+CREATE INDEX `conversation_tag_tag` ON `conversation_tag` (`tag_id`);

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -12,6 +12,7 @@ import { oauthProviders } from "@/routes/oauth-providers";
 import { projects } from "@/routes/projects";
 import { sources } from "@/routes/sources";
 import { systemPrompts } from "@/routes/system-prompts";
+import { tags } from "@/routes/tags";
 import { widgetAsset } from "@/routes/widget-asset";
 import { widgetConfig } from "@/routes/widget-config";
 import { widgetCsat } from "@/routes/widget-csat";
@@ -87,6 +88,7 @@ app.route("/api", workspaces);
 app.route("/api", projects);
 app.route("/api", systemPrompts);
 app.route("/api", sources);
+app.route("/api", tags);
 app.route("/api", conversations);
 app.route("/", inboundEmail);
 // Billing mounts at root so the webhook is reachable at /billing/webhook

--- a/apps/api/src/lib/tag-colors.ts
+++ b/apps/api/src/lib/tag-colors.ts
@@ -1,0 +1,33 @@
+// Fixed tag palette. A new tag with no color gets one assigned deterministically
+// from its name, so the same label tends to keep the same color and the spread
+// across a workspace stays balanced without storing a counter. The dashboard
+// just renders whatever hex the server returns — this is the single source.
+
+export const TAG_PALETTE = [
+	"#6366f1", // indigo
+	"#0ea5e9", // sky
+	"#10b981", // emerald
+	"#f59e0b", // amber
+	"#ef4444", // red
+	"#ec4899", // pink
+	"#8b5cf6", // violet
+	"#14b8a6", // teal
+] as const;
+
+export type TagColor = (typeof TAG_PALETTE)[number];
+
+/** Whether a string is a hex color the client may supply (#rgb or #rrggbb). */
+export function isHexColor(value: string): boolean {
+	return /^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/.test(value);
+}
+
+/** Stable palette pick from a tag name (case-insensitive) so the same label maps
+ * to the same color every time. */
+export function colorForName(name: string): TagColor {
+	const key = name.trim().toLowerCase();
+	let hash = 0;
+	for (let i = 0; i < key.length; i++) {
+		hash = (hash * 31 + key.charCodeAt(i)) | 0;
+	}
+	return TAG_PALETTE[Math.abs(hash) % TAG_PALETTE.length];
+}

--- a/apps/api/src/lib/tags.ts
+++ b/apps/api/src/lib/tags.ts
@@ -1,0 +1,66 @@
+// Shared tag helpers used by both the /tags route (create) and the conversation
+// attach-by-name path, so dedupe + color assignment live in exactly one place.
+
+import { db } from "@/lib/db";
+import { colorForName, isHexColor } from "@/lib/tag-colors";
+
+import { and, eq, sql, tag } from "@llmchat/db";
+
+import type { AppContext } from "@/env";
+
+type Env = AppContext["Bindings"];
+
+export const TAG_NAME_MAX = 40;
+
+/** A tag row as returned to clients. */
+export interface TagRow {
+	id: string;
+	workspaceId: string;
+	name: string;
+	color: string | null;
+	createdAt: Date;
+}
+
+/** Case-insensitive lookup of a tag by name within a workspace (matches the
+ * COLLATE NOCASE unique index). */
+export async function findTagByName(
+	env: Env,
+	workspaceId: string,
+	name: string,
+): Promise<TagRow | undefined> {
+	const [row] = await db(env)
+		.select()
+		.from(tag)
+		.where(
+			and(
+				eq(tag.workspaceId, workspaceId),
+				sql`lower(${tag.name}) = ${name.toLowerCase()}`,
+			),
+		)
+		.limit(1);
+	return row;
+}
+
+/**
+ * Find-or-create a workspace tag by name (case-insensitive). Dedupe is a no-op
+ * that returns the existing tag — never a duplicate. A missing color is assigned
+ * deterministically from the name; a provided hex color is honored, anything
+ * else is ignored (falls back to the derived color).
+ */
+export async function findOrCreateTag(
+	env: Env,
+	workspaceId: string,
+	rawName: string,
+	color?: string | null,
+): Promise<{ tag: TagRow; created: boolean }> {
+	const name = rawName.trim();
+	const existing = await findTagByName(env, workspaceId, name);
+	if (existing) return { tag: existing, created: false };
+
+	const resolvedColor = color && isHexColor(color) ? color : colorForName(name);
+	const [created] = await db(env)
+		.insert(tag)
+		.values({ workspaceId, name, color: resolvedColor })
+		.returning();
+	return { tag: created!, created: true };
+}

--- a/apps/api/src/routes/conversations.test.ts
+++ b/apps/api/src/routes/conversations.test.ts
@@ -4,7 +4,13 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { decodeCursor, encodeCursor } from "@/lib/cursor";
 import { db } from "@/lib/db";
 
-import { conversation, message, readStatus } from "@llmchat/db";
+import {
+	conversation,
+	conversationTag,
+	message,
+	readStatus,
+	tag as tagTable,
+} from "@llmchat/db";
 
 import { conversations } from "./conversations";
 
@@ -55,7 +61,26 @@ interface State {
 	conv?: Row;
 	/** Rows the thread message window query returns (relational findMany). */
 	threadMessages?: Row[];
+	/** Batched per-page tag rows (conversation_tag ⨝ tag) for the list response. */
+	tagRows?: {
+		conversationId: string;
+		id: string;
+		name: string;
+		color: string | null;
+	}[];
+	/** A tag resolved by id on attach (undefined ⇒ 404, e.g. foreign workspace). */
+	tag?: Row;
+	/** Existing (conversation,tag) association for the idempotency check. */
+	existingAssoc?: Row;
+	/** Tag lookup result for findOrCreateTag's dedupe select (attach-by-name). */
+	tagLookup?: Row[];
 }
+
+/** How many times the batched per-page tag query (conversation_tag) ran — used
+ * to assert the list attaches tags in ONE query (no N+1). */
+let conversationTagSelects: number;
+let insertSpy: ReturnType<typeof vi.fn>;
+let deleteSpy: ReturnType<typeof vi.fn>;
 
 /** Records the shape of every message-table query so tests can assert the
  * content-search queries are scoped via a conversation join. */
@@ -66,6 +91,17 @@ let lastConversationWhere: Parameters<typeof dialect.sqlToQuery>[0] | null;
 function mockDb(state: State) {
 	messageQueries = [];
 	lastConversationWhere = null;
+	conversationTagSelects = 0;
+	insertSpy = vi.fn(() => ({
+		values: (data: Record<string, unknown>) => {
+			const result = [{ id: "row_new", ...data }];
+			const ret = { returning: async () => result };
+			// `.values()` is awaited directly for join inserts and `.returning()`ed
+			// for tag inserts, so it must be both thenable and expose returning.
+			return Object.assign(Promise.resolve(result), ret);
+		},
+	}));
+	deleteSpy = vi.fn(() => ({ where: async () => [] }));
 
 	function builder(distinct: boolean) {
 		const q = { table: null as unknown, joined: false };
@@ -80,6 +116,12 @@ function mockDb(state: State) {
 				return state.firstMessages ?? [];
 			}
 			if (q.table === conversation) return state.conversationRows ?? [];
+			if (q.table === conversationTag) {
+				// The batched per-page tag join (list response).
+				conversationTagSelects += 1;
+				return state.tagRows ?? [];
+			}
+			if (q.table === tagTable) return state.tagLookup ?? [];
 			if (q.table === readStatus) return [];
 			return [];
 		};
@@ -133,9 +175,17 @@ function mockDb(state: State) {
 			message: {
 				findMany: async () => state.threadMessages ?? [],
 			},
+			tag: {
+				findFirst: async () => state.tag,
+			},
+			conversationTag: {
+				findFirst: async () => state.existingAssoc,
+			},
 		},
 		select: () => builder(false),
 		selectDistinct: () => builder(true),
+		insert: insertSpy,
+		delete: deleteSpy,
 	};
 	vi.mocked(db).mockReturnValue(fake as unknown as ReturnType<typeof db>);
 }
@@ -565,5 +615,224 @@ describe("thread pagination (GET conversations/:id)", () => {
 		mockDb({});
 		const res = await get("/projects/p1/conversations/cThread", MEMBER);
 		expect(res.status).toBe(403);
+	});
+});
+
+const JSONH = { "content-type": "application/json" };
+function send(
+	path: string,
+	method: string,
+	body?: unknown,
+	headers: Record<string, string> = MEMBER,
+) {
+	return conversations.request(
+		path,
+		{
+			method,
+			headers: body ? { ...headers, ...JSONH } : headers,
+			body: body ? JSON.stringify(body) : undefined,
+		},
+		ENV,
+	);
+}
+
+describe("inbox tag filter (tagIds)", () => {
+	it("adds an OR subquery on conversation_tag, still project-scoped", async () => {
+		mockDb({ role: "agent", project: PROJECT, conversationRows: [] });
+		await get("/projects/p1/conversations?tagIds=t1,t2", MEMBER);
+		const sql = whereSql();
+		expect(sql).toContain("conversation_tag");
+		expect(sql).toContain("in (select");
+		expect(sql).toContain('"project_id"');
+	});
+
+	it("composes with archived + search + cursor in one WHERE", async () => {
+		mockDb({
+			role: "agent",
+			project: PROJECT,
+			conversationRows: [],
+			bodyMatchIds: ["cZ"],
+		});
+		const cursor = encodeCursor({ updatedAt: 250, id: "cMid" });
+		await get(
+			`/projects/p1/conversations?tagIds=t1&archived=true&search=refund&cursor=${cursor}`,
+			MEMBER,
+		);
+		const sql = whereSql();
+		expect(sql).toContain("conversation_tag"); // tag filter
+		expect(sql).toContain('"archived_at" is not null'); // archived
+		expect(sql).toContain("like"); // search
+		expect(sql).toContain('"updated_at" <'); // keyset cursor
+	});
+
+	it("empty/whitespace tagIds adds NO tag predicate", async () => {
+		mockDb({ role: "agent", project: PROJECT, conversationRows: [] });
+		await get("/projects/p1/conversations?tagIds=%20%20", MEMBER);
+		expect(whereSql()).not.toContain("conversation_tag");
+	});
+});
+
+describe("inbox list — tags attached per page (no N+1)", () => {
+	it("attaches each conversation's tags in ONE batched query", async () => {
+		mockDb({
+			role: "agent",
+			project: PROJECT,
+			conversationRows: [
+				{ id: "cA", name: "Bob", email: null, messageCount: 1 },
+				{ id: "cB", name: "Ada", email: null, messageCount: 1 },
+			],
+			tagRows: [
+				{ conversationId: "cA", id: "t1", name: "Billing", color: "#6366f1" },
+				{ conversationId: "cA", id: "t2", name: "VIP", color: "#ef4444" },
+				{ conversationId: "cB", id: "t1", name: "Billing", color: "#6366f1" },
+			],
+		});
+		const res = await get("/projects/p1/conversations", MEMBER);
+		const body = (await res.json()) as {
+			conversations: { id: string; tags: { id: string; name: string }[] }[];
+		};
+		expect(body.conversations[0]!.tags.map((t) => t.id)).toEqual(["t1", "t2"]);
+		expect(body.conversations[1]!.tags.map((t) => t.name)).toEqual(["Billing"]);
+		// Exactly one conversation_tag query for the whole page — not one per row.
+		expect(conversationTagSelects).toBe(1);
+	});
+
+	it("returns an empty tags array when a conversation has none", async () => {
+		mockDb({
+			role: "agent",
+			project: PROJECT,
+			conversationRows: [
+				{ id: "cA", name: "Bob", email: null, messageCount: 1 },
+			],
+			tagRows: [],
+		});
+		const res = await get("/projects/p1/conversations", MEMBER);
+		const body = (await res.json()) as { conversations: { tags: unknown[] }[] };
+		expect(body.conversations[0]!.tags).toEqual([]);
+	});
+});
+
+describe("attach tag — POST conversations/:id/tags", () => {
+	const CONV = { id: "c1", projectId: "p1" };
+
+	it("attaches an existing workspace tag by id (idempotent: inserts once)", async () => {
+		mockDb({
+			role: "agent",
+			project: PROJECT,
+			conv: CONV,
+			tag: { id: "t1", name: "Billing", color: "#6366f1", workspaceId: "ws_1" },
+			existingAssoc: undefined,
+		});
+		const res = await send("/projects/p1/conversations/c1/tags", "POST", {
+			tagId: "t1",
+		});
+		expect(res.status).toBe(200);
+		expect((await res.json()) as unknown).toMatchObject({
+			tag: { id: "t1", name: "Billing" },
+		});
+		expect(insertSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it("is idempotent: an existing association is not re-inserted", async () => {
+		mockDb({
+			role: "agent",
+			project: PROJECT,
+			conv: CONV,
+			tag: { id: "t1", name: "Billing", color: null, workspaceId: "ws_1" },
+			existingAssoc: { id: "a1", conversationId: "c1", tagId: "t1" },
+		});
+		const res = await send("/projects/p1/conversations/c1/tags", "POST", {
+			tagId: "t1",
+		});
+		expect(res.status).toBe(200);
+		expect(insertSpy).not.toHaveBeenCalled();
+	});
+
+	it("404s a tag from another workspace; never inserts (no cross-workspace attach)", async () => {
+		mockDb({
+			role: "agent",
+			project: PROJECT,
+			conv: CONV,
+			tag: undefined, // the workspace-scoped tag lookup finds nothing
+		});
+		const res = await send("/projects/p1/conversations/c1/tags", "POST", {
+			tagId: "foreign",
+		});
+		expect(res.status).toBe(404);
+		expect(insertSpy).not.toHaveBeenCalled();
+	});
+
+	it("404s when the project isn't in the caller's workspace", async () => {
+		mockDb({ role: "owner", project: undefined });
+		const res = await send("/projects/pX/conversations/c1/tags", "POST", {
+			tagId: "t1",
+		});
+		expect(res.status).toBe(404);
+		expect(insertSpy).not.toHaveBeenCalled();
+	});
+
+	it("404s when the conversation isn't in the project", async () => {
+		mockDb({ role: "agent", project: PROJECT, conv: undefined });
+		const res = await send("/projects/p1/conversations/nope/tags", "POST", {
+			tagId: "t1",
+		});
+		expect(res.status).toBe(404);
+	});
+
+	it("create-and-attach by name (no existing tag) mints the tag then associates", async () => {
+		mockDb({
+			role: "agent",
+			project: PROJECT,
+			conv: CONV,
+			tagLookup: [], // findOrCreateTag finds no existing → creates
+			existingAssoc: undefined,
+		});
+		const res = await send("/projects/p1/conversations/c1/tags", "POST", {
+			name: "Refunds",
+		});
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { tag: { name: string } };
+		expect(body.tag.name).toBe("Refunds");
+		// One insert for the tag + one for the association.
+		expect(insertSpy).toHaveBeenCalledTimes(2);
+	});
+
+	it("400s when neither tagId nor name is provided", async () => {
+		mockDb({ role: "agent", project: PROJECT, conv: CONV });
+		const res = await send("/projects/p1/conversations/c1/tags", "POST", {});
+		expect(res.status).toBe(400);
+	});
+
+	it("403s a non-member", async () => {
+		mockDb({});
+		const res = await send("/projects/p1/conversations/c1/tags", "POST", {
+			tagId: "t1",
+		});
+		expect(res.status).toBe(403);
+	});
+});
+
+describe("detach tag — DELETE conversations/:id/tags/:tagId", () => {
+	const CONV = { id: "c1", projectId: "p1" };
+
+	it("detaches and is no-op-safe when not attached", async () => {
+		mockDb({ role: "agent", project: PROJECT, conv: CONV });
+		const res = await send("/projects/p1/conversations/c1/tags/t1", "DELETE");
+		expect(res.status).toBe(200);
+		expect(deleteSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it("404s when the project isn't in the caller's workspace; never deletes", async () => {
+		mockDb({ role: "owner", project: undefined });
+		const res = await send("/projects/pX/conversations/c1/tags/t1", "DELETE");
+		expect(res.status).toBe(404);
+		expect(deleteSpy).not.toHaveBeenCalled();
+	});
+
+	it("403s a non-member; never deletes", async () => {
+		mockDb({});
+		const res = await send("/projects/p1/conversations/c1/tags/t1", "DELETE");
+		expect(res.status).toBe(403);
+		expect(deleteSpy).not.toHaveBeenCalled();
 	});
 });

--- a/apps/api/src/routes/conversations.test.ts
+++ b/apps/api/src/routes/conversations.test.ts
@@ -1,3 +1,5 @@
+import { DatabaseSync } from "node:sqlite";
+
 import { SQLiteSyncDialect } from "drizzle-orm/sqlite-core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -669,6 +671,47 @@ describe("inbox tag filter (tagIds)", () => {
 		mockDb({ role: "agent", project: PROJECT, conversationRows: [] });
 		await get("/projects/p1/conversations?tagIds=%20%20", MEMBER);
 		expect(whereSql()).not.toContain("conversation_tag");
+	});
+
+	it("a conversation with 2+ of the filtered tags appears EXACTLY ONCE (IN-subquery, no JOIN dup)", async () => {
+		// Capture the route's ACTUAL generated WHERE, then execute it verbatim
+		// against a real SQLite seeded with one conversation that carries BOTH
+		// filtered tags. A JOIN-style filter would return it twice; the IN-subquery
+		// returns it once. This proves the predicate itself, not the mock.
+		mockDb({ role: "agent", project: PROJECT, conversationRows: [] });
+		await get("/projects/p1/conversations?tagIds=t1,t2", MEMBER);
+		expect(lastConversationWhere).not.toBeNull();
+		const { sql, params } = dialect.sqlToQuery(lastConversationWhere!);
+
+		const db = new DatabaseSync(":memory:");
+		db.exec(
+			`CREATE TABLE conversation (id text PRIMARY KEY, project_id text, archived_at integer, updated_at integer);`,
+		);
+		db.exec(
+			`CREATE TABLE conversation_tag (id text PRIMARY KEY, conversation_id text, tag_id text);`,
+		);
+		// One conversation, two matching associations (t1 AND t2).
+		db.exec(
+			`INSERT INTO conversation (id, project_id, archived_at, updated_at) VALUES ('c1','p1',NULL,100);`,
+		);
+		db.exec(
+			`INSERT INTO conversation_tag (id, conversation_id, tag_id) VALUES ('a1','c1','t1'),('a2','c1','t2');`,
+		);
+		// A control conversation with a non-matching tag must NOT appear.
+		db.exec(
+			`INSERT INTO conversation (id, project_id, archived_at, updated_at) VALUES ('c2','p1',NULL,90);`,
+		);
+		db.exec(
+			`INSERT INTO conversation_tag (id, conversation_id, tag_id) VALUES ('a3','c2','tX');`,
+		);
+
+		const rows = db
+			.prepare(
+				`SELECT id FROM conversation WHERE ${sql} ORDER BY updated_at DESC`,
+			)
+			.all(...(params as (string | number)[]));
+		// Exactly one row, no duplication despite two matching tags.
+		expect(rows.map((r) => (r as { id: string }).id)).toEqual(["c1"]);
 	});
 });
 

--- a/apps/api/src/routes/conversations.ts
+++ b/apps/api/src/routes/conversations.ts
@@ -11,6 +11,7 @@ import {
 	includesCI,
 	likeContains,
 } from "@/lib/search";
+import { TAG_NAME_MAX, findOrCreateTag } from "@/lib/tags";
 import {
 	requireRole,
 	requireSession,
@@ -21,6 +22,7 @@ import {
 	and,
 	asc,
 	conversation,
+	conversationTag,
 	count,
 	desc,
 	eq,
@@ -31,9 +33,13 @@ import {
 	or,
 	readStatus,
 	sql,
+	tag as tagTable,
 } from "@llmchat/db";
 
 import type { AppContext } from "@/env";
+
+/** A tag as attached to a conversation in list responses. */
+type ConversationTagView = { id: string; name: string; color: string | null };
 
 /** Why a conversation surfaced in a search: an excerpt of the hit and which
  * field it came from, so the agent sees the reason in the list. */
@@ -52,11 +58,14 @@ export const conversations = new Hono<AppContext>()
 				// Opaque keyset cursor (see lib/cursor). A garbage value decodes to
 				// null below and just serves the first page — never a 400.
 				cursor: z.string().optional(),
+				// Comma-separated tag ids. OR semantics (a conversation matches if it
+				// has ANY of them). Empty/absent ⇒ no tag filtering.
+				tagIds: z.string().optional(),
 			}),
 		),
 		async (c) => {
 			const { projectId } = c.req.param();
-			const { search, archived, limit, cursor } = c.req.valid("query");
+			const { search, archived, limit, cursor, tagIds } = c.req.valid("query");
 			const workspaceId = c.get("workspaceId");
 			const userId = c.get("userId");
 
@@ -122,6 +131,29 @@ export const conversations = new Hono<AppContext>()
 			if (cur) {
 				conditions.push(
 					sql`(${conversation.updatedAt} < ${cur.updatedAt} OR (${conversation.updatedAt} = ${cur.updatedAt} AND ${conversation.id} < ${cur.id}))`,
+				);
+			}
+
+			// Tag filter (OR semantics): keep conversations that carry ANY of the
+			// given tags, via a scoped subquery on the join table. ANDed into the
+			// same conditions as project scope / archived / search / cursor, so it
+			// composes with keyset pagination and never widens beyond this project.
+			// A foreign tag id simply matches nothing here — no leak.
+			const tagIdList =
+				tagIds
+					?.split(",")
+					.map((t) => t.trim())
+					.filter(Boolean) ?? [];
+			if (tagIdList.length) {
+				// EXISTS-style subquery in raw SQL (like the keyset predicate above):
+				// one round-trip, no giant IN list, and it stays a single ANDed
+				// predicate so pagination + search + archived all still compose.
+				const ids = sql.join(
+					tagIdList.map((t) => sql`${t}`),
+					sql`, `,
+				);
+				conditions.push(
+					sql`${conversation.id} IN (SELECT ${conversationTag.conversationId} FROM ${conversationTag} WHERE ${conversationTag.tagId} IN (${ids}))`,
 				);
 			}
 
@@ -234,12 +266,35 @@ export const conversations = new Hono<AppContext>()
 				reads.map((r) => [r.conversationId, r.lastReadMessageCount]),
 			);
 
+			// Tags for the whole page in ONE query (no N+1): join the page's
+			// conversation ids to their tags, grouped client-side into a map.
+			const tagsByConv = new Map<string, ConversationTagView[]>();
+			if (ids.length) {
+				const tagRows = await db(c.env)
+					.select({
+						conversationId: conversationTag.conversationId,
+						id: tagTable.id,
+						name: tagTable.name,
+						color: tagTable.color,
+					})
+					.from(conversationTag)
+					.innerJoin(tagTable, eq(tagTable.id, conversationTag.tagId))
+					.where(inArray(conversationTag.conversationId, ids))
+					.orderBy(sql`lower(${tagTable.name})`);
+				for (const t of tagRows) {
+					const list = tagsByConv.get(t.conversationId) ?? [];
+					list.push({ id: t.id, name: t.name, color: t.color });
+					tagsByConv.set(t.conversationId, list);
+				}
+			}
+
 			return c.json({
 				conversations: rows.map((r) => ({
 					...r,
 					firstMessage: firstByConv.get(r.id) ?? null,
 					unread: (readByConv.get(r.id) ?? 0) < r.messageCount,
 					match: matchFor(r),
+					tags: tagsByConv.get(r.id) ?? [],
 				})),
 				nextCursor,
 			});
@@ -481,6 +536,98 @@ export const conversations = new Hono<AppContext>()
 			return c.json({ ok: true });
 		},
 	)
+	// Attach a tag to a conversation. `tagId` attaches an existing workspace tag;
+	// `name` creates-and-attaches (dedupe case-insensitively). Any workspace
+	// member. Idempotent: re-attaching the same tag is a no-op.
+	.post(
+		"/projects/:projectId/conversations/:id/tags",
+		zValidator(
+			"json",
+			z
+				.object({
+					tagId: z.string().optional(),
+					name: z.string().trim().min(1).max(TAG_NAME_MAX).optional(),
+					color: z.string().max(32).optional(),
+				})
+				.refine((d) => d.tagId || d.name, {
+					message: "tagId or name required",
+				}),
+		),
+		async (c) => {
+			const { projectId, id } = c.req.param();
+			const { tagId, name, color } = c.req.valid("json");
+			const workspaceId = c.get("workspaceId");
+
+			// Tenant chain: project ∈ workspace, conversation ∈ project.
+			const proj = await db(c.env).query.project.findFirst({
+				where: (pt, { and: a, eq: e }) =>
+					a(e(pt.id, projectId), e(pt.workspaceId, workspaceId)),
+			});
+			if (!proj) return c.json({ error: "not found" }, 404);
+			const conv = await db(c.env).query.conversation.findFirst({
+				where: (ct, { and: a, eq: e }) =>
+					a(e(ct.id, id), e(ct.projectId, projectId)),
+			});
+			if (!conv) return c.json({ error: "not found" }, 404);
+
+			// Resolve the tag. By id: it MUST belong to this workspace (else 404 — no
+			// cross-workspace attach, no existence leak). By name: find-or-create.
+			let resolved: ConversationTagView;
+			if (tagId) {
+				const t = await db(c.env).query.tag.findFirst({
+					where: (tt, { and: a, eq: e }) =>
+						a(e(tt.id, tagId), e(tt.workspaceId, workspaceId)),
+				});
+				if (!t) return c.json({ error: "not found" }, 404);
+				resolved = { id: t.id, name: t.name, color: t.color };
+			} else {
+				const { tag: t } = await findOrCreateTag(
+					c.env,
+					workspaceId,
+					name!,
+					color,
+				);
+				resolved = { id: t.id, name: t.name, color: t.color };
+			}
+
+			// Idempotent attach: skip if the association already exists.
+			const already = await db(c.env).query.conversationTag.findFirst({
+				where: (xt, { and: a, eq: e }) =>
+					a(e(xt.conversationId, id), e(xt.tagId, resolved.id)),
+			});
+			if (!already) {
+				await db(c.env)
+					.insert(conversationTag)
+					.values({ conversationId: id, tagId: resolved.id });
+			}
+			return c.json({ tag: resolved });
+		},
+	)
+	// Detach a tag. No-op-safe when the association doesn't exist. Any member.
+	.delete("/projects/:projectId/conversations/:id/tags/:tagId", async (c) => {
+		const { projectId, id, tagId } = c.req.param();
+		const workspaceId = c.get("workspaceId");
+		const proj = await db(c.env).query.project.findFirst({
+			where: (pt, { and: a, eq: e }) =>
+				a(e(pt.id, projectId), e(pt.workspaceId, workspaceId)),
+		});
+		if (!proj) return c.json({ error: "not found" }, 404);
+		const conv = await db(c.env).query.conversation.findFirst({
+			where: (ct, { and: a, eq: e }) =>
+				a(e(ct.id, id), e(ct.projectId, projectId)),
+		});
+		if (!conv) return c.json({ error: "not found" }, 404);
+
+		await db(c.env)
+			.delete(conversationTag)
+			.where(
+				and(
+					eq(conversationTag.conversationId, id),
+					eq(conversationTag.tagId, tagId),
+				),
+			);
+		return c.json({ ok: true });
+	})
 	.delete(
 		"/projects/:projectId/conversations/:id",
 		requireRole("admin"),

--- a/apps/api/src/routes/tags.test.ts
+++ b/apps/api/src/routes/tags.test.ts
@@ -1,0 +1,182 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { db } from "@/lib/db";
+
+import { tags } from "./tags";
+
+vi.mock("@/auth", () => ({
+	createAuth: () => ({
+		api: {
+			getSession: async ({ headers }: { headers: Headers }) => {
+				const id = headers.get("x-test-user");
+				return id ? { user: { id } } : null;
+			},
+		},
+	}),
+}));
+
+vi.mock("@/lib/db", () => ({ db: vi.fn() }));
+
+const ENV = { vars: {}, DB: {} } as unknown as Parameters<
+	typeof tags.request
+>[2];
+
+interface State {
+	role?: "owner" | "admin" | "agent";
+	/** Result of the select chain (GET list, or the POST dedupe lookup). */
+	selectResult?: Record<string, unknown>[];
+}
+
+let insertSpy: ReturnType<typeof vi.fn>;
+let lastInsert: Record<string, unknown> | null;
+
+function mockDb(state: State) {
+	lastInsert = null;
+	insertSpy = vi.fn(() => ({
+		values: (data: Record<string, unknown>) => {
+			lastInsert = data;
+			return { returning: async () => [{ id: "tag_new", ...data }] };
+		},
+	}));
+	const selectChain: Record<string, unknown> = {
+		from: () => selectChain,
+		leftJoin: () => selectChain,
+		where: () => selectChain,
+		groupBy: () => selectChain,
+		orderBy: () => selectChain,
+		limit: () => selectChain,
+		// eslint-disable-next-line unicorn/no-thenable
+		then: <R>(onF: (v: unknown[]) => R) =>
+			Promise.resolve(state.selectResult ?? []).then(onF),
+	};
+	const fake = {
+		query: {
+			member: {
+				findFirst: async () => (state.role ? { role: state.role } : undefined),
+			},
+		},
+		select: () => selectChain,
+		insert: insertSpy,
+	};
+	vi.mocked(db).mockReturnValue(fake as unknown as ReturnType<typeof db>);
+}
+
+const json = { "content-type": "application/json" };
+const MEMBER = { "x-test-user": "u1", "x-workspace-id": "ws_1", ...json };
+
+function post(body: unknown, headers: Record<string, string> = MEMBER) {
+	return tags.request(
+		"/tags",
+		{ method: "POST", headers, body: JSON.stringify(body) },
+		ENV,
+	);
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("GET /tags", () => {
+	it("lists workspace tags with a conversation count", async () => {
+		mockDb({
+			role: "agent",
+			selectResult: [
+				{
+					id: "t1",
+					workspaceId: "ws_1",
+					name: "Billing",
+					color: "#6366f1",
+					count: 12,
+				},
+				{
+					id: "t2",
+					workspaceId: "ws_1",
+					name: "Bug",
+					color: "#ef4444",
+					count: 0,
+				},
+			],
+		});
+		const res = await tags.request(
+			"/tags",
+			{ method: "GET", headers: MEMBER },
+			ENV,
+		);
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as {
+			tags: { name: string; count: number }[];
+		};
+		expect(body.tags).toHaveLength(2);
+		expect(body.tags[0]).toMatchObject({ name: "Billing", count: 12 });
+	});
+
+	it("403s a non-member; 401s the signed-out", async () => {
+		mockDb({});
+		expect(
+			(await tags.request("/tags", { method: "GET", headers: MEMBER }, ENV))
+				.status,
+		).toBe(403);
+		mockDb({ role: "agent" });
+		expect(
+			(
+				await tags.request(
+					"/tags",
+					{ method: "GET", headers: { "x-workspace-id": "ws_1" } },
+					ENV,
+				)
+			).status,
+		).toBe(401);
+	});
+});
+
+describe("POST /tags", () => {
+	it("creates a new tag, auto-assigning a palette color when none is given", async () => {
+		mockDb({ role: "agent", selectResult: [] }); // no existing match
+		const res = await post({ name: "Refunds" });
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as {
+			tag: { name: string; color: string };
+			created: boolean;
+		};
+		expect(body.created).toBe(true);
+		expect(body.tag.name).toBe("Refunds");
+		expect(body.tag.color).toMatch(/^#[0-9a-f]{6}$/i); // assigned from palette
+		expect(insertSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it("honors a provided hex color", async () => {
+		mockDb({ role: "agent", selectResult: [] });
+		await post({ name: "VIP", color: "#123abc" });
+		expect(lastInsert).toMatchObject({ name: "VIP", color: "#123abc" });
+	});
+
+	it("dedupes case-insensitively: returns the existing tag, no new row", async () => {
+		mockDb({
+			role: "agent",
+			selectResult: [
+				{ id: "t1", workspaceId: "ws_1", name: "Billing", color: "#6366f1" },
+			],
+		});
+		const res = await post({ name: "BILLING" });
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as {
+			tag: { id: string };
+			created: boolean;
+		};
+		expect(body.tag.id).toBe("t1");
+		expect(body.created).toBe(false);
+		expect(insertSpy).not.toHaveBeenCalled();
+	});
+
+	it("400s an empty name and an over-length name; never inserts", async () => {
+		mockDb({ role: "agent", selectResult: [] });
+		expect((await post({ name: "   " })).status).toBe(400);
+		expect((await post({ name: "x".repeat(41) })).status).toBe(400);
+		expect(insertSpy).not.toHaveBeenCalled();
+	});
+
+	it("403s a non-member; never inserts", async () => {
+		mockDb({ selectResult: [] });
+		const res = await post({ name: "Nope" });
+		expect(res.status).toBe(403);
+		expect(insertSpy).not.toHaveBeenCalled();
+	});
+});

--- a/apps/api/src/routes/tags.ts
+++ b/apps/api/src/routes/tags.ts
@@ -1,0 +1,55 @@
+import { zValidator } from "@hono/zod-validator";
+import { Hono } from "hono";
+import { z } from "zod";
+
+import { db } from "@/lib/db";
+import { TAG_NAME_MAX, findOrCreateTag } from "@/lib/tags";
+import { requireSession, requireWorkspace } from "@/middleware/session";
+
+import { conversationTag, count, eq, sql, tag as tagTable } from "@llmchat/db";
+
+import type { AppContext } from "@/env";
+
+const createInput = z.object({
+	name: z.string().trim().min(1).max(TAG_NAME_MAX),
+	color: z.string().max(32).optional(),
+});
+
+// Any workspace member can manage tags (same posture as the reply route — no
+// requireRole). Strictly workspace-scoped via requireWorkspace + the x-workspace
+// header, so a tag from another workspace is never visible or mutable here.
+export const tags = new Hono<AppContext>()
+	.use("*", requireSession, requireWorkspace)
+	.get("/tags", async (c) => {
+		const workspaceId = c.get("workspaceId");
+		// Tags for this workspace, each with how many conversations carry it — one
+		// grouped LEFT JOIN aggregate (so a brand-new tag reports 0, not missing).
+		const rows = await db(c.env)
+			.select({
+				id: tagTable.id,
+				workspaceId: tagTable.workspaceId,
+				name: tagTable.name,
+				color: tagTable.color,
+				createdAt: tagTable.createdAt,
+				count: count(conversationTag.id),
+			})
+			.from(tagTable)
+			.leftJoin(conversationTag, eq(conversationTag.tagId, tagTable.id))
+			.where(eq(tagTable.workspaceId, workspaceId))
+			.groupBy(tagTable.id)
+			.orderBy(sql`lower(${tagTable.name})`);
+		return c.json({ tags: rows });
+	})
+	.post("/tags", zValidator("json", createInput), async (c) => {
+		const workspaceId = c.get("workspaceId");
+		const { name, color } = c.req.valid("json");
+		// Dedupe is case-insensitive: a matching tag (any casing) is returned as-is
+		// rather than creating a second row.
+		const { tag, created } = await findOrCreateTag(
+			c.env,
+			workspaceId,
+			name,
+			color,
+		);
+		return c.json({ tag, created });
+	});

--- a/apps/dashboard/src/app/inbox/_components/ConversationList.tsx
+++ b/apps/dashboard/src/app/inbox/_components/ConversationList.tsx
@@ -7,6 +7,7 @@ import { cn } from "@/lib/utils";
 
 import { initials, pluralize, timeAgo } from "./format";
 import { Highlighted } from "./highlight";
+import { TagChip } from "./TagChip";
 import type { Conversation, SearchMatch } from "./types";
 
 /** Short label shown before a name/email match so the agent knows where the term
@@ -100,12 +101,15 @@ function ConversationRow({
 							"No messages yet"}
 					</p>
 				)}
-				<div className="mt-0.5 flex items-center gap-1.5">
+				<div className="mt-0.5 flex flex-wrap items-center gap-1.5">
 					{escalated && (
 						<Badge variant="warning" className="h-4 px-1.5 text-[10px]">
 							Escalated
 						</Badge>
 					)}
+					{conversation.tags?.map((t) => (
+						<TagChip key={t.id} tag={t} />
+					))}
 					<span className="text-[11px] text-muted-foreground/70">
 						{pluralize(conversation.messageCount, "message")}
 					</span>

--- a/apps/dashboard/src/app/inbox/_components/InboxToolbar.test.tsx
+++ b/apps/dashboard/src/app/inbox/_components/InboxToolbar.test.tsx
@@ -13,16 +13,20 @@ beforeAll(() => {
 function setup(props: Partial<React.ComponentProps<typeof InboxToolbar>> = {}) {
 	const onSearch = vi.fn();
 	const onShowArchivedChange = vi.fn();
+	const onTagIdsChange = vi.fn();
 	render(
 		<InboxToolbar
 			search=""
 			onSearch={onSearch}
 			showArchived={false}
 			onShowArchivedChange={onShowArchivedChange}
+			tags={[]}
+			tagIds={[]}
+			onTagIdsChange={onTagIdsChange}
 			{...props}
 		/>,
 	);
-	return { onSearch, onShowArchivedChange };
+	return { onSearch, onShowArchivedChange, onTagIdsChange };
 }
 
 describe("InboxToolbar", () => {
@@ -34,24 +38,20 @@ describe("InboxToolbar", () => {
 	});
 
 	it("reflects the active status in the filter control", () => {
+		const base = {
+			search: "",
+			onSearch: vi.fn(),
+			onShowArchivedChange: vi.fn(),
+			tags: [],
+			tagIds: [],
+			onTagIdsChange: vi.fn(),
+		};
 		const { rerender } = render(
-			<InboxToolbar
-				search=""
-				onSearch={vi.fn()}
-				showArchived={false}
-				onShowArchivedChange={vi.fn()}
-			/>,
+			<InboxToolbar {...base} showArchived={false} />,
 		);
 		expect(screen.getByText("All conversations")).toBeInTheDocument();
 
-		rerender(
-			<InboxToolbar
-				search=""
-				onSearch={vi.fn()}
-				showArchived
-				onShowArchivedChange={vi.fn()}
-			/>,
-		);
+		rerender(<InboxToolbar {...base} showArchived />);
 		expect(screen.getByText("Archived")).toBeInTheDocument();
 	});
 
@@ -63,8 +63,20 @@ describe("InboxToolbar", () => {
 		expect(onShowArchivedChange).toHaveBeenCalledWith(true);
 	});
 
-	it("marks the not-yet-available Filters control as disabled", () => {
-		setup();
-		expect(screen.getByRole("button", { name: /filters/i })).toBeDisabled();
+	it("disables the Tags filter when the workspace has no tags", () => {
+		setup({ tags: [] });
+		expect(screen.getByRole("button", { name: /tags/i })).toBeDisabled();
+	});
+
+	it("opens the tag filter and reports a toggled tag id upward", async () => {
+		const user = userEvent.setup();
+		const { onTagIdsChange } = setup({
+			tags: [{ id: "t1", name: "Billing", color: "#6366f1", count: 3 }],
+		});
+		const btn = screen.getByRole("button", { name: /tags/i });
+		expect(btn).not.toBeDisabled();
+		await user.click(btn);
+		await user.click(screen.getByRole("option", { name: /Billing/ }));
+		expect(onTagIdsChange).toHaveBeenCalledWith(["t1"]);
 	});
 });

--- a/apps/dashboard/src/app/inbox/_components/InboxToolbar.tsx
+++ b/apps/dashboard/src/app/inbox/_components/InboxToolbar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Search, SlidersHorizontal } from "lucide-react";
+import { Search } from "lucide-react";
 
 import { Input } from "@/components/ui/input";
 import {
@@ -11,25 +11,36 @@ import {
 	SelectValue,
 } from "@/components/ui/select";
 
+import { TagFilter } from "./TagFilter";
+import type { Tag } from "./types";
+
 export interface InboxToolbarProps {
 	search: string;
 	onSearch: (value: string) => void;
 	/** Active vs archived view — the only real conversation filter we have. */
 	showArchived: boolean;
 	onShowArchivedChange: (archived: boolean) => void;
+	/** Workspace tags for the toolbar tag filter. */
+	tags: Tag[];
+	/** Selected tag ids (OR filter). */
+	tagIds: string[];
+	onTagIdsChange: (ids: string[]) => void;
 }
 
 /**
- * Top toolbar spanning the inbox panes: status filter + search are real and
- * drive the list. "Filters" and "Sort" are clearly-disabled placeholders — there
- * is no filter/sort backend yet, and the list is always ordered latest-first
- * (so the "Latest" label is truthful, not a fabricated control).
+ * Top toolbar spanning the inbox panes: status filter + search + a real tag
+ * filter (in the slot the disabled "Filters" placeholder used to occupy). The
+ * list is always ordered latest-first, so the "Latest" label is truthful. PR2
+ * will unify all of these into one filter surface.
  */
 export function InboxToolbar({
 	search,
 	onSearch,
 	showArchived,
 	onShowArchivedChange,
+	tags,
+	tagIds,
+	onTagIdsChange,
 }: InboxToolbarProps) {
 	return (
 		<div className="flex items-center gap-2 border-b px-4 py-2.5">
@@ -60,17 +71,7 @@ export function InboxToolbar({
 				/>
 			</div>
 
-			{/* Placeholders: no filter/sort backend yet. Disabled so they read as
-			    not-yet-available rather than fabricating behavior. */}
-			<button
-				type="button"
-				disabled
-				title="Advanced filters aren't available yet"
-				className="inline-flex h-9 shrink-0 cursor-not-allowed items-center gap-1.5 rounded-md border px-3 text-sm text-muted-foreground opacity-60"
-			>
-				<SlidersHorizontal className="size-4" />
-				Filters
-			</button>
+			<TagFilter tags={tags} selectedIds={tagIds} onChange={onTagIdsChange} />
 			<span className="hidden shrink-0 px-1 text-sm text-muted-foreground sm:inline">
 				Sort: <span className="font-medium text-foreground">Latest</span>
 			</span>

--- a/apps/dashboard/src/app/inbox/_components/TagChip.tsx
+++ b/apps/dashboard/src/app/inbox/_components/TagChip.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { X } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+import type { Tag } from "./types";
+
+const FALLBACK = "#6b7280"; // gray-500 when a tag has no color
+
+/** Tint a tag's color into a soft chip (subtle bg/border, readable text) that
+ * reads in both themes — we never paint the raw saturated color as a fill. */
+function chipStyle(color: string | null): React.CSSProperties {
+	const c = color ?? FALLBACK;
+	return {
+		// 18% bg / 38% border over the theme surface; text stays the full color and
+		// is lightened by the dark-mode class below.
+		backgroundColor: `${c}2e`,
+		borderColor: `${c}61`,
+		color: c,
+	};
+}
+
+export function TagChip({
+	tag,
+	onRemove,
+	className,
+}: {
+	tag: Pick<Tag, "id" | "name" | "color">;
+	/** When provided, renders a trailing "×" that calls this instead of nothing. */
+	onRemove?: (tagId: string) => void;
+	className?: string;
+}) {
+	return (
+		<span
+			style={chipStyle(tag.color)}
+			className={cn(
+				"inline-flex max-w-[10rem] items-center gap-1 rounded-full border px-1.5 py-0 text-[10px] font-medium leading-5 [color-scheme:light] dark:brightness-150",
+				className,
+			)}
+		>
+			<span className="truncate">{tag.name}</span>
+			{onRemove && (
+				<button
+					type="button"
+					onClick={(e) => {
+						e.stopPropagation();
+						onRemove(tag.id);
+					}}
+					aria-label={`Remove tag ${tag.name}`}
+					className="-mr-0.5 grid size-3.5 shrink-0 place-items-center rounded-full hover:bg-black/10 dark:hover:bg-white/15"
+				>
+					<X className="size-2.5" />
+				</button>
+			)}
+		</span>
+	);
+}

--- a/apps/dashboard/src/app/inbox/_components/TagFilter.tsx
+++ b/apps/dashboard/src/app/inbox/_components/TagFilter.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { Check, SlidersHorizontal } from "lucide-react";
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+	Command,
+	CommandEmpty,
+	CommandGroup,
+	CommandInput,
+	CommandItem,
+	CommandList,
+} from "@/components/ui/command";
+import {
+	Popover,
+	PopoverContent,
+	PopoverTrigger,
+} from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
+
+import type { Tag } from "./types";
+
+export interface TagFilterProps {
+	tags: Tag[];
+	/** Currently-selected tag ids (OR filter). */
+	selectedIds: string[];
+	onChange: (ids: string[]) => void;
+}
+
+/**
+ * Multi-select tag filter for the toolbar (OR semantics — show conversations
+ * with ANY selected tag). Lives where the disabled "Filters" placeholder was;
+ * PR2 will unify all inbox filters, so this stays intentionally lightweight.
+ */
+export function TagFilter({ tags, selectedIds, onChange }: TagFilterProps) {
+	const [open, setOpen] = useState(false);
+	const selected = new Set(selectedIds);
+	const count = selectedIds.length;
+
+	function toggle(id: string) {
+		const next = new Set(selected);
+		if (next.has(id)) next.delete(id);
+		else next.add(id);
+		onChange([...next]);
+	}
+
+	return (
+		<Popover open={open} onOpenChange={setOpen}>
+			<PopoverTrigger asChild>
+				<Button
+					type="button"
+					variant="outline"
+					size="sm"
+					className={cn(
+						"h-9 shrink-0 gap-1.5",
+						count > 0 && "border-primary/40 text-foreground",
+					)}
+					// Disabled only when there are no tags to filter by.
+					disabled={tags.length === 0}
+				>
+					<SlidersHorizontal className="size-4" />
+					Tags
+					{count > 0 && (
+						<span className="ml-0.5 grid min-w-4 place-items-center rounded-full bg-primary px-1 text-[10px] font-semibold text-primary-foreground">
+							{count}
+						</span>
+					)}
+				</Button>
+			</PopoverTrigger>
+			<PopoverContent className="w-56 p-0" align="end">
+				<Command>
+					<CommandInput placeholder="Filter by tag…" />
+					<CommandList>
+						<CommandEmpty>No tags yet.</CommandEmpty>
+						<CommandGroup>
+							{tags.map((tag) => (
+								<CommandItem
+									key={tag.id}
+									value={tag.name}
+									onSelect={() => toggle(tag.id)}
+									className="gap-2"
+								>
+									<span
+										className="size-2.5 shrink-0 rounded-full"
+										style={{ backgroundColor: tag.color ?? "#6b7280" }}
+									/>
+									<span className="flex-1 truncate">{tag.name}</span>
+									{typeof tag.count === "number" && (
+										<span className="text-[10px] tabular-nums text-muted-foreground/70">
+											{tag.count}
+										</span>
+									)}
+									<Check
+										className={cn(
+											"size-3.5 shrink-0",
+											selected.has(tag.id) ? "opacity-100" : "opacity-0",
+										)}
+									/>
+								</CommandItem>
+							))}
+						</CommandGroup>
+					</CommandList>
+				</Command>
+				{count > 0 && (
+					<div className="border-t p-1">
+						<Button
+							type="button"
+							variant="ghost"
+							size="sm"
+							className="w-full justify-center text-xs text-muted-foreground"
+							onClick={() => onChange([])}
+						>
+							Clear {count} filter{count > 1 ? "s" : ""}
+						</Button>
+					</div>
+				)}
+			</PopoverContent>
+		</Popover>
+	);
+}

--- a/apps/dashboard/src/app/inbox/_components/TagPicker.test.tsx
+++ b/apps/dashboard/src/app/inbox/_components/TagPicker.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+import { TagPicker } from "./TagPicker";
+import type { Tag } from "./types";
+
+beforeAll(() => {
+	// Radix Popover/Command use these jsdom-unimplemented APIs.
+	Element.prototype.scrollIntoView = vi.fn();
+	Element.prototype.hasPointerCapture ??= () => false;
+});
+
+const TAGS: Tag[] = [
+	{ id: "t1", name: "Billing", color: "#6366f1" },
+	{ id: "t2", name: "VIP", color: "#ef4444" },
+];
+
+function setup(props: Partial<React.ComponentProps<typeof TagPicker>> = {}) {
+	const onToggle = vi.fn();
+	const onCreate = vi.fn();
+	render(
+		<TagPicker
+			tags={TAGS}
+			attachedIds={[]}
+			onToggle={onToggle}
+			onCreate={onCreate}
+			{...props}
+		/>,
+	);
+	return { onToggle, onCreate };
+}
+
+describe("TagPicker", () => {
+	it("toggles an existing tag (reports the tag upward)", async () => {
+		const user = userEvent.setup();
+		const { onToggle } = setup();
+		await user.click(screen.getByRole("button", { name: /^tag$/i }));
+		await user.click(screen.getByRole("option", { name: /Billing/ }));
+		expect(onToggle).toHaveBeenCalledWith(TAGS[0]);
+	});
+
+	it("offers a Create row for a new name and calls onCreate with it", async () => {
+		const user = userEvent.setup();
+		const { onCreate } = setup();
+		await user.click(screen.getByRole("button", { name: /^tag$/i }));
+		await user.type(
+			screen.getByPlaceholderText(/search or create/i),
+			"Refunds",
+		);
+		const createRow = await screen.findByRole("option", { name: /Create/ });
+		await user.click(createRow);
+		expect(onCreate).toHaveBeenCalledWith("Refunds");
+	});
+
+	it("does NOT offer Create when the typed name already exists (case-insensitive)", async () => {
+		const user = userEvent.setup();
+		setup();
+		await user.click(screen.getByRole("button", { name: /^tag$/i }));
+		await user.type(
+			screen.getByPlaceholderText(/search or create/i),
+			"billing",
+		);
+		expect(screen.queryByRole("option", { name: /Create/ })).toBeNull();
+		// The existing tag is still shown to toggle.
+		expect(screen.getByRole("option", { name: /Billing/ })).toBeInTheDocument();
+	});
+
+	it("shows a check on already-attached tags", async () => {
+		const user = userEvent.setup();
+		setup({ attachedIds: ["t1"] });
+		await user.click(screen.getByRole("button", { name: /^tag$/i }));
+		const billing = screen.getByRole("option", { name: /Billing/ });
+		// The check icon (opacity-100) marks it attached vs the unattached VIP.
+		expect(billing.querySelector(".opacity-100")).not.toBeNull();
+		const vip = screen.getByRole("option", { name: /VIP/ });
+		expect(vip.querySelector(".opacity-100")).toBeNull();
+	});
+});

--- a/apps/dashboard/src/app/inbox/_components/TagPicker.tsx
+++ b/apps/dashboard/src/app/inbox/_components/TagPicker.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { Check, Plus, Tag as TagIcon } from "lucide-react";
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+	Command,
+	CommandEmpty,
+	CommandGroup,
+	CommandInput,
+	CommandItem,
+	CommandList,
+} from "@/components/ui/command";
+import {
+	Popover,
+	PopoverContent,
+	PopoverTrigger,
+} from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
+
+import type { Tag } from "./types";
+
+export interface TagPickerProps {
+	/** All workspace tags to search/toggle. */
+	tags: Tag[];
+	/** Ids currently attached to the open conversation. */
+	attachedIds: string[];
+	/** Toggle an existing tag on/off (optimistic in the caller). */
+	onToggle: (tag: Tag) => void;
+	/** Create-and-attach a brand-new tag (awaited in the caller). */
+	onCreate: (name: string) => void;
+	/** True while a create is in flight. */
+	creating?: boolean;
+}
+
+/**
+ * Tag combobox for the open conversation: search existing workspace tags, toggle
+ * them on/off, or create a new one inline when nothing matches the query. Purely
+ * presentational — attach/detach/create mutations live in the inbox page.
+ */
+export function TagPicker({
+	tags,
+	attachedIds,
+	onToggle,
+	onCreate,
+	creating,
+}: TagPickerProps) {
+	const [open, setOpen] = useState(false);
+	const [query, setQuery] = useState("");
+	const attached = new Set(attachedIds);
+
+	const trimmed = query.trim();
+	// Offer "Create" only when the typed name doesn't already exist (case-insensitive).
+	const exists = tags.some(
+		(t) => t.name.toLowerCase() === trimmed.toLowerCase(),
+	);
+	const canCreate = trimmed.length > 0 && !exists;
+
+	return (
+		<Popover open={open} onOpenChange={setOpen}>
+			<PopoverTrigger asChild>
+				<Button
+					type="button"
+					variant="outline"
+					size="sm"
+					className="h-6 gap-1 px-2 text-[11px] text-muted-foreground"
+				>
+					<TagIcon className="size-3" />
+					Tag
+				</Button>
+			</PopoverTrigger>
+			<PopoverContent className="w-60 p-0" align="start">
+				<Command
+					// Let our own substring logic drive what's shown (we add a Create row).
+					filter={(value, search) =>
+						value.toLowerCase().includes(search.toLowerCase()) ? 1 : 0
+					}
+				>
+					<CommandInput
+						placeholder="Search or create…"
+						value={query}
+						onValueChange={setQuery}
+					/>
+					<CommandList>
+						{!canCreate && <CommandEmpty>No tags found.</CommandEmpty>}
+						<CommandGroup>
+							{tags.map((tag) => {
+								const on = attached.has(tag.id);
+								return (
+									<CommandItem
+										key={tag.id}
+										value={tag.name}
+										onSelect={() => onToggle(tag)}
+										className="gap-2"
+									>
+										<span
+											className="size-2.5 shrink-0 rounded-full"
+											style={{ backgroundColor: tag.color ?? "#6b7280" }}
+										/>
+										<span className="flex-1 truncate">{tag.name}</span>
+										<Check
+											className={cn(
+												"size-3.5 shrink-0",
+												on ? "opacity-100" : "opacity-0",
+											)}
+										/>
+									</CommandItem>
+								);
+							})}
+							{canCreate && (
+								<CommandItem
+									value={`__create__${trimmed}`}
+									onSelect={() => {
+										onCreate(trimmed);
+										setQuery("");
+									}}
+									disabled={creating}
+									className="gap-2 text-muted-foreground"
+								>
+									<Plus className="size-3.5 shrink-0" />
+									<span className="truncate">
+										Create “<span className="text-foreground">{trimmed}</span>”
+									</span>
+								</CommandItem>
+							)}
+						</CommandGroup>
+					</CommandList>
+				</Command>
+			</PopoverContent>
+		</Popover>
+	);
+}

--- a/apps/dashboard/src/app/inbox/_components/conversation-list.test.ts
+++ b/apps/dashboard/src/app/inbox/_components/conversation-list.test.ts
@@ -1,14 +1,18 @@
 import { describe, expect, it } from "vitest";
 
 import {
+	addTagToConversation,
 	dropConversationFromCache,
 	flattenPages,
 	mergeConversationPages,
+	removeTagFromConversation,
 	setConversationRead,
 	type ConversationPage,
 } from "./conversation-list";
 
-import type { Conversation } from "./types";
+import type { Conversation, Tag } from "./types";
+
+const TAG: Tag = { id: "t1", name: "Billing", color: "#6366f1" };
 
 function conv(overrides: Partial<Conversation> & { id: string }): Conversation {
 	return {
@@ -129,6 +133,41 @@ describe("setConversationRead (shape-aware)", () => {
 		expect(nextInf.pages[0].conversations[0]).toMatchObject({
 			id: "a",
 			unread: false,
+		});
+	});
+});
+
+describe("addTagToConversation / removeTagFromConversation (shape-aware)", () => {
+	it("attaches a tag to the right conversation across both cache shapes", () => {
+		const head = page([conv({ id: "a" }), conv({ id: "b" })]);
+		const nextHead = addTagToConversation(head, "a", TAG) as ConversationPage;
+		expect(nextHead.conversations[0]!.tags).toEqual([TAG]);
+		expect(nextHead.conversations[1]!.tags ?? []).toEqual([]);
+
+		const inf = infinite([page([conv({ id: "a" })])]);
+		const nextInf = addTagToConversation(inf, "a", TAG) as ReturnType<
+			typeof infinite
+		>;
+		expect(nextInf.pages[0].conversations[0]!.tags).toEqual([TAG]);
+	});
+
+	it("is idempotent — attaching an already-present tag is a no-op", () => {
+		const head = page([conv({ id: "a", tags: [TAG] })]);
+		const next = addTagToConversation(head, "a", TAG) as ConversationPage;
+		expect(next.conversations[0]!.tags).toEqual([TAG]);
+	});
+
+	it("removes a tag by id, leaving the others", () => {
+		const other: Tag = { id: "t2", name: "VIP", color: null };
+		const head = page([conv({ id: "a", tags: [TAG, other] })]);
+		const next = removeTagFromConversation(head, "a", "t1") as ConversationPage;
+		expect(next.conversations[0]!.tags).toEqual([other]);
+	});
+
+	it("passes unknown shapes / undefined through unchanged", () => {
+		expect(addTagToConversation(undefined, "a", TAG)).toBeUndefined();
+		expect(removeTagFromConversation({ nope: 1 }, "a", "t1")).toEqual({
+			nope: 1,
 		});
 	});
 });

--- a/apps/dashboard/src/app/inbox/_components/conversation-list.ts
+++ b/apps/dashboard/src/app/inbox/_components/conversation-list.ts
@@ -1,4 +1,4 @@
-import type { Conversation } from "./types";
+import type { Conversation, Tag } from "./types";
 
 /** A single list page from the API. */
 export interface ConversationPage {
@@ -93,5 +93,37 @@ export function dropConversationFromCache(prev: unknown, id: string): unknown {
 export function setConversationRead(prev: unknown, id: string): unknown {
 	return mapConversationsInCache(prev, (list) =>
 		list.map((c) => (c.id === id ? { ...c, unread: false } : c)),
+	);
+}
+
+/** Optimistic updater: attach a tag to a conversation across head + infinite
+ * caches. Idempotent (skips if already present) and immutable. */
+export function addTagToConversation(
+	prev: unknown,
+	id: string,
+	tag: Tag,
+): unknown {
+	return mapConversationsInCache(prev, (list) =>
+		list.map((c) => {
+			if (c.id !== id) return c;
+			const tags = c.tags ?? [];
+			if (tags.some((t) => t.id === tag.id)) return c;
+			return { ...c, tags: [...tags, tag] };
+		}),
+	);
+}
+
+/** Optimistic updater: detach a tag from a conversation across both caches. */
+export function removeTagFromConversation(
+	prev: unknown,
+	id: string,
+	tagId: string,
+): unknown {
+	return mapConversationsInCache(prev, (list) =>
+		list.map((c) =>
+			c.id === id
+				? { ...c, tags: (c.tags ?? []).filter((t) => t.id !== tagId) }
+				: c,
+		),
 	);
 }

--- a/apps/dashboard/src/app/inbox/_components/tags-poll.test.tsx
+++ b/apps/dashboard/src/app/inbox/_components/tags-poll.test.tsx
@@ -1,0 +1,162 @@
+import {
+	QueryClient,
+	QueryClientProvider,
+	useQuery,
+} from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { describe, expect, it } from "vitest";
+
+import { useOptimisticMutation } from "@/lib/optimistic";
+
+import {
+	addTagToConversation,
+	mergeConversationPages,
+	type ConversationPage,
+} from "./conversation-list";
+import type { Conversation, Tag } from "./types";
+
+const TAG: Tag = { id: "t1", name: "Billing", color: "#6366f1" };
+
+function conv(tags: Tag[]): Conversation {
+	return {
+		id: "c1",
+		clientId: "c",
+		name: "Bob",
+		email: null,
+		ipAddress: null,
+		userAgent: null,
+		messageCount: 1,
+		escalatedAt: null,
+		archivedAt: null,
+		createdAt: "2026-06-16T05:00:00.000Z",
+		updatedAt: "2026-06-16T05:00:00.000Z",
+		csatRating: null,
+		tags,
+	};
+}
+
+function page(tags: Tag[]): ConversationPage {
+	return { conversations: [conv(tags)], nextCursor: null };
+}
+
+// The head (5s poll) and list query keys the inbox uses — both share the
+// `["conversations", "p1"]` prefix the optimistic mutation writes to.
+const HEAD_KEY = ["conversations", "p1", "head", "", false, ""];
+const LIST_KEY = ["conversations", "p1", "list", "", false, ""];
+
+function wrapper(client: QueryClient) {
+	return ({ children }: { children: ReactNode }) =>
+		createElement(QueryClientProvider, { client }, children);
+}
+
+/**
+ * Reproduces the inbox's tag wiring with the REAL hooks: a head query (the poll)
+ * + a list query, the shared optimistic mutation (attach), and the render-time
+ * merge. `server` is the source both queries fetch from — the attach mutationFn
+ * persists the tag into it (modelling the POST succeeding server-side) so a
+ * later poll/invalidation sees the tag, exactly like production.
+ */
+function useInboxTagSlice(server: {
+	head: ConversationPage;
+	list: ConversationPage;
+}) {
+	const head = useQuery({
+		queryKey: HEAD_KEY,
+		queryFn: async () => server.head,
+	});
+	const list = useQuery({
+		queryKey: LIST_KEY,
+		queryFn: async () => server.list,
+	});
+	const attach = useOptimisticMutation<{ id: string; tag: Tag }>({
+		queryKey: ["conversations", "p1"],
+		invalidateKey: HEAD_KEY,
+		// The exact updater the inbox page uses for an optimistic attach.
+		apply: (prev, vars) => addTagToConversation(prev, vars.id, vars.tag),
+		mutationFn: async () => {
+			// The attach POST persists the tag, so any subsequent fetch returns it
+			// (identical serialization to the list — a Tag[] on the conversation).
+			server.head = page([TAG]);
+			server.list = page([TAG]);
+			return { ok: true };
+		},
+	});
+	const merged = mergeConversationPages([
+		head.data?.conversations,
+		list.data?.conversations,
+	]);
+	return { head, attach, merged };
+}
+
+describe("optimistic tag attach survives the head/poll refetch", () => {
+	it("keeps the chip on the row AND the open-thread conversation after a poll", async () => {
+		const client = new QueryClient({
+			defaultOptions: {
+				queries: { retry: false },
+				mutations: { retry: false },
+			},
+		});
+		// Server starts with the conversation untagged.
+		const server = { head: page([]), list: page([]) };
+
+		const { result } = renderHook(() => useInboxTagSlice(server), {
+			wrapper: wrapper(client),
+		});
+
+		// Both queries load: the conversation has no tags yet.
+		await waitFor(() => expect(result.current.merged).toHaveLength(1));
+		expect(result.current.merged[0]!.tags).toEqual([]);
+
+		// Attach a tag optimistically.
+		act(() => result.current.attach.mutate({ id: "c1", tag: TAG }));
+
+		// The chip appears immediately (before any refetch).
+		await waitFor(() => expect(result.current.merged[0]!.tags).toEqual([TAG]));
+
+		// Let the mutation settle — onSettled invalidates the head, triggering a
+		// refetch (the same path a 5s poll takes). The server now returns the tag.
+		await waitFor(() => expect(result.current.attach.isSuccess).toBe(true));
+
+		// Explicit poll refetch on top, to be unambiguous.
+		await act(async () => {
+			await result.current.head.refetch();
+		});
+
+		// The head poll returned the tag (identical serialization), so the chip
+		// PERSISTS — the poll never blanks the optimistically-added tag.
+		expect(result.current.head.data?.conversations[0]!.tags).toEqual([TAG]);
+
+		// `merged` is what the LIST rows render from, and `merged.find(id)` is the
+		// `selectedConv` the open THREAD reads its chips from — both still carry it.
+		const row = result.current.merged[0]!;
+		const selectedConv = result.current.merged.find((c) => c.id === "c1")!;
+		expect(row.tags).toEqual([TAG]);
+		expect(selectedConv.tags).toEqual([TAG]);
+	});
+
+	it("a poll that returns the tag does not produce a duplicate chip", async () => {
+		const client = new QueryClient({
+			defaultOptions: {
+				queries: { retry: false },
+				mutations: { retry: false },
+			},
+		});
+		const server = { head: page([]), list: page([]) };
+		const { result } = renderHook(() => useInboxTagSlice(server), {
+			wrapper: wrapper(client),
+		});
+		await waitFor(() => expect(result.current.merged).toHaveLength(1));
+
+		act(() => result.current.attach.mutate({ id: "c1", tag: TAG }));
+		await waitFor(() => expect(result.current.attach.isSuccess).toBe(true));
+		await act(async () => {
+			await result.current.head.refetch();
+		});
+
+		// Optimistic write + server poll both carry the tag, but the conversation
+		// shows it ONCE (merge dedupes the row; the tag isn't double-applied).
+		expect(result.current.merged).toHaveLength(1);
+		expect(result.current.merged[0]!.tags).toEqual([TAG]);
+	});
+});

--- a/apps/dashboard/src/app/inbox/_components/types.ts
+++ b/apps/dashboard/src/app/inbox/_components/types.ts
@@ -1,3 +1,11 @@
+/** A workspace label. `count` is present only on the /tags list aggregate. */
+export interface Tag {
+	id: string;
+	name: string;
+	color: string | null;
+	count?: number;
+}
+
 export interface Conversation {
 	id: string;
 	clientId: string;
@@ -10,6 +18,8 @@ export interface Conversation {
 	archivedAt: string | null;
 	createdAt: string;
 	updatedAt: string;
+	/** Tags attached to this conversation (added by the list API; [] when none). */
+	tags?: Tag[];
 	/** End-of-conversation CSAT (1–5 stars); null when the visitor didn't rate.
 	 * Distinct from per-message thumbs (Message.rating). */
 	csatRating: number | null;

--- a/apps/dashboard/src/app/inbox/page.tsx
+++ b/apps/dashboard/src/app/inbox/page.tsx
@@ -2,6 +2,7 @@
 
 import {
 	useInfiniteQuery,
+	useMutation,
 	useQuery,
 	useQueryClient,
 } from "@tanstack/react-query";
@@ -22,9 +23,11 @@ import { track, ANALYTICS_EVENTS } from "@/lib/analytics";
 import { ConversationList } from "./_components/ConversationList";
 import { ConversationListSkeleton } from "./_components/ConversationListSkeleton";
 import {
+	addTagToConversation,
 	dropConversationFromCache,
 	flattenPages,
 	mergeConversationPages,
+	removeTagFromConversation,
 	setConversationRead,
 	type ConversationPage,
 } from "./_components/conversation-list";
@@ -39,8 +42,10 @@ import { MessageThread } from "./_components/MessageThread";
 import { appendOptimisticReply } from "./_components/optimistic-updaters";
 import { ProjectSwitcher } from "./_components/ProjectSwitcher";
 import { ReplyComposer } from "./_components/ReplyComposer";
+import { TagChip } from "./_components/TagChip";
+import { TagPicker } from "./_components/TagPicker";
 import { useThreadMessages } from "./_components/useThreadMessages";
-import type { ConversationStats } from "./_components/types";
+import type { ConversationStats, Tag } from "./_components/types";
 import type { ProjectOption } from "./_components/ProjectSwitcher";
 
 const PAGE_SIZE = 30;
@@ -58,6 +63,7 @@ export default function InboxPage() {
 	const [reply, setReply] = useState("");
 	const [search, setSearch] = useState("");
 	const [showArchived, setShowArchived] = useState(false);
+	const [tagIds, setTagIds] = useState<string[]>([]);
 	// Contact-details sheet (mobile/tablet); on desktop details are a permanent aside.
 	const [detailsOpen, setDetailsOpen] = useState(false);
 
@@ -69,6 +75,15 @@ export default function InboxPage() {
 				workspaceId: workspaceId!,
 			}),
 	});
+
+	// Workspace tags drive the toolbar filter + the per-conversation picker.
+	const tagsQuery = useQuery({
+		queryKey: ["tags", workspaceId],
+		enabled: !!workspaceId,
+		queryFn: () =>
+			api<{ tags: Tag[] }>("/api/tags", { workspaceId: workspaceId! }),
+	});
+	const allTags = tagsQuery.data?.tags ?? [];
 
 	// Keep the selected project valid for the current workspace; a stale id
 	// (e.g. after a workspace switch) falls back to the first project.
@@ -92,15 +107,18 @@ export default function InboxPage() {
 
 	// Build the list query string for a given cursor. Search + archived go to the
 	// server (pre-resolved before LIMIT), so they compose with keyset paging.
+	// Stable joined key for the tag filter so it slots into query keys + params.
+	const tagFilterKey = tagIds.join(",");
 	const listParams = useCallback(
 		(cursor?: string) => {
 			const params = new URLSearchParams({ limit: String(PAGE_SIZE) });
 			if (debouncedSearch) params.set("search", debouncedSearch);
 			if (showArchived) params.set("archived", "true");
+			if (tagFilterKey) params.set("tagIds", tagFilterKey);
 			if (cursor) params.set("cursor", cursor);
 			return params.toString();
 		},
-		[debouncedSearch, showArchived],
+		[debouncedSearch, showArchived, tagFilterKey],
 	);
 
 	// The paginated list: keyset cursor, NO polling (a background refetch of an
@@ -113,6 +131,7 @@ export default function InboxPage() {
 			"list",
 			debouncedSearch,
 			showArchived,
+			tagFilterKey,
 		],
 		enabled: !!projectId && !!workspaceId,
 		initialPageParam: undefined as string | undefined,
@@ -134,6 +153,7 @@ export default function InboxPage() {
 			"head",
 			debouncedSearch,
 			showArchived,
+			tagFilterKey,
 		],
 		enabled: !!projectId && !!workspaceId,
 		refetchInterval: 5_000,
@@ -192,6 +212,76 @@ export default function InboxPage() {
 		projectId && workspaceId
 			? { projectId, projectName, workspaceId }
 			: undefined;
+
+	// Tags for the open conversation come from the LIST cache row (the thread
+	// endpoint doesn't carry tags), so one optimistic write updates both the row
+	// chips and the thread picker.
+	const selectedTags = selectedConv?.tags ?? [];
+
+	// Attach/detach EXISTING tags optimistically — same prefix-key pattern as
+	// archive/delete: the chip appears/disappears across every list cache variant
+	// instantly, rolls back on failure, and only the head is revalidated.
+	const attachTagMut = useOptimisticMutation<{ id: string; tag: Tag }>({
+		queryKey: ["conversations", projectId],
+		invalidateKey: ["conversations", projectId, "head"],
+		apply: (prev, vars) => addTagToConversation(prev, vars.id, vars.tag),
+		mutationFn: (vars) =>
+			api(`/api/projects/${projectId}/conversations/${vars.id}/tags`, {
+				method: "POST",
+				body: { tagId: vars.tag.id },
+				workspaceId: workspaceId!,
+			}),
+		onError: (e) => toast.error(describeApiError(e, "Failed to add tag")),
+	});
+
+	const detachTagMut = useOptimisticMutation<{ id: string; tagId: string }>({
+		queryKey: ["conversations", projectId],
+		invalidateKey: ["conversations", projectId, "head"],
+		apply: (prev, vars) => removeTagFromConversation(prev, vars.id, vars.tagId),
+		mutationFn: (vars) =>
+			api(
+				`/api/projects/${projectId}/conversations/${vars.id}/tags/${vars.tagId}`,
+				{ method: "DELETE", workspaceId: workspaceId! },
+			),
+		onError: (e) => toast.error(describeApiError(e, "Failed to remove tag")),
+	});
+
+	// Create-and-attach a NEW tag: a normal awaited mutation (the server must mint
+	// the id + color first), then graft the returned tag into the cache and
+	// refresh the tag list so the new tag shows in the picker/filter.
+	const createTagMut = useMutation({
+		mutationFn: (vars: { id: string; name: string }) =>
+			api<{ tag: Tag }>(
+				`/api/projects/${projectId}/conversations/${vars.id}/tags`,
+				{
+					method: "POST",
+					body: { name: vars.name },
+					workspaceId: workspaceId!,
+				},
+			),
+		onSuccess: ({ tag }, vars) => {
+			qc.setQueriesData({ queryKey: ["conversations", projectId] }, (prev) =>
+				addTagToConversation(prev, vars.id, tag),
+			);
+			void qc.invalidateQueries({ queryKey: ["tags", workspaceId] });
+			void qc.invalidateQueries({
+				queryKey: ["conversations", projectId, "head"],
+			});
+		},
+		onError: (e) => toast.error(describeApiError(e, "Failed to create tag")),
+	});
+
+	function handleToggleTag(tag: Tag) {
+		if (!selectedId) return;
+		const on = selectedTags.some((t) => t.id === tag.id);
+		if (on) detachTagMut.mutate({ id: selectedId, tagId: tag.id });
+		else attachTagMut.mutate({ id: selectedId, tag });
+	}
+
+	function handleCreateTag(name: string) {
+		if (!selectedId) return;
+		createTagMut.mutate({ id: selectedId, name });
+	}
 
 	// Mark a conversation read for this user. Optimistically clears the unread dot
 	// in-cache across the head + loaded pages (so a row deep in a loaded page
@@ -384,6 +474,9 @@ export default function InboxPage() {
 						setShowArchived(archived);
 						setSelectedId(null);
 					}}
+					tags={allTags}
+					tagIds={tagIds}
+					onTagIdsChange={setTagIds}
 				/>
 			</div>
 
@@ -438,6 +531,26 @@ export default function InboxPage() {
 								<Badge variant="warning" className="shrink-0">
 									Escalated
 								</Badge>
+							)}
+							{selectedId && (
+								<div className="flex flex-wrap items-center justify-end gap-1">
+									{selectedTags.map((t) => (
+										<TagChip
+											key={t.id}
+											tag={t}
+											onRemove={(tagId) =>
+												detachTagMut.mutate({ id: selectedId, tagId })
+											}
+										/>
+									))}
+									<TagPicker
+										tags={allTags}
+										attachedIds={selectedTags.map((t) => t.id)}
+										onToggle={handleToggleTag}
+										onCreate={handleCreateTag}
+										creating={createTagMut.isPending}
+									/>
+								</div>
 							)}
 						</>
 					)

--- a/apps/dashboard/src/lib/optimistic.test.tsx
+++ b/apps/dashboard/src/lib/optimistic.test.tsx
@@ -3,6 +3,8 @@ import { act, renderHook, waitFor } from "@testing-library/react";
 import { createElement, type ReactNode } from "react";
 import { describe, expect, it, vi } from "vitest";
 
+import { addTagToConversation } from "@/app/inbox/_components/conversation-list";
+
 import { dropById, mapById, useOptimisticMutation } from "./optimistic";
 
 function makeClient() {
@@ -114,6 +116,20 @@ describe("useOptimisticMutation", () => {
 					"a",
 					(p) => ({ ...p, pinned: true }),
 				),
+		},
+		{
+			// Tag attach: the chip is added optimistically, then a failed POST must
+			// restore the conversation's original (tag-less) state.
+			name: "conversation tag attach",
+			key: ["conversations", "p1", "", false],
+			partial: ["conversations", "p1"],
+			seed: { conversations: [{ id: "a" }] },
+			apply: (prev: unknown) =>
+				addTagToConversation(prev, "a", {
+					id: "t1",
+					name: "Billing",
+					color: "#6366f1",
+				}),
 		},
 	];
 

--- a/apps/dashboard/vitest.setup.ts
+++ b/apps/dashboard/vitest.setup.ts
@@ -3,6 +3,14 @@ import "@testing-library/jest-dom/vitest";
 import { cleanup } from "@testing-library/react";
 import { afterEach } from "vitest";
 
+// jsdom lacks ResizeObserver, which cmdk (the shadcn Command/combobox) calls on
+// mount. A no-op stub lets tag pickers/filters and any command menu render.
+globalThis.ResizeObserver ??= class {
+	observe() {}
+	unobserve() {}
+	disconnect() {}
+};
+
 afterEach(() => {
 	cleanup();
 });

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -193,6 +193,47 @@ export const conversation = sqliteTable(
 	],
 );
 
+// Workspace-scoped labels an agent can attach to conversations. Name uniqueness
+// is case-insensitive PER WORKSPACE — enforced by a COLLATE NOCASE unique index
+// in the hand-authored migration (drizzle can't emit the collation here, so this
+// uniqueIndex decl is cosmetic; the DB index + an app-level lower() dedupe are
+// the real guarantees).
+export const tag = sqliteTable(
+	"tag",
+	{
+		id: id(),
+		workspaceId: text()
+			.notNull()
+			.references(() => workspace.id, { onDelete: "cascade" }),
+		name: text().notNull(),
+		// Nullable: a tag created without a color is auto-assigned one server-side.
+		color: text(),
+		createdAt: createdAt(),
+	},
+	(t) => [uniqueIndex("tag_workspace_name").on(t.workspaceId, t.name)],
+);
+
+// Many-to-many join: which tags are attached to which conversation. Mirrors
+// read_status (surrogate id + a unique pair index). Both FKs cascade, so
+// deleting a conversation OR a tag removes the associations (no orphan rows).
+export const conversationTag = sqliteTable(
+	"conversation_tag",
+	{
+		id: id(),
+		conversationId: text()
+			.notNull()
+			.references(() => conversation.id, { onDelete: "cascade" }),
+		tagId: text()
+			.notNull()
+			.references(() => tag.id, { onDelete: "cascade" }),
+		createdAt: createdAt(),
+	},
+	(t) => [
+		uniqueIndex("conversation_tag_unique").on(t.conversationId, t.tagId),
+		index("conversation_tag_tag").on(t.tagId),
+	],
+);
+
 export const systemPrompt = sqliteTable(
 	"system_prompt",
 	{


### PR DESCRIPTION
## What

Tags/labels on conversations: create workspace tags, attach/detach them on a conversation (chips + inline combobox), and filter the inbox by tag — composing with the existing search, archived filter, and keyset pagination.

## Schema + migration (0013 — low risk, additive)

New `tag` (workspace-scoped; `name` **case-insensitive unique** per workspace via `COLLATE NOCASE`; nullable `color`) and `conversation_tag` join (cascade on both FKs; unique `(conversation,tag)`; index on `tag_id`). Migration `0013_conversation_tags.sql` is **purely additive** — two `CREATE TABLE`s + indexes, **no rewrite of any populated table** (unlike 0012). Hand-authored, scoped to the new tables (drizzle-kit generate stays unusable — frozen journal). **Prod:** ship the file; Ploy's filename-keyed ledger applies each `migrations/*.sql` once, in order, each in a transaction, so `0013` runs after `0012` on deploy. Validated on a scratch `node:sqlite`: NOCASE blocks `Billing`/`billing` dupes, same name allowed in another workspace, duplicate `(conversation,tag)` blocked, and deleting a **conversation or a tag** cascades the join rows.

## API

- **`GET /tags`** → workspace tags + per-tag conversation count (one grouped LEFT JOIN; new tags report 0).
- **`POST /tags`** `{ name, color? }` → create; **case-insensitive dedupe** returns the existing tag; auto-assigns a deterministic palette color when none given.
- **`POST /projects/:projectId/conversations/:id/tags`** — attach by `tagId` (existing) or `name` (create-and-attach); **idempotent**.
- **`DELETE …/:id/tags/:tagId`** — detach, no-op-safe.
- **List `tagIds` filter** — comma-separated, OR semantics, as a raw-SQL subquery on the join table; one ANDed predicate so it composes with search + archived + the keyset cursor and **stays correctly paginated**. Each list row carries its `tags`, fetched in **one batched query per page (no N+1)**.
- **Auth/tenant:** any workspace member (matches the reply route — no `requireRole`); attach/detach assert project ∈ workspace and conversation ∈ project, and a tag attached by id must belong to the workspace. **Cross-workspace tag/conversation → 404, nothing leaked**; a foreign tag id in the filter matches nothing.

## UI (current inbox; PR2 restyle inherits this)

Colored **chips** on each list row and on the open thread; a shadcn **Popover + Command** picker on the open conversation (search existing tags, toggle on/off, **create inline** when nothing matches), chip `×` to remove; a multi-select **tag filter** in the toolbar — wired into the slot the disabled "Filters" placeholder occupied (PR2 will unify filters, so it's intentionally lightweight). Attach/detach of existing tags are **optimistic** via the shared lib (prefix key spanning all list variants, rollback on failure); **create-new-tag is a normal awaited mutation** (server mints id/color), then grafted into the cache.

## Tests (all green)

API **229** (+23): cross-workspace attach/filter → 404; case-insensitive dedupe → existing, no dup; attach-twice → no dup; detach-unattached → safe; `tagIds` filter + composition with search/archived/cursor; batched tags assert **one** query (no N+1); name validation; member vs non-member (403); cascade verified on scratch SQLite. Dashboard **286** (+10): picker toggle/create/dedup-suppression/attached-check; toolbar tag filter; cache updaters (attach idempotent / remove / both shapes); **optimistic tag-attach rollback** on failure. Added a `ResizeObserver` polyfill to the vitest setup for cmdk.

Gates: `pnpm build` (5/5), `pnpm test` (all packages), `pnpm lint`, prettier `--check`, secret scan — clean. Unrelated drift (`.agents/*`, `skills-lock.json`, `consent.ts`, `docs/`) left unstaged.

### Open decision carried from the plan
Attach/detach are nested under the existing `/projects/:projectId/conversations/:id/...` path (not a flat `/conversations/:id/...`) to reuse the project∈workspace tenant check — flag if you'd prefer the flat shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)