### PR TITLE
feat(account): minimal account-settings page (PR1 — non-destructive)

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -3,6 +3,7 @@ import { cors } from "hono/cors";
 
 import { createAuth } from "@/auth";
 import { isAllowedOrigin } from "@/lib/origins";
+import { account } from "@/routes/account";
 import { billing } from "@/routes/billing";
 import { chat } from "@/routes/chat";
 import { conversations } from "@/routes/conversations";
@@ -84,6 +85,7 @@ app.route("/v1", widgetMessages);
 app.route("/v1", widgetRating);
 app.route("/v1", widgetCsat);
 app.route("/api", oauthProviders);
+app.route("/api", account);
 app.route("/api", workspaces);
 app.route("/api", projects);
 app.route("/api", systemPrompts);

--- a/apps/api/src/routes/account.test.ts
+++ b/apps/api/src/routes/account.test.ts
@@ -1,0 +1,157 @@
+import { SQLiteSyncDialect } from "drizzle-orm/sqlite-core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { db } from "@/lib/db";
+
+import { account } from "./account";
+
+// Render a captured drizzle WHERE to SQL so a test can prove the update is keyed
+// to the SESSION user (and never to an id from the request body).
+const dialect = new SQLiteSyncDialect({ casing: "snake_case" });
+
+// Header-driven fake session: `x-test-user` present ⇒ that user is signed in.
+vi.mock("@/auth", () => ({
+	createAuth: () => ({
+		api: {
+			getSession: async ({ headers }: { headers: Headers }) => {
+				const id = headers.get("x-test-user");
+				return id ? { user: { id } } : null;
+			},
+		},
+	}),
+}));
+
+vi.mock("@/lib/db", () => ({ db: vi.fn() }));
+
+const ENV = { vars: {}, DB: {} } as unknown as Parameters<
+	typeof account.request
+>[2];
+
+interface State {
+	/** The row query.user.findFirst resolves (undefined ⇒ 404). */
+	user?: { name: string; email: string };
+}
+
+let updateSpy: ReturnType<typeof vi.fn>;
+let lastSet: Record<string, unknown> | null;
+let lastWhere: Parameters<typeof dialect.sqlToQuery>[0] | null;
+
+function mockDb(state: State) {
+	lastSet = null;
+	lastWhere = null;
+	updateSpy = vi.fn(() => ({
+		set: (data: Record<string, unknown>) => {
+			lastSet = data;
+			return {
+				where: (cond: Parameters<typeof dialect.sqlToQuery>[0]) => {
+					lastWhere = cond;
+					return {
+						returning: async () => [
+							{
+								name: (data.name as string) ?? state.user?.name ?? "",
+								email: state.user?.email ?? "me@x.io",
+							},
+						],
+					};
+				},
+			};
+		},
+	}));
+	const fake = {
+		query: {
+			user: { findFirst: async () => state.user },
+		},
+		update: updateSpy,
+	};
+	vi.mocked(db).mockReturnValue(fake as unknown as ReturnType<typeof db>);
+}
+
+const ME = { "x-test-user": "u1" };
+const json = { "content-type": "application/json" };
+
+function get(headers: Record<string, string>) {
+	return account.request("/account", { method: "GET", headers }, ENV);
+}
+function patch(body: unknown, headers: Record<string, string> = ME) {
+	return account.request(
+		"/account",
+		{
+			method: "PATCH",
+			headers: { ...headers, ...json },
+			body: JSON.stringify(body),
+		},
+		ENV,
+	);
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("GET /account", () => {
+	it("401s without a session", async () => {
+		mockDb({});
+		expect((await get({})).status).toBe(401);
+	});
+
+	it("returns the signed-in user's own profile", async () => {
+		mockDb({ user: { name: "Ada Lovelace", email: "ada@x.io" } });
+		const res = await get(ME);
+		expect(res.status).toBe(200);
+		expect(await res.json()).toEqual({
+			name: "Ada Lovelace",
+			email: "ada@x.io",
+		});
+	});
+});
+
+describe("PATCH /account", () => {
+	it("401s without a session; never updates", async () => {
+		mockDb({});
+		const res = await patch({ name: "New" }, {});
+		expect(res.status).toBe(401);
+		expect(updateSpy).not.toHaveBeenCalled();
+	});
+
+	it("updates the name and returns the profile", async () => {
+		mockDb({ user: { name: "Ada", email: "ada@x.io" } });
+		const res = await patch({ name: "Grace Hopper" });
+		expect(res.status).toBe(200);
+		expect(await res.json()).toEqual({
+			name: "Grace Hopper",
+			email: "ada@x.io",
+		});
+		// Only name (+ updatedAt) is written — no other columns.
+		expect(Object.keys(lastSet ?? {}).sort()).toEqual(["name", "updatedAt"]);
+		expect(lastSet).toMatchObject({ name: "Grace Hopper" });
+	});
+
+	it("400s an empty / whitespace-only name; never updates", async () => {
+		mockDb({ user: { name: "Ada", email: "ada@x.io" } });
+		expect((await patch({ name: "" })).status).toBe(400);
+		expect((await patch({ name: "   " })).status).toBe(400);
+		expect(updateSpy).not.toHaveBeenCalled();
+	});
+
+	it("400s an over-length name (>100); never updates", async () => {
+		mockDb({ user: { name: "Ada", email: "ada@x.io" } });
+		expect((await patch({ name: "x".repeat(101) })).status).toBe(400);
+		expect(updateSpy).not.toHaveBeenCalled();
+	});
+
+	it("is self-only: the update is keyed to the SESSION user, and a smuggled id is ignored", async () => {
+		mockDb({ user: { name: "Ada", email: "ada@x.io" } });
+		// Try to target another user via the body — it must have no effect.
+		const res = await patch({
+			name: "Renamed",
+			id: "victim",
+			userId: "victim",
+		});
+		expect(res.status).toBe(200);
+		// The write is scoped to the session user u1, never "victim".
+		const { params } = dialect.sqlToQuery(lastWhere!);
+		expect(params).toContain("u1");
+		expect(params).not.toContain("victim");
+		// And the smuggled fields never reached the column set.
+		expect(lastSet).not.toHaveProperty("id");
+		expect(lastSet).not.toHaveProperty("userId");
+	});
+});

--- a/apps/api/src/routes/account.ts
+++ b/apps/api/src/routes/account.ts
@@ -1,0 +1,50 @@
+import { zValidator } from "@hono/zod-validator";
+import { Hono } from "hono";
+import { z } from "zod";
+
+import { db } from "@/lib/db";
+import { requireSession } from "@/middleware/session";
+
+import { eq, user } from "@llmchat/db";
+
+import type { AppContext } from "@/env";
+
+// UPDATE validator: a single required field, NO `.partial()`/`.default()` (the
+// Zod-v4 footgun where a default fires on an absent key). `.trim()` runs before
+// `.min(1)`, so a whitespace-only name fails validation (400). Unknown keys
+// (e.g. an attempt to smuggle an `id`) are stripped by Zod — the handler never
+// reads anything but `name` from the body.
+const updateInput = z.object({
+	name: z.string().trim().min(1).max(100),
+});
+
+/**
+ * The caller's OWN account. Every handler derives the user from the session
+ * (requireSession sets `userId`); no user id is ever accepted from the request,
+ * so these endpoints can only ever read/mutate the signed-in user. PR2 extends
+ * GET with deletion impact and adds the destructive DELETE — kept separate so
+ * the dangerous path is reviewed in isolation.
+ */
+export const account = new Hono<AppContext>()
+	.use("*", requireSession)
+	.get("/account", async (c) => {
+		const userId = c.get("userId");
+		const me = await db(c.env).query.user.findFirst({
+			where: (u, { eq: e }) => e(u.id, userId),
+			columns: { name: true, email: true },
+		});
+		if (!me) return c.json({ error: "not found" }, 404);
+		return c.json({ name: me.name, email: me.email });
+	})
+	.patch("/account", zValidator("json", updateInput), async (c) => {
+		const userId = c.get("userId");
+		const { name } = c.req.valid("json");
+		// Name isn't auth-sensitive, so a direct column update is simplest and
+		// keeps the write keyed to the SESSION user — never an id from the body.
+		const [updated] = await db(c.env)
+			.update(user)
+			.set({ name: name.trim(), updatedAt: new Date() })
+			.where(eq(user.id, userId))
+			.returning({ name: user.name, email: user.email });
+		return c.json({ name: updated!.name, email: updated!.email });
+	});

--- a/apps/dashboard/src/app/settings/account/layout.tsx
+++ b/apps/dashboard/src/app/settings/account/layout.tsx
@@ -1,0 +1,9 @@
+import { DashboardGate } from "@/components/dashboard-gate";
+
+export default function AccountLayout({
+	children,
+}: {
+	children: React.ReactNode;
+}) {
+	return <DashboardGate>{children}</DashboardGate>;
+}

--- a/apps/dashboard/src/app/settings/account/page.test.tsx
+++ b/apps/dashboard/src/app/settings/account/page.test.tsx
@@ -1,0 +1,115 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { api } from "@/lib/api";
+
+import AccountSettingsPage from "./page";
+
+const toastSuccess = vi.fn();
+vi.mock("sonner", () => ({
+	toast: { success: (m: string) => toastSuccess(m), error: vi.fn() },
+}));
+
+// Only the transport is mocked; describeApiError stays real.
+vi.mock("@/lib/api", async (orig) => ({
+	...(await orig<typeof import("@/lib/api")>()),
+	api: vi.fn(),
+}));
+
+let calls: { path: string; method: string; body?: unknown }[];
+let profile: { name: string; email: string };
+
+function setupApi() {
+	calls = [];
+	profile = { name: "Ada Lovelace", email: "ada@example.io" };
+	vi.mocked(api).mockImplementation(
+		async (path: string, opts: { method?: string; body?: unknown } = {}) => {
+			const method = opts.method ?? "GET";
+			calls.push({ path, method, body: opts.body });
+			if (path === "/api/account" && method === "PATCH") {
+				profile = { ...profile, name: (opts.body as { name: string }).name };
+			}
+			return profile;
+		},
+	);
+}
+
+function renderPage() {
+	const client = new QueryClient({
+		defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+	});
+	render(
+		<QueryClientProvider client={client}>
+			<AccountSettingsPage />
+		</QueryClientProvider>,
+	);
+}
+
+beforeEach(() => {
+	toastSuccess.mockClear();
+	setupApi();
+});
+
+describe("AccountSettingsPage", () => {
+	it("shows the name (editable) and the email (read-only) with the support note", async () => {
+		renderPage();
+		const nameInput = await screen.findByLabelText("Name");
+		expect(nameInput).toHaveValue("Ada Lovelace");
+		expect(nameInput).not.toHaveAttribute("readonly");
+
+		const emailInput = screen.getByLabelText("Email (read-only)");
+		expect(emailInput).toHaveValue("ada@example.io");
+		expect(emailInput).toHaveAttribute("readonly");
+		expect(
+			screen.getByText(/contact support to change your email/i),
+		).toBeInTheDocument();
+	});
+
+	it("has a Billing link to the billing page", async () => {
+		renderPage();
+		await screen.findByLabelText("Name");
+		const link = screen.getByRole("link", { name: /billing/i });
+		expect(link).toHaveAttribute("href", "/settings/billing");
+	});
+
+	it("disables Save until the name changes, then PATCHes and toasts", async () => {
+		const user = userEvent.setup();
+		renderPage();
+		const nameInput = await screen.findByLabelText("Name");
+
+		// Unchanged → Save is disabled.
+		expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+
+		await user.clear(nameInput);
+		await user.type(nameInput, "Grace Hopper");
+		const saveBtn = screen.getByRole("button", { name: "Save" });
+		expect(saveBtn).toBeEnabled();
+		await user.click(saveBtn);
+
+		await waitFor(() => {
+			const patch = calls.find((c) => c.method === "PATCH");
+			expect(patch).toBeTruthy();
+			expect(patch!.path).toBe("/api/account");
+			expect(patch!.body).toEqual({ name: "Grace Hopper" });
+		});
+		await waitFor(() =>
+			expect(toastSuccess).toHaveBeenCalledWith("Name updated"),
+		);
+		// The field reflects the saved value and Save goes disabled again.
+		expect(nameInput).toHaveValue("Grace Hopper");
+		await waitFor(() =>
+			expect(screen.getByRole("button", { name: "Save" })).toBeDisabled(),
+		);
+	});
+
+	it("does not save a whitespace-only name (Save stays disabled)", async () => {
+		const user = userEvent.setup();
+		renderPage();
+		const nameInput = await screen.findByLabelText("Name");
+		await user.clear(nameInput);
+		await user.type(nameInput, "   ");
+		expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+	});
+});

--- a/apps/dashboard/src/app/settings/account/page.tsx
+++ b/apps/dashboard/src/app/settings/account/page.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { CreditCard, Info } from "lucide-react";
+import Link from "next/link";
+import { useState } from "react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+	ACCOUNT_KEY,
+	fetchAccount,
+	updateAccountName,
+	type Account,
+} from "@/lib/account";
+import { describeApiError } from "@/lib/api";
+
+const NAME_MAX = 100;
+
+export default function AccountSettingsPage() {
+	const qc = useQueryClient();
+	const accountQ = useQuery({ queryKey: ACCOUNT_KEY, queryFn: fetchAccount });
+
+	// Draft name, seeded from the loaded profile. Keyed on the loaded value so a
+	// background refetch that changes the server name re-seeds the field (when the
+	// user hasn't started editing — see `dirty`).
+	const loadedName = accountQ.data?.name ?? "";
+	const [draft, setDraft] = useState<string | null>(null);
+	const name = draft ?? loadedName;
+	const trimmed = name.trim();
+	const dirty = draft !== null && trimmed !== loadedName;
+
+	const save = useMutation({
+		mutationFn: () => updateAccountName(trimmed),
+		onSuccess: (data: Account) => {
+			qc.setQueryData(ACCOUNT_KEY, data);
+			setDraft(null);
+			toast.success("Name updated");
+		},
+		onError: (e) =>
+			toast.error(describeApiError(e, "Couldn't update your name")),
+	});
+
+	return (
+		<div className="mx-auto w-full max-w-[800px] space-y-6 p-6">
+			<header>
+				<h1 className="font-display text-2xl font-semibold tracking-tight-display">
+					Account
+				</h1>
+				<p className="mt-0.5 text-sm text-muted-foreground">
+					Manage your personal account details.
+				</p>
+			</header>
+
+			<Card>
+				<CardHeader>
+					<CardTitle>Profile</CardTitle>
+					<CardDescription>
+						Your name and the email you sign in with.
+					</CardDescription>
+				</CardHeader>
+				<CardContent className="space-y-5">
+					{accountQ.isLoading ? (
+						<div className="space-y-4">
+							<Skeleton className="h-10 w-full" />
+							<Skeleton className="h-10 w-full" />
+						</div>
+					) : (
+						<>
+							<form
+								className="flex flex-col gap-1.5"
+								onSubmit={(e) => {
+									e.preventDefault();
+									if (dirty && trimmed) save.mutate();
+								}}
+							>
+								<Label htmlFor="account-name">Name</Label>
+								<div className="flex flex-col gap-2 sm:flex-row">
+									<Input
+										id="account-name"
+										value={name}
+										maxLength={NAME_MAX}
+										onChange={(e) => setDraft(e.target.value)}
+										placeholder="Your name"
+										autoComplete="name"
+									/>
+									<Button
+										type="submit"
+										disabled={!dirty || !trimmed || save.isPending}
+										className="shrink-0"
+									>
+										{save.isPending ? "Saving…" : "Save"}
+									</Button>
+								</div>
+							</form>
+
+							<div className="flex flex-col gap-1.5">
+								<Label htmlFor="account-email">Email</Label>
+								<Input
+									id="account-email"
+									value={accountQ.data?.email ?? ""}
+									readOnly
+									disabled
+									aria-label="Email (read-only)"
+								/>
+								<p className="flex items-center gap-1.5 text-xs text-muted-foreground">
+									<Info className="size-3.5 shrink-0" />
+									Contact support to change your email.
+								</p>
+							</div>
+						</>
+					)}
+				</CardContent>
+			</Card>
+
+			<Card>
+				<CardHeader>
+					<CardTitle>Billing</CardTitle>
+					<CardDescription>
+						Manage your workspace plan and subscription.
+					</CardDescription>
+				</CardHeader>
+				<CardContent>
+					<Button asChild variant="outline">
+						<Link href="/settings/billing">
+							<CreditCard />
+							Go to Billing
+						</Link>
+					</Button>
+				</CardContent>
+			</Card>
+		</div>
+	);
+}

--- a/apps/dashboard/src/components/app-sidebar.tsx
+++ b/apps/dashboard/src/components/app-sidebar.tsx
@@ -14,6 +14,7 @@ import {
 	LogOut,
 	MessagesSquare,
 	Plus,
+	UserCog,
 } from "lucide-react";
 
 import { api } from "@/lib/api";
@@ -341,6 +342,13 @@ export function AppSidebar({ userEmail }: { userEmail: string }) {
 								<DropdownMenuLabel className="truncate text-xs text-muted-foreground">
 									{userEmail}
 								</DropdownMenuLabel>
+								<DropdownMenuSeparator />
+								<DropdownMenuItem asChild>
+									<Link href="/settings/account">
+										<UserCog />
+										Account
+									</Link>
+								</DropdownMenuItem>
 								{workspaces.length > 1 && (
 									<>
 										<DropdownMenuSeparator />

--- a/apps/dashboard/src/lib/account.ts
+++ b/apps/dashboard/src/lib/account.ts
@@ -1,0 +1,18 @@
+import { api } from "@/lib/api";
+
+/** The signed-in user's own profile (session-scoped; no id is ever sent). */
+export interface Account {
+	name: string;
+	email: string;
+}
+
+/** react-query key for the account profile. */
+export const ACCOUNT_KEY = ["account"] as const;
+
+export function fetchAccount() {
+	return api<Account>("/api/account");
+}
+
+export function updateAccountName(name: string) {
+	return api<Account>("/api/account", { method: "PATCH", body: { name } });
+}


### PR DESCRIPTION
**PR1 of 2** for the account-settings feature — **non-destructive only**. The dangerous core (shared workspace-deletion service + `DELETE /api/account` + danger zone, with the FKs-off cascade proof, live+fail-closed sub-gate, re-auth, and co-owner guard) lands separately in **PR2** so it can be reviewed in isolation.

## API (`apps/api`)
- **`routes/account.ts`** (new), mounted under `/api`, behind `requireSession`:
  - **`GET /account`** → the caller's own `{ name, email }`.
  - **`PATCH /account`** → `{ name }` only: trim + validate 1–100 (empty/whitespace → 400), direct `user.name` update.
  - **Self-only by construction:** the user comes from the **session** (`requireSession` sets `userId`); no id is accepted from the request. The update validator carries **no `.partial()`/`.default()`**, unknown body keys are stripped by Zod, and the write is keyed to the session user.
- Kept cleanly extendable — PR2 adds deletion-impact to `GET` and the destructive `DELETE`.

## Dashboard (`apps/dashboard`)
- **`/settings/account` page** — editable **Name** (mutation + toast, reflects on save, Save gated until a real change), **read-only Email** with *"Contact support to change your email."*, and a **Billing** link.
- **`lib/account.ts`** — api helpers/types.
- **Sidebar** — an **"Account"** item in the footer account dropdown (→ `/settings/account`), not a new top-level nav row.
- No delete/danger-zone UI, no `/settings/workspace` retirement, no deletion endpoint — all PR2.

## Tests (all green)
API **251** (+7): GET/PATCH without a session → 401; empty/whitespace name → 400; over-length (>100) → 400; PATCH writes **only** `name` (+`updatedAt`) keyed to the **session user** and ignores a smuggled `id`/`userId` (asserted by rendering the captured WHERE — params contain the session id, never `victim`). Dashboard **303** (+4): renders name (editable) + email (read-only) + support note; Billing link → `/settings/billing`; name save PATCHes `{name}` + toasts + reflects; whitespace-only name keeps Save disabled.

Gates: `pnpm build` (5/5), `pnpm test`, `pnpm lint`, prettier `--check`, secret scan — clean. Unrelated drift (`.agents/*`, `skills-lock.json`, `consent.ts`, `docs/`) left unstaged.

### RTL assertions (stand-ins for screenshots — no headless browser)
- name input editable with the loaded value; **email input `readonly`** + the support note text present.
- **Billing** link asserts `href="/settings/billing"`.
- type a new name → Save enables → PATCH `{name:"Grace Hopper"}` → "Name updated" toast → field reflects → Save disabled again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)