### PR TITLE
feat(inbox): global tag management — rename, recolor, delete

### DIFF
--- a/apps/api/src/lib/tag-colors.ts
+++ b/apps/api/src/lib/tag-colors.ts
@@ -1,20 +1,11 @@
-// Fixed tag palette. A new tag with no color gets one assigned deterministically
-// from its name, so the same label tends to keep the same color and the spread
-// across a workspace stays balanced without storing a counter. The dashboard
-// just renders whatever hex the server returns — this is the single source.
+// Tag color helpers. The palette itself lives in @llmchat/shared so the colors
+// the server validates and the swatches the dashboard renders can't drift; a new
+// tag with no color gets one assigned deterministically from its name, so the
+// same label tends to keep the same color without storing a counter.
 
-export const TAG_PALETTE = [
-	"#6366f1", // indigo
-	"#0ea5e9", // sky
-	"#10b981", // emerald
-	"#f59e0b", // amber
-	"#ef4444", // red
-	"#ec4899", // pink
-	"#8b5cf6", // violet
-	"#14b8a6", // teal
-] as const;
+import { TAG_PALETTE, type TagColor } from "@llmchat/shared";
 
-export type TagColor = (typeof TAG_PALETTE)[number];
+export { TAG_PALETTE, isPaletteColor, type TagColor } from "@llmchat/shared";
 
 /** Whether a string is a hex color the client may supply (#rgb or #rrggbb). */
 export function isHexColor(value: string): boolean {

--- a/apps/api/src/lib/tags.ts
+++ b/apps/api/src/lib/tags.ts
@@ -4,7 +4,7 @@
 import { db } from "@/lib/db";
 import { colorForName, isHexColor } from "@/lib/tag-colors";
 
-import { and, eq, sql, tag } from "@llmchat/db";
+import { and, eq, ne, sql, tag } from "@llmchat/db";
 
 import type { AppContext } from "@/env";
 
@@ -34,6 +34,29 @@ export async function findTagByName(
 		.where(
 			and(
 				eq(tag.workspaceId, workspaceId),
+				sql`lower(${tag.name}) = ${name.toLowerCase()}`,
+			),
+		)
+		.limit(1);
+	return row;
+}
+
+/** Case-insensitive name lookup within a workspace, EXCLUDING one tag id — used
+ * on rename to detect a collision with a DIFFERENT tag (renaming a tag to its own
+ * current name/casing is not a collision). */
+export async function findTagByNameExcluding(
+	env: Env,
+	workspaceId: string,
+	name: string,
+	excludeId: string,
+): Promise<TagRow | undefined> {
+	const [row] = await db(env)
+		.select()
+		.from(tag)
+		.where(
+			and(
+				eq(tag.workspaceId, workspaceId),
+				ne(tag.id, excludeId),
 				sql`lower(${tag.name}) = ${name.toLowerCase()}`,
 			),
 		)

--- a/apps/api/src/routes/tags.test.ts
+++ b/apps/api/src/routes/tags.test.ts
@@ -23,21 +23,38 @@ const ENV = { vars: {}, DB: {} } as unknown as Parameters<
 
 interface State {
 	role?: "owner" | "admin" | "agent";
-	/** Result of the select chain (GET list, or the POST dedupe lookup). */
+	/** Result of the select chain (GET list, or the POST/PATCH dedupe lookup). */
 	selectResult?: Record<string, unknown>[];
+	/** The tag resolved by query.tag.findFirst (tenant check). undefined ⇒ 404. */
+	existingTag?: Record<string, unknown>;
 }
 
 let insertSpy: ReturnType<typeof vi.fn>;
+let updateSpy: ReturnType<typeof vi.fn>;
+let deleteSpy: ReturnType<typeof vi.fn>;
 let lastInsert: Record<string, unknown> | null;
+/** The object handed to update(tag).set(...) on the last PATCH — lets a test
+ * assert ONLY the provided fields are written (no clobbered sibling). */
+let lastSet: Record<string, unknown> | null;
 
 function mockDb(state: State) {
 	lastInsert = null;
+	lastSet = null;
 	insertSpy = vi.fn(() => ({
 		values: (data: Record<string, unknown>) => {
 			lastInsert = data;
 			return { returning: async () => [{ id: "tag_new", ...data }] };
 		},
 	}));
+	updateSpy = vi.fn(() => ({
+		set: (data: Record<string, unknown>) => {
+			lastSet = data;
+			return {
+				where: () => ({ returning: async () => [{ id: "t1", ...data }] }),
+			};
+		},
+	}));
+	deleteSpy = vi.fn(() => ({ where: async () => [] }));
 	const selectChain: Record<string, unknown> = {
 		from: () => selectChain,
 		leftJoin: () => selectChain,
@@ -54,9 +71,14 @@ function mockDb(state: State) {
 			member: {
 				findFirst: async () => (state.role ? { role: state.role } : undefined),
 			},
+			tag: {
+				findFirst: async () => state.existingTag,
+			},
 		},
 		select: () => selectChain,
 		insert: insertSpy,
+		update: updateSpy,
+		delete: deleteSpy,
 	};
 	vi.mocked(db).mockReturnValue(fake as unknown as ReturnType<typeof db>);
 }
@@ -178,5 +200,135 @@ describe("POST /tags", () => {
 		const res = await post({ name: "Nope" });
 		expect(res.status).toBe(403);
 		expect(insertSpy).not.toHaveBeenCalled();
+	});
+});
+
+const TAG = {
+	id: "t1",
+	workspaceId: "ws_1",
+	name: "Billing",
+	color: "#6366f1",
+};
+
+function patch(
+	body: unknown,
+	tagId = "t1",
+	headers: Record<string, string> = MEMBER,
+) {
+	return tags.request(
+		`/tags/${tagId}`,
+		{ method: "PATCH", headers, body: JSON.stringify(body) },
+		ENV,
+	);
+}
+function del(tagId = "t1", headers: Record<string, string> = MEMBER) {
+	return tags.request(`/tags/${tagId}`, { method: "DELETE", headers }, ENV);
+}
+
+describe("PATCH /tags/:tagId — rename / recolor", () => {
+	it("renames a tag (admin); no collision", async () => {
+		mockDb({ role: "admin", existingTag: TAG, selectResult: [] });
+		const res = await patch({ name: "Payments" });
+		expect(res.status).toBe(200);
+		expect(lastSet).toEqual({ name: "Payments" });
+		expect(updateSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it("recolors a tag to a palette color (admin)", async () => {
+		mockDb({ role: "admin", existingTag: TAG, selectResult: [] });
+		const res = await patch({ color: "#ef4444" });
+		expect(res.status).toBe(200);
+		expect(lastSet).toEqual({ color: "#ef4444" });
+	});
+
+	it("PATCH with only color does NOT blank name (per-field, no clobber)", async () => {
+		mockDb({ role: "admin", existingTag: TAG, selectResult: [] });
+		await patch({ color: "#10b981" });
+		expect(lastSet).toEqual({ color: "#10b981" });
+		expect(lastSet).not.toHaveProperty("name");
+	});
+
+	it("PATCH with only name does NOT blank color", async () => {
+		mockDb({ role: "admin", existingTag: TAG, selectResult: [] });
+		await patch({ name: "Renamed" });
+		expect(lastSet).toEqual({ name: "Renamed" });
+		expect(lastSet).not.toHaveProperty("color");
+	});
+
+	it("allows renaming a tag to its own current name/casing (exclude-self)", async () => {
+		// findTagByNameExcluding finds nothing (the only match is the tag itself).
+		mockDb({ role: "admin", existingTag: TAG, selectResult: [] });
+		const res = await patch({ name: "billing" });
+		expect(res.status).toBe(200);
+		expect(updateSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it("409s a rename colliding (case-insensitively) with a DIFFERENT tag; no update", async () => {
+		mockDb({
+			role: "admin",
+			existingTag: TAG,
+			// A different tag already owns this name.
+			selectResult: [{ id: "t2", workspaceId: "ws_1", name: "Payments" }],
+		});
+		const res = await patch({ name: "PAYMENTS" });
+		expect(res.status).toBe(409);
+		expect(updateSpy).not.toHaveBeenCalled();
+	});
+
+	it("404s a tag from another workspace; no update (no cross-workspace rename)", async () => {
+		mockDb({ role: "admin", existingTag: undefined });
+		const res = await patch({ name: "X" });
+		expect(res.status).toBe(404);
+		expect(updateSpy).not.toHaveBeenCalled();
+	});
+
+	it("400s an off-palette color; no update", async () => {
+		mockDb({ role: "admin", existingTag: TAG, selectResult: [] });
+		const res = await patch({ color: "#123456" });
+		expect(res.status).toBe(400);
+		expect(updateSpy).not.toHaveBeenCalled();
+	});
+
+	it("400s empty/whitespace/over-length name; no update", async () => {
+		mockDb({ role: "admin", existingTag: TAG, selectResult: [] });
+		expect((await patch({ name: "   " })).status).toBe(400);
+		expect((await patch({ name: "x".repeat(41) })).status).toBe(400);
+		expect(updateSpy).not.toHaveBeenCalled();
+	});
+
+	it("400s an empty body (neither name nor color)", async () => {
+		mockDb({ role: "admin", existingTag: TAG });
+		const res = await patch({});
+		expect(res.status).toBe(400);
+	});
+
+	it("403s an agent renaming (manage is admin+); no update", async () => {
+		mockDb({ role: "agent", existingTag: TAG });
+		const res = await patch({ name: "Nope" });
+		expect(res.status).toBe(403);
+		expect(updateSpy).not.toHaveBeenCalled();
+	});
+});
+
+describe("DELETE /tags/:tagId", () => {
+	it("deletes a tag (admin); the 0013 cascade clears its associations", async () => {
+		mockDb({ role: "admin", existingTag: TAG });
+		const res = await del();
+		expect(res.status).toBe(200);
+		expect(deleteSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it("404s a tag from another workspace; never deletes", async () => {
+		mockDb({ role: "admin", existingTag: undefined });
+		const res = await del();
+		expect(res.status).toBe(404);
+		expect(deleteSpy).not.toHaveBeenCalled();
+	});
+
+	it("403s an agent deleting; never deletes", async () => {
+		mockDb({ role: "agent", existingTag: TAG });
+		const res = await del();
+		expect(res.status).toBe(403);
+		expect(deleteSpy).not.toHaveBeenCalled();
 	});
 });

--- a/apps/api/src/routes/tags.ts
+++ b/apps/api/src/routes/tags.ts
@@ -3,8 +3,17 @@ import { Hono } from "hono";
 import { z } from "zod";
 
 import { db } from "@/lib/db";
-import { TAG_NAME_MAX, findOrCreateTag } from "@/lib/tags";
-import { requireSession, requireWorkspace } from "@/middleware/session";
+import { isPaletteColor } from "@/lib/tag-colors";
+import {
+	TAG_NAME_MAX,
+	findOrCreateTag,
+	findTagByNameExcluding,
+} from "@/lib/tags";
+import {
+	requireRole,
+	requireSession,
+	requireWorkspace,
+} from "@/middleware/session";
 
 import { conversationTag, count, eq, sql, tag as tagTable } from "@llmchat/db";
 
@@ -14,6 +23,22 @@ const createInput = z.object({
 	name: z.string().trim().min(1).max(TAG_NAME_MAX),
 	color: z.string().max(32).optional(),
 });
+
+// UPDATE: every field optional, NO `.default()`/`.partial()` (the Zod-v4 footgun
+// where a default fires on an absent key and clobbers the sibling) — a PATCH with
+// only `color` must not blank `name`, and vice versa. `color` is restricted to
+// the fixed palette (stricter than create); at least one field must be present.
+const updateInput = z
+	.object({
+		name: z.string().trim().min(1).max(TAG_NAME_MAX).optional(),
+		color: z
+			.string()
+			.refine(isPaletteColor, { message: "color must be one of the palette" })
+			.optional(),
+	})
+	.refine((d) => d.name !== undefined || d.color !== undefined, {
+		message: "name or color required",
+	});
 
 // Any workspace member can manage tags (same posture as the reply route — no
 // requireRole). Strictly workspace-scoped via requireWorkspace + the x-workspace
@@ -52,4 +77,63 @@ export const tags = new Hono<AppContext>()
 			color,
 		);
 		return c.json({ tag, created });
+	})
+	// Rename / recolor a tag. Admin+ (create/assign stay open to any member).
+	.patch(
+		"/tags/:tagId",
+		requireRole("admin"),
+		zValidator("json", updateInput),
+		async (c) => {
+			const { tagId } = c.req.param();
+			const workspaceId = c.get("workspaceId");
+			const { name, color } = c.req.valid("json");
+
+			// Tenant: the tag must belong to the caller's workspace (else 404 — no
+			// cross-workspace rename, no existence leak).
+			const existing = await db(c.env).query.tag.findFirst({
+				where: (t, { and, eq: e }) =>
+					and(e(t.id, tagId), e(t.workspaceId, workspaceId)),
+			});
+			if (!existing) return c.json({ error: "not found" }, 404);
+
+			// Rename collision: a DIFFERENT tag with the same name (case-insensitive)
+			// ⇒ 409, no change. Renaming to the tag's own current name/casing is fine
+			// (the exclude-self lookup returns nothing).
+			if (name !== undefined) {
+				const collision = await findTagByNameExcluding(
+					c.env,
+					workspaceId,
+					name,
+					tagId,
+				);
+				if (collision) {
+					return c.json({ error: "name already exists" }, 409);
+				}
+			}
+
+			// Only the provided fields are written — a color-only PATCH never blanks
+			// name, and vice versa (the updateInput carries no defaults).
+			const data: { name?: string; color?: string } = {};
+			if (name !== undefined) data.name = name.trim();
+			if (color !== undefined) data.color = color;
+
+			const [updated] = await db(c.env)
+				.update(tagTable)
+				.set(data)
+				.where(eq(tagTable.id, tagId))
+				.returning();
+			return c.json({ tag: updated });
+		},
+	)
+	// Delete a tag. The 0013 cascade FK removes its conversation_tag rows. Admin+.
+	.delete("/tags/:tagId", requireRole("admin"), async (c) => {
+		const { tagId } = c.req.param();
+		const workspaceId = c.get("workspaceId");
+		const existing = await db(c.env).query.tag.findFirst({
+			where: (t, { and, eq: e }) =>
+				and(e(t.id, tagId), e(t.workspaceId, workspaceId)),
+		});
+		if (!existing) return c.json({ error: "not found" }, 404);
+		await db(c.env).delete(tagTable).where(eq(tagTable.id, tagId));
+		return c.json({ ok: true });
 	});

--- a/apps/dashboard/src/app/inbox/_components/InboxToolbar.test.tsx
+++ b/apps/dashboard/src/app/inbox/_components/InboxToolbar.test.tsx
@@ -14,7 +14,7 @@ function setup(props: Partial<React.ComponentProps<typeof InboxToolbar>> = {}) {
 	const onSearch = vi.fn();
 	const onShowArchivedChange = vi.fn();
 	const onTagIdsChange = vi.fn();
-	render(
+	const { unmount } = render(
 		<InboxToolbar
 			search=""
 			onSearch={onSearch}
@@ -26,7 +26,7 @@ function setup(props: Partial<React.ComponentProps<typeof InboxToolbar>> = {}) {
 			{...props}
 		/>,
 	);
-	return { onSearch, onShowArchivedChange, onTagIdsChange };
+	return { onSearch, onShowArchivedChange, onTagIdsChange, unmount };
 }
 
 describe("InboxToolbar", () => {
@@ -78,5 +78,25 @@ describe("InboxToolbar", () => {
 		await user.click(btn);
 		await user.click(screen.getByRole("option", { name: /Billing/ }));
 		expect(onTagIdsChange).toHaveBeenCalledWith(["t1"]);
+	});
+
+	it("shows the 'Manage tags' link only when onManageTags is provided (admin/owner)", async () => {
+		const user = userEvent.setup();
+		const tags = [{ id: "t1", name: "Billing", color: "#6366f1", count: 3 }];
+
+		// No onManageTags (agent): the link is absent from the filter popover.
+		const { unmount } = setup({ tags });
+		await user.click(screen.getByRole("button", { name: /tags/i }));
+		expect(
+			screen.queryByRole("button", { name: /manage tags/i }),
+		).not.toBeInTheDocument();
+		unmount();
+
+		// With onManageTags (admin/owner): the link shows and fires.
+		const onManageTags = vi.fn();
+		setup({ tags, onManageTags });
+		await user.click(screen.getByRole("button", { name: /tags/i }));
+		await user.click(screen.getByRole("button", { name: /manage tags/i }));
+		expect(onManageTags).toHaveBeenCalled();
 	});
 });

--- a/apps/dashboard/src/app/inbox/_components/InboxToolbar.tsx
+++ b/apps/dashboard/src/app/inbox/_components/InboxToolbar.tsx
@@ -25,6 +25,8 @@ export interface InboxToolbarProps {
 	/** Selected tag ids (OR filter). */
 	tagIds: string[];
 	onTagIdsChange: (ids: string[]) => void;
+	/** Opens the manage-tags dialog (admin/owner only; omit to hide the link). */
+	onManageTags?: () => void;
 }
 
 /**
@@ -41,6 +43,7 @@ export function InboxToolbar({
 	tags,
 	tagIds,
 	onTagIdsChange,
+	onManageTags,
 }: InboxToolbarProps) {
 	return (
 		<div className="flex items-center gap-2 border-b px-4 py-2.5">
@@ -71,7 +74,12 @@ export function InboxToolbar({
 				/>
 			</div>
 
-			<TagFilter tags={tags} selectedIds={tagIds} onChange={onTagIdsChange} />
+			<TagFilter
+				tags={tags}
+				selectedIds={tagIds}
+				onChange={onTagIdsChange}
+				onManage={onManageTags}
+			/>
 			<span className="hidden shrink-0 px-1 text-sm text-muted-foreground sm:inline">
 				Sort: <span className="font-medium text-foreground">Latest</span>
 			</span>

--- a/apps/dashboard/src/app/inbox/_components/ManageTagsDialog.test.tsx
+++ b/apps/dashboard/src/app/inbox/_components/ManageTagsDialog.test.tsx
@@ -1,0 +1,103 @@
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+import { ManageTagsDialog } from "./ManageTagsDialog";
+import type { Tag } from "./types";
+
+beforeAll(() => {
+	Element.prototype.scrollIntoView = vi.fn();
+	Element.prototype.hasPointerCapture ??= () => false;
+});
+
+const TAGS: Tag[] = [
+	{ id: "t1", name: "Billing", color: "#6366f1", count: 12 },
+	{ id: "t2", name: "Bug", color: "#ef4444", count: 0 },
+];
+
+function setup(
+	props: Partial<React.ComponentProps<typeof ManageTagsDialog>> = {},
+) {
+	const onRename = vi.fn();
+	const onRecolor = vi.fn();
+	const onDelete = vi.fn();
+	render(
+		<ManageTagsDialog
+			open
+			onOpenChange={vi.fn()}
+			tags={TAGS}
+			onRename={onRename}
+			onRecolor={onRecolor}
+			onDelete={onDelete}
+			{...props}
+		/>,
+	);
+	return { onRename, onRecolor, onDelete };
+}
+
+describe("ManageTagsDialog", () => {
+	it("lists each tag with its conversation count", () => {
+		setup();
+		expect(screen.getByText("Billing")).toBeInTheDocument();
+		expect(screen.getByText("12 conversations")).toBeInTheDocument();
+		expect(screen.getByText("0 conversations")).toBeInTheDocument();
+	});
+
+	it("renames a tag inline (Enter commits the new name)", async () => {
+		const user = userEvent.setup();
+		const { onRename } = setup();
+		await user.click(screen.getByRole("button", { name: "Edit Billing" }));
+		const input = screen.getByRole("textbox", { name: "Rename Billing" });
+		await user.clear(input);
+		await user.type(input, "Payments{Enter}");
+		expect(onRename).toHaveBeenCalledWith(TAGS[0], "Payments");
+	});
+
+	it("does not call onRename when the name is unchanged", async () => {
+		const user = userEvent.setup();
+		const { onRename } = setup();
+		await user.click(screen.getByRole("button", { name: "Edit Billing" }));
+		await user.type(
+			screen.getByRole("textbox", { name: "Rename Billing" }),
+			"{Enter}",
+		);
+		expect(onRename).not.toHaveBeenCalled();
+	});
+
+	it("recolors a tag from the palette (reports a palette hex)", async () => {
+		const user = userEvent.setup();
+		const { onRecolor } = setup();
+		await user.click(screen.getByRole("button", { name: "Recolor Billing" }));
+		await user.click(screen.getByRole("button", { name: "Set color #10b981" }));
+		expect(onRecolor).toHaveBeenCalledWith(TAGS[0], "#10b981");
+	});
+
+	it("delete confirm states the impact with the real count, then calls onDelete", async () => {
+		const user = userEvent.setup();
+		const { onDelete } = setup();
+		await user.click(screen.getByRole("button", { name: "Delete Billing" }));
+		// The confirm names the tag and the conversation count.
+		const dialog = screen.getByRole("alertdialog");
+		expect(within(dialog).getByText(/Delete “Billing”\?/)).toBeInTheDocument();
+		expect(
+			within(dialog).getByText(/removed from 12 conversations/),
+		).toBeInTheDocument();
+		await user.click(within(dialog).getByRole("button", { name: "Delete" }));
+		expect(onDelete).toHaveBeenCalledWith(TAGS[0]);
+	});
+
+	it("for a tag on no conversations, the confirm says so (no '0 conversations' impact)", async () => {
+		const user = userEvent.setup();
+		setup();
+		await user.click(screen.getByRole("button", { name: "Delete Bug" }));
+		const dialog = screen.getByRole("alertdialog");
+		expect(
+			within(dialog).getByText(/isn't on any conversations/),
+		).toBeInTheDocument();
+	});
+
+	it("shows an empty state when there are no tags", () => {
+		setup({ tags: [] });
+		expect(screen.getByText(/No tags yet/)).toBeInTheDocument();
+	});
+});

--- a/apps/dashboard/src/app/inbox/_components/ManageTagsDialog.tsx
+++ b/apps/dashboard/src/app/inbox/_components/ManageTagsDialog.tsx
@@ -1,0 +1,254 @@
+"use client";
+
+import { Check, Pencil, Trash2 } from "lucide-react";
+import { useState } from "react";
+
+import { TAG_PALETTE } from "@llmchat/shared";
+
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+	AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import {
+	Popover,
+	PopoverContent,
+	PopoverTrigger,
+} from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
+
+import { pluralize } from "./format";
+import type { Tag } from "./types";
+
+const FALLBACK = "#6b7280";
+
+/** Palette swatch grid for recoloring a tag. */
+function RecolorPopover({
+	tag,
+	onRecolor,
+	disabled,
+}: {
+	tag: Tag;
+	onRecolor: (color: string) => void;
+	disabled?: boolean;
+}) {
+	const [open, setOpen] = useState(false);
+	return (
+		<Popover open={open} onOpenChange={setOpen}>
+			<PopoverTrigger asChild>
+				<button
+					type="button"
+					disabled={disabled}
+					aria-label={`Recolor ${tag.name}`}
+					className="size-4 shrink-0 rounded-full ring-1 ring-inset ring-black/10 transition-transform hover:scale-110 disabled:opacity-50 dark:ring-white/15"
+					style={{ backgroundColor: tag.color ?? FALLBACK }}
+				/>
+			</PopoverTrigger>
+			<PopoverContent className="w-auto p-2" align="start">
+				<div className="grid grid-cols-4 gap-1.5">
+					{TAG_PALETTE.map((c) => {
+						const active = (tag.color ?? "").toLowerCase() === c.toLowerCase();
+						return (
+							<button
+								key={c}
+								type="button"
+								aria-label={`Set color ${c}`}
+								onClick={() => {
+									onRecolor(c);
+									setOpen(false);
+								}}
+								className="grid size-6 place-items-center rounded-full ring-1 ring-inset ring-black/10 transition-transform hover:scale-110 dark:ring-white/15"
+								style={{ backgroundColor: c }}
+							>
+								{active && <Check className="size-3.5 text-white" />}
+							</button>
+						);
+					})}
+				</div>
+			</PopoverContent>
+		</Popover>
+	);
+}
+
+function ManageTagRow({
+	tag,
+	onRename,
+	onRecolor,
+	onDelete,
+	busy,
+}: {
+	tag: Tag;
+	onRename: (name: string) => void;
+	onRecolor: (color: string) => void;
+	onDelete: () => void;
+	busy?: boolean;
+}) {
+	const [editing, setEditing] = useState(false);
+	const [draft, setDraft] = useState(tag.name);
+	const count = tag.count ?? 0;
+
+	function commit() {
+		const next = draft.trim();
+		// Skip the call when nothing changed (the server treats a same-name rename
+		// as a no-op anyway, but this avoids a needless request).
+		if (next && next !== tag.name) onRename(next);
+		setEditing(false);
+	}
+
+	return (
+		<li className="flex items-center gap-2 rounded-lg border border-border bg-card px-2.5 py-2">
+			<RecolorPopover tag={tag} onRecolor={onRecolor} disabled={busy} />
+
+			{editing ? (
+				<Input
+					autoFocus
+					value={draft}
+					maxLength={40}
+					onChange={(e) => setDraft(e.target.value)}
+					onKeyDown={(e) => {
+						if (e.key === "Enter") commit();
+						if (e.key === "Escape") {
+							setDraft(tag.name);
+							setEditing(false);
+						}
+					}}
+					onBlur={commit}
+					aria-label={`Rename ${tag.name}`}
+					className="h-7 flex-1 text-sm"
+				/>
+			) : (
+				<>
+					<span className="flex-1 truncate text-sm font-medium">
+						{tag.name}
+					</span>
+					<span className="shrink-0 text-[11px] tabular-nums text-muted-foreground/70">
+						{pluralize(count, "conversation")}
+					</span>
+					<Button
+						type="button"
+						variant="ghost"
+						size="icon"
+						className="size-7 text-muted-foreground hover:text-foreground"
+						onClick={() => {
+							setDraft(tag.name);
+							setEditing(true);
+						}}
+						disabled={busy}
+						aria-label={`Edit ${tag.name}`}
+					>
+						<Pencil className="size-3.5" />
+					</Button>
+				</>
+			)}
+
+			<AlertDialog>
+				<AlertDialogTrigger asChild>
+					<Button
+						type="button"
+						variant="ghost"
+						size="icon"
+						className={cn(
+							"size-7 text-muted-foreground",
+							"hover:bg-red-500/10 hover:text-red-600 dark:hover:text-red-400",
+						)}
+						disabled={busy}
+						aria-label={`Delete ${tag.name}`}
+					>
+						<Trash2 className="size-3.5" />
+					</Button>
+				</AlertDialogTrigger>
+				<AlertDialogContent>
+					<AlertDialogHeader>
+						<AlertDialogTitle>Delete “{tag.name}”?</AlertDialogTitle>
+						<AlertDialogDescription>
+							{count > 0
+								? `It will be removed from ${pluralize(count, "conversation")}. This can't be undone.`
+								: "This tag isn't on any conversations. This can't be undone."}
+						</AlertDialogDescription>
+					</AlertDialogHeader>
+					<AlertDialogFooter>
+						<AlertDialogCancel>Cancel</AlertDialogCancel>
+						<AlertDialogAction
+							onClick={onDelete}
+							className="bg-red-600 text-white hover:bg-red-600/90"
+						>
+							Delete
+						</AlertDialogAction>
+					</AlertDialogFooter>
+				</AlertDialogContent>
+			</AlertDialog>
+		</li>
+	);
+}
+
+export interface ManageTagsDialogProps {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	tags: Tag[];
+	onRename: (tag: Tag, name: string) => void;
+	onRecolor: (tag: Tag, color: string) => void;
+	onDelete: (tag: Tag) => void;
+	/** The id of a tag with a mutation in flight (its row is disabled). */
+	busyId?: string | null;
+}
+
+/**
+ * Global tag management for the workspace: rename, recolor (palette), and delete
+ * (with an impact-stating confirm). Admin/owner only — the caller renders this
+ * behind a role gate, and the API enforces the same with requireRole("admin").
+ */
+export function ManageTagsDialog({
+	open,
+	onOpenChange,
+	tags,
+	onRename,
+	onRecolor,
+	onDelete,
+	busyId,
+}: ManageTagsDialogProps) {
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent>
+				<DialogHeader>
+					<DialogTitle>Manage tags</DialogTitle>
+					<DialogDescription>
+						Rename, recolor, or delete the tags used across this workspace.
+					</DialogDescription>
+				</DialogHeader>
+				{tags.length === 0 ? (
+					<p className="py-6 text-center text-sm text-muted-foreground">
+						No tags yet. Create one from a conversation’s tag picker.
+					</p>
+				) : (
+					<ul className="flex max-h-[60vh] flex-col gap-1.5 overflow-y-auto">
+						{tags.map((tag) => (
+							<ManageTagRow
+								key={tag.id}
+								tag={tag}
+								busy={busyId === tag.id}
+								onRename={(name) => onRename(tag, name)}
+								onRecolor={(color) => onRecolor(tag, color)}
+								onDelete={() => onDelete(tag)}
+							/>
+						))}
+					</ul>
+				)}
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/apps/dashboard/src/app/inbox/_components/TagFilter.tsx
+++ b/apps/dashboard/src/app/inbox/_components/TagFilter.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Check, SlidersHorizontal } from "lucide-react";
+import { Check, Settings2, SlidersHorizontal } from "lucide-react";
 import { useState } from "react";
 
 import { Button } from "@/components/ui/button";
@@ -26,6 +26,8 @@ export interface TagFilterProps {
 	/** Currently-selected tag ids (OR filter). */
 	selectedIds: string[];
 	onChange: (ids: string[]) => void;
+	/** When provided (admin/owner), shows a "Manage tags" link in the footer. */
+	onManage?: () => void;
 }
 
 /**
@@ -33,7 +35,12 @@ export interface TagFilterProps {
  * with ANY selected tag). Lives where the disabled "Filters" placeholder was;
  * PR2 will unify all inbox filters, so this stays intentionally lightweight.
  */
-export function TagFilter({ tags, selectedIds, onChange }: TagFilterProps) {
+export function TagFilter({
+	tags,
+	selectedIds,
+	onChange,
+	onManage,
+}: TagFilterProps) {
 	const [open, setOpen] = useState(false);
 	const selected = new Set(selectedIds);
 	const count = selectedIds.length;
@@ -102,17 +109,36 @@ export function TagFilter({ tags, selectedIds, onChange }: TagFilterProps) {
 						</CommandGroup>
 					</CommandList>
 				</Command>
-				{count > 0 && (
-					<div className="border-t p-1">
-						<Button
-							type="button"
-							variant="ghost"
-							size="sm"
-							className="w-full justify-center text-xs text-muted-foreground"
-							onClick={() => onChange([])}
-						>
-							Clear {count} filter{count > 1 ? "s" : ""}
-						</Button>
+				{(count > 0 || onManage) && (
+					<div className="flex items-center justify-between gap-1 border-t p-1">
+						{onManage ? (
+							<Button
+								type="button"
+								variant="ghost"
+								size="sm"
+								className="gap-1.5 text-xs text-muted-foreground"
+								onClick={() => {
+									setOpen(false);
+									onManage();
+								}}
+							>
+								<Settings2 className="size-3.5" />
+								Manage tags
+							</Button>
+						) : (
+							<span />
+						)}
+						{count > 0 && (
+							<Button
+								type="button"
+								variant="ghost"
+								size="sm"
+								className="text-xs text-muted-foreground"
+								onClick={() => onChange([])}
+							>
+								Clear {count}
+							</Button>
+						)}
 					</div>
 				)}
 			</PopoverContent>

--- a/apps/dashboard/src/app/inbox/_components/conversation-list.test.ts
+++ b/apps/dashboard/src/app/inbox/_components/conversation-list.test.ts
@@ -5,6 +5,7 @@ import {
 	dropConversationFromCache,
 	flattenPages,
 	mergeConversationPages,
+	removeTagFromAllConversations,
 	removeTagFromConversation,
 	setConversationRead,
 	type ConversationPage,
@@ -167,6 +168,35 @@ describe("addTagToConversation / removeTagFromConversation (shape-aware)", () =>
 	it("passes unknown shapes / undefined through unchanged", () => {
 		expect(addTagToConversation(undefined, "a", TAG)).toBeUndefined();
 		expect(removeTagFromConversation({ nope: 1 }, "a", "t1")).toEqual({
+			nope: 1,
+		});
+	});
+});
+
+describe("removeTagFromAllConversations (tag delete)", () => {
+	const other: Tag = { id: "t2", name: "VIP", color: null };
+
+	it("strips the deleted tag from EVERY conversation across both cache shapes", () => {
+		const head = page([
+			conv({ id: "a", tags: [TAG, other] }),
+			conv({ id: "b", tags: [TAG] }),
+			conv({ id: "c", tags: [other] }),
+		]);
+		const next = removeTagFromAllConversations(head, "t1") as ConversationPage;
+		expect(next.conversations[0]!.tags).toEqual([other]); // TAG gone, VIP kept
+		expect(next.conversations[1]!.tags).toEqual([]); // TAG gone
+		expect(next.conversations[2]!.tags).toEqual([other]); // untouched
+
+		const inf = infinite([page([conv({ id: "a", tags: [TAG] })])]);
+		const nextInf = removeTagFromAllConversations(inf, "t1") as ReturnType<
+			typeof infinite
+		>;
+		expect(nextInf.pages[0].conversations[0]!.tags).toEqual([]);
+	});
+
+	it("passes unknown shapes / undefined through unchanged", () => {
+		expect(removeTagFromAllConversations(undefined, "t1")).toBeUndefined();
+		expect(removeTagFromAllConversations({ nope: 1 }, "t1")).toEqual({
 			nope: 1,
 		});
 	});

--- a/apps/dashboard/src/app/inbox/_components/conversation-list.ts
+++ b/apps/dashboard/src/app/inbox/_components/conversation-list.ts
@@ -127,3 +127,19 @@ export function removeTagFromConversation(
 		),
 	);
 }
+
+/** Updater for a tag DELETE: strip the tag's chip from EVERY cached conversation
+ * across head + infinite caches, so a deleted tag vanishes from all rows at once
+ * without waiting for a refetch. */
+export function removeTagFromAllConversations(
+	prev: unknown,
+	tagId: string,
+): unknown {
+	return mapConversationsInCache(prev, (list) =>
+		list.map((c) =>
+			(c.tags ?? []).some((t) => t.id === tagId)
+				? { ...c, tags: (c.tags ?? []).filter((t) => t.id !== tagId) }
+				: c,
+		),
+	);
+}

--- a/apps/dashboard/src/app/inbox/page.test.tsx
+++ b/apps/dashboard/src/app/inbox/page.test.tsx
@@ -1,0 +1,210 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { api } from "@/lib/api";
+
+import InboxPage from "./page";
+
+import type { Tag } from "./_components/types";
+
+beforeAll(() => {
+	Element.prototype.scrollIntoView = vi.fn();
+	Element.prototype.hasPointerCapture ??= () => false;
+});
+
+vi.mock("next/navigation", () => ({
+	useRouter: () => ({ replace: vi.fn(), push: vi.fn() }),
+}));
+
+// Admin in a workspace with a project, so the inbox renders (not onboarding) and
+// the "Manage tags" affordance is available.
+vi.mock("@/lib/workspace", () => ({
+	useWorkspace: () => ({
+		workspaces: [{ id: "ws1", name: "Acme" }],
+		workspaceId: "ws1",
+		role: "admin",
+		canManage: true,
+		isLoading: false,
+	}),
+}));
+
+vi.mock("@/lib/analytics", () => ({
+	track: vi.fn(),
+	ANALYTICS_EVENTS: new Proxy({}, { get: () => "evt" }),
+}));
+
+vi.mock("sonner", () => ({
+	toast: { success: vi.fn(), error: vi.fn(), warning: vi.fn() },
+}));
+
+// Only the transport is mocked; ApiError / describeApiError stay real.
+vi.mock("@/lib/api", async (orig) => ({
+	...(await orig<typeof import("@/lib/api")>()),
+	api: vi.fn(),
+}));
+
+// MessageThread (imported by the page) pulls useStickToBottom from the widget;
+// the thread isn't rendered in this test, but the import must resolve.
+vi.mock("@llmchat/widget/chat", () => ({
+	useStickToBottom: () => ({
+		containerRef: { current: null },
+		atBottom: true,
+		scrollToBottom: vi.fn(),
+	}),
+}));
+
+/** Every api() call, in order, so we can assert what the list refetched with. */
+let calls: { path: string; method: string }[];
+let tagsState: Tag[];
+
+function convPage(path: string) {
+	// Reflect the filter in the payload just enough to be realistic; the test
+	// asserts on the request URL, not these rows.
+	const url = new URL(`http://x${path}`);
+	const filtered = url.searchParams.get("tagIds");
+	const tags =
+		filtered && filtered.includes("t1")
+			? [{ id: "t1", name: "Billing", color: "#6366f1" }]
+			: tagsState.find((t) => t.id === "t1")
+				? [{ id: "t1", name: "Billing", color: "#6366f1" }]
+				: [];
+	return {
+		conversations: [
+			{
+				id: "c1",
+				clientId: "c",
+				name: "Bob",
+				email: null,
+				ipAddress: null,
+				userAgent: null,
+				messageCount: 1,
+				escalatedAt: null,
+				archivedAt: null,
+				createdAt: "2026-06-16T05:00:00.000Z",
+				updatedAt: "2026-06-16T05:00:00.000Z",
+				csatRating: null,
+				tags,
+			},
+		],
+		nextCursor: null,
+	};
+}
+
+function setupApi() {
+	calls = [];
+	tagsState = [
+		{ id: "t1", name: "Billing", color: "#6366f1", count: 2 },
+		{ id: "t2", name: "Bug", color: "#ef4444", count: 0 },
+	];
+	vi.mocked(api).mockImplementation(
+		async (path: string, opts: { method?: string } = {}) => {
+			const method = opts.method ?? "GET";
+			calls.push({ path, method });
+			if (path === "/api/projects")
+				return { projects: [{ id: "p1", name: "Bot", brandColor: "#000000" }] };
+			if (path === "/api/tags") return { tags: tagsState };
+			if (path.startsWith("/api/projects/p1/conversations/stats"))
+				return { total: 1, escalated: 0, resolved: 0, avgRating: null };
+			if (path.startsWith("/api/projects/p1/conversations"))
+				return convPage(path);
+			if (method === "DELETE" && path === "/api/tags/t1") {
+				tagsState = tagsState.filter((t) => t.id !== "t1");
+				return { ok: true };
+			}
+			return {};
+		},
+	);
+}
+
+function renderInbox() {
+	const client = new QueryClient({
+		defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+	});
+	render(
+		<QueryClientProvider client={client}>
+			<InboxPage />
+		</QueryClientProvider>,
+	);
+}
+
+const listCalls = () =>
+	calls.filter(
+		(c) =>
+			c.method === "GET" &&
+			c.path.startsWith("/api/projects/p1/conversations") &&
+			!c.path.includes("/stats"),
+	);
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	setupApi();
+});
+
+describe("InboxPage — deleting a filtered tag reconciles the filter", () => {
+	it("drops the deleted tag id from the active filter and refetches the list without it", async () => {
+		const user = userEvent.setup();
+		renderInbox();
+
+		// The inbox is ready once the project + tags have loaded.
+		await screen.findByRole("heading", { name: "Conversations" });
+		await waitFor(() => expect(listCalls().length).toBeGreaterThan(0));
+
+		// Select the "Billing" tag in the toolbar filter → it becomes part of the
+		// active filter and the list refetches scoped to it.
+		await user.click(screen.getByRole("button", { name: /^tags$/i }));
+		await user.click(await screen.findByRole("option", { name: /Billing/ }));
+		await waitFor(() =>
+			expect(listCalls().some((c) => c.path.includes("tagIds=t1"))).toBe(true),
+		);
+		// The filter now shows one active selection.
+		expect(screen.getByRole("button", { name: "Tags 1" })).toBeInTheDocument();
+
+		// Open Manage tags and delete the currently-filtered "Billing" tag.
+		await user.click(screen.getByRole("button", { name: /manage tags/i }));
+		const dialog = await screen.findByRole("dialog");
+		await user.click(
+			within(dialog).getByRole("button", { name: "Delete Billing" }),
+		);
+		const confirm = await screen.findByRole("alertdialog");
+		// Record where the call log is BEFORE the delete so we only inspect refetches
+		// that happen afterwards.
+		const before = calls.length;
+		await user.click(within(confirm).getByRole("button", { name: "Delete" }));
+
+		// 1) The list refetched with the CORRECTED filter: after the delete, a
+		//    conversations request fires with the deleted tag id gone from the filter
+		//    (no tagIds at all, since it was the only selection) — the list ends up
+		//    scoped without the dangling id.
+		const postList = () =>
+			calls
+				.slice(before)
+				.filter(
+					(c) =>
+						c.method === "GET" &&
+						c.path.startsWith("/api/projects/p1/conversations") &&
+						!c.path.includes("/stats"),
+				);
+		await waitFor(() => {
+			const post = postList();
+			expect(post.length).toBeGreaterThan(0);
+			// A corrected refetch (no tagIds) happened…
+			expect(post.some((c) => !c.path.includes("tagIds"))).toBe(true);
+			// …and the LATEST list request carries no tag filter (it settled corrected,
+			// never leaving the deleted id dangling on the server query).
+			expect(post.at(-1)!.path.includes("tagIds=t1")).toBe(false);
+		});
+
+		// 2) No dangling filter id in the UI either: close the (modal) manage dialog
+		//    and the toolbar filter no longer shows an active selection.
+		await user.keyboard("{Escape}");
+		await waitFor(() =>
+			expect(screen.queryByRole("dialog")).not.toBeInTheDocument(),
+		);
+		expect(screen.getByRole("button", { name: "Tags" })).toBeInTheDocument();
+		expect(
+			screen.queryByRole("button", { name: "Tags 1" }),
+		).not.toBeInTheDocument();
+	});
+});

--- a/apps/dashboard/src/app/inbox/page.test.tsx
+++ b/apps/dashboard/src/app/inbox/page.test.tsx
@@ -188,13 +188,13 @@ describe("InboxPage — deleting a filtered tag reconciles the filter", () => {
 				);
 		await waitFor(() => {
 			const post = postList();
-			expect(post.length).toBeGreaterThan(0);
-			// A corrected refetch (no tagIds) happened…
+			// A corrected refetch (no tagIds) happened on the new key.
 			expect(post.some((c) => !c.path.includes("tagIds"))).toBe(true);
-			// …and the LATEST list request carries no tag filter (it settled corrected,
-			// never leaving the deleted id dangling on the server query).
-			expect(post.at(-1)!.path.includes("tagIds=t1")).toBe(false);
 		});
+		// No transient stale request: NO post-delete list call carries the deleted
+		// tag id (the redundant conversations invalidation was dropped, so the stale
+		// key is never refetched).
+		expect(postList().every((c) => !c.path.includes("tagIds=t1"))).toBe(true);
 
 		// 2) No dangling filter id in the UI either: close the (modal) manage dialog
 		//    and the toolbar filter no longer shows an active selection.

--- a/apps/dashboard/src/app/inbox/page.tsx
+++ b/apps/dashboard/src/app/inbox/page.tsx
@@ -313,8 +313,12 @@ export default function InboxPage() {
 
 	// Delete: remove the tag from the tags query, strip its chips from every
 	// cached conversation, and reconcile the active filter — dropping the id (which
-	// changes the list/head query keys and refetches) so no dangling filter id
-	// remains. Then invalidate to settle against the server's cascade.
+	// changes the list/head query keys, so the list refetches on the corrected
+	// filter) so no dangling filter id remains. The conversations caches are NOT
+	// invalidated: the server cascade already removed the associations, the direct
+	// removeTagFromAllConversations patch reflects that, and invalidating would
+	// force a transient refetch on the stale (still-mounted) key — re-issuing a
+	// request with the just-deleted tagId before the key change lands.
 	const deleteTagMut = useMutation({
 		mutationFn: (tag: Tag) =>
 			api(`/api/tags/${tag.id}`, {
@@ -331,7 +335,6 @@ export default function InboxPage() {
 				removeTagFromAllConversations(prev, tag.id),
 			);
 			void qc.invalidateQueries({ queryKey: ["tags", workspaceId] });
-			void qc.invalidateQueries({ queryKey: ["conversations", projectId] });
 		},
 		onError: (e) => toast.error(describeApiError(e, "Couldn't delete the tag")),
 	});

--- a/apps/dashboard/src/app/inbox/page.tsx
+++ b/apps/dashboard/src/app/inbox/page.tsx
@@ -11,7 +11,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 
 import { Badge } from "@/components/ui/badge";
-import { api, describeApiError } from "@/lib/api";
+import { ApiError, api, describeApiError } from "@/lib/api";
 import { resolveOnboardingState } from "@/lib/onboarding";
 import { useOptimisticMutation } from "@/lib/optimistic";
 import { resolveSelectedId } from "@/lib/selection";
@@ -27,10 +27,12 @@ import {
 	dropConversationFromCache,
 	flattenPages,
 	mergeConversationPages,
+	removeTagFromAllConversations,
 	removeTagFromConversation,
 	setConversationRead,
 	type ConversationPage,
 } from "./_components/conversation-list";
+import { ManageTagsDialog } from "./_components/ManageTagsDialog";
 import { DetailPanel } from "./_components/DetailPanel";
 import { initials, parseDevice, pluralize } from "./_components/format";
 import { InboxPanes } from "./_components/InboxPanes";
@@ -54,6 +56,7 @@ export default function InboxPage() {
 	const {
 		workspaces,
 		workspaceId,
+		canManage,
 		isLoading: workspacesLoading,
 	} = useWorkspace();
 	const qc = useQueryClient();
@@ -64,6 +67,7 @@ export default function InboxPage() {
 	const [search, setSearch] = useState("");
 	const [showArchived, setShowArchived] = useState(false);
 	const [tagIds, setTagIds] = useState<string[]>([]);
+	const [manageTagsOpen, setManageTagsOpen] = useState(false);
 	// Contact-details sheet (mobile/tablet); on desktop details are a permanent aside.
 	const [detailsOpen, setDetailsOpen] = useState(false);
 
@@ -283,6 +287,61 @@ export default function InboxPage() {
 		createTagMut.mutate({ id: selectedId, name });
 	}
 
+	// ── Global tag management (admin/owner) ──────────────────────────────────
+	// Rename/recolor: tag ids are stable, so after the write we just invalidate
+	// the tags query (picker/filter) AND the conversations prefix (head + every
+	// list variant) so the denormalized chips re-render with the new name/color.
+	const patchTagMut = useMutation({
+		mutationFn: (vars: { tag: Tag; name?: string; color?: string }) =>
+			api<{ tag: Tag }>(`/api/tags/${vars.tag.id}`, {
+				method: "PATCH",
+				body: { name: vars.name, color: vars.color },
+				workspaceId: workspaceId!,
+			}),
+		onSuccess: () => {
+			toast.success("Tag updated");
+			void qc.invalidateQueries({ queryKey: ["tags", workspaceId] });
+			void qc.invalidateQueries({ queryKey: ["conversations", projectId] });
+		},
+		onError: (e) =>
+			toast.error(
+				e instanceof ApiError && e.status === 409
+					? "A tag with that name already exists."
+					: describeApiError(e, "Couldn't update the tag"),
+			),
+	});
+
+	// Delete: remove the tag from the tags query, strip its chips from every
+	// cached conversation, and reconcile the active filter — dropping the id (which
+	// changes the list/head query keys and refetches) so no dangling filter id
+	// remains. Then invalidate to settle against the server's cascade.
+	const deleteTagMut = useMutation({
+		mutationFn: (tag: Tag) =>
+			api(`/api/tags/${tag.id}`, {
+				method: "DELETE",
+				workspaceId: workspaceId!,
+			}),
+		onSuccess: (_data, tag) => {
+			toast.success(`Deleted “${tag.name}”`);
+			setTagIds((prev) => prev.filter((id) => id !== tag.id));
+			qc.setQueryData<{ tags: Tag[] }>(["tags", workspaceId], (prev) =>
+				prev ? { tags: prev.tags.filter((t) => t.id !== tag.id) } : prev,
+			);
+			qc.setQueriesData({ queryKey: ["conversations", projectId] }, (prev) =>
+				removeTagFromAllConversations(prev, tag.id),
+			);
+			void qc.invalidateQueries({ queryKey: ["tags", workspaceId] });
+			void qc.invalidateQueries({ queryKey: ["conversations", projectId] });
+		},
+		onError: (e) => toast.error(describeApiError(e, "Couldn't delete the tag")),
+	});
+
+	const tagBusyId = patchTagMut.isPending
+		? (patchTagMut.variables?.tag.id ?? null)
+		: deleteTagMut.isPending
+			? (deleteTagMut.variables?.id ?? null)
+			: null;
+
 	// Mark a conversation read for this user. Optimistically clears the unread dot
 	// in-cache across the head + loaded pages (so a row deep in a loaded page
 	// clears instantly without any refetch), then PATCHes. Best-effort: on failure
@@ -477,6 +536,7 @@ export default function InboxPage() {
 					tags={allTags}
 					tagIds={tagIds}
 					onTagIdsChange={setTagIds}
+					onManageTags={canManage ? () => setManageTagsOpen(true) : undefined}
 				/>
 			</div>
 
@@ -611,6 +671,18 @@ export default function InboxPage() {
 					</div>
 				}
 			/>
+
+			{canManage && (
+				<ManageTagsDialog
+					open={manageTagsOpen}
+					onOpenChange={setManageTagsOpen}
+					tags={allTags}
+					busyId={tagBusyId}
+					onRename={(tag, name) => patchTagMut.mutate({ tag, name })}
+					onRecolor={(tag, color) => patchTagMut.mutate({ tag, color })}
+					onDelete={(tag) => deleteTagMut.mutate(tag)}
+				/>
+			)}
 		</div>
 	);
 }

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -12,6 +12,7 @@ export { schema };
 export * from "./schema";
 export {
 	eq,
+	ne,
 	and,
 	or,
 	desc,

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -9,6 +9,7 @@ export {
 	setStoredConsent,
 } from "./consent";
 export { resolveSiblingUrl } from "./preview-url";
+export { TAG_PALETTE, type TagColor, isPaletteColor } from "./tag-colors";
 export {
 	DEFAULT_MODEL,
 	effectiveModel,

--- a/packages/shared/src/tag-colors.ts
+++ b/packages/shared/src/tag-colors.ts
@@ -1,0 +1,24 @@
+/**
+ * The fixed tag palette — the single source of truth shared by the API (which
+ * validates a recolor against it) and the dashboard (which renders the swatches).
+ * Keeping it here means the swatches a user can pick and the colors the server
+ * accepts can never drift apart.
+ */
+export const TAG_PALETTE = [
+	"#6366f1", // indigo
+	"#0ea5e9", // sky
+	"#10b981", // emerald
+	"#f59e0b", // amber
+	"#ef4444", // red
+	"#ec4899", // pink
+	"#8b5cf6", // violet
+	"#14b8a6", // teal
+] as const;
+
+export type TagColor = (typeof TAG_PALETTE)[number];
+
+/** Whether `value` is one of the fixed palette colors (case-insensitive). */
+export function isPaletteColor(value: string): value is TagColor {
+	const v = value.toLowerCase();
+	return (TAG_PALETTE as readonly string[]).some((c) => c.toLowerCase() === v);
+}


### PR DESCRIPTION
Small follow-up to #58. Global tag management: rename, recolor (palette), and delete tags from the inbox. No schema change — uses the `tag` + `conversation_tag` tables and the `0013` cascade from #58.

## API
- **`PATCH /tags/:tagId`** `{ name?, color? }` — admin+ (`requireRole`), workspace-scoped.
  - **Rename:** trim, validate 1–40, **case-insensitive dedupe excluding self** (renaming to a tag's own name/casing is allowed; colliding with a *different* tag → **409**, no change).
  - **Recolor:** validated against the fixed palette → off-palette **400**.
  - **`updateInput`** is all-optional with **no `.partial()`/`.default()`** (the Zod-v4 footgun) and only writes provided fields — a color-only PATCH never blanks `name`, and vice versa (per-field no-clobber test).
- **`DELETE /tags/:tagId`** — admin+, workspace-scoped; the `0013` cascade FK removes its `conversation_tag` rows.
- **Tenant:** `tag.workspace_id` must equal the caller's workspace or **404** — no cross-workspace rename/delete, tested both directions. Create/assign stay open to any member, unchanged.
- **Shared single-source:** moved `TAG_PALETTE` + `isPaletteColor` to `@llmchat/shared` so the colors the server validates and the swatches the dashboard renders can't drift; `apps/api/lib/tag-colors` re-exports them. Added `ne` to the `@llmchat/db` re-exports.

## UI
A **"Manage tags"** link in the tag-filter popover footer (admin/owner only — gated by `canManage`; the API enforces the same). It opens a dialog listing every workspace tag with its color + conversation count, with **inline rename**, **palette recolor**, and **delete** behind a confirm that states impact with the real count — *"Delete 'Billing'? It will be removed from 12 conversations."*

## Cache coherence (the careful part)
Chips render from two sources — the `GET /tags` query (picker/filter) and the denormalized `conversation.tags` on list rows.
- **Rename/recolor:** invalidate the **tags** query and the **conversations prefix** (head + every list variant) so chips re-render with the new name/color. Tag ids are stable across rename, so an active filter selection stays valid by id.
- **Delete:** remove the tag from the tags query, strip its chips from **all** cached conversations, and **reconcile the active filter** — if the deleted id is selected, drop it (which changes the list/head query keys → refetch), so no dangling filter id remains. Then invalidate to settle against the server cascade.

## Tests (all green)
API **244** (+14): cross-workspace rename/delete → 404; case-insensitive collision → 409; rename-to-own-casing allowed; per-field no-clobber (color-only doesn't blank name & vice versa); off-palette color → 400; name validation; **agent → 403 on rename/delete** while still able to create/assign; cascade-delete proven on scratch SQLite back in #58. Dashboard **298** (+10): `removeTagFromAllConversations` (delete strips chips across both cache shapes); ManageTagsDialog **rename / recolor (palette hex) / delete-confirm-with-count / empty state**; **"Manage tags" link visible only when `onManage` is provided** (admin/owner proxy).

Gates: `pnpm build` (5/5), `pnpm test`, `pnpm lint`, prettier `--check`, secret scan — clean. Unrelated drift (`.agents/*`, `skills-lock.json`, `consent.ts`, `docs/`) left unstaged.

### RTL assertions standing in for screenshots (no headless browser)
- **rename:** edit → type "Payments" + Enter → `onRename(tag, "Payments")`; unchanged name → not called.
- **recolor:** open swatches → click `#10b981` → `onRecolor(tag, "#10b981")`.
- **delete confirm:** names the tag + "removed from 12 conversations"; a 0-count tag says "isn't on any conversations"; confirm → `onDelete(tag)`.
- **admin-only:** the Manage-tags link only renders when `onManageTags` is passed (the page passes it only when `canManage`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)