### PR TITLE
feat(account): delete my account — destructive core (PR2)

### DIFF
--- a/apps/api/src/lib/stripe.ts
+++ b/apps/api/src/lib/stripe.ts
@@ -73,6 +73,46 @@ async function stripePost<T>(
 	return JSON.parse(text) as T;
 }
 
+async function stripeGet<T>(secretKey: string, path: string): Promise<T> {
+	const res = await fetch(`${STRIPE_API}${path}`, {
+		headers: { Authorization: `Bearer ${secretKey}` },
+	});
+	const text = await res.text();
+	if (!res.ok) {
+		let message = "request failed";
+		try {
+			message =
+				(JSON.parse(text) as { error?: { message?: string } })?.error
+					?.message ?? message;
+		} catch {
+			// Non-JSON error body — keep the default; raw text is on .body.
+		}
+		throw new StripeError(res.status, text, message);
+	}
+	return JSON.parse(text) as T;
+}
+
+/** A Stripe subscription — only the status we gate on. The full Stripe status
+ * set: active, trialing, past_due, unpaid, paused, canceled, incomplete,
+ * incomplete_expired. */
+export interface StripeSubscription {
+	id: string;
+	status: string;
+}
+
+/** Fetch a subscription by id. Throws StripeError on a non-2xx (e.g. the sub
+ * was deleted ⇒ 404) — the account-deletion gate treats any throw as
+ * "can't verify" and fails closed. */
+export function retrieveSubscription(
+	secretKey: string,
+	id: string,
+): Promise<StripeSubscription> {
+	return stripeGet<StripeSubscription>(
+		secretKey,
+		`/subscriptions/${encodeURIComponent(id)}`,
+	);
+}
+
 export interface StripeCustomer {
 	id: string;
 }

--- a/apps/api/src/lib/workspace-deletion.test.ts
+++ b/apps/api/src/lib/workspace-deletion.test.ts
@@ -1,0 +1,341 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createDb } from "@llmchat/db";
+
+import {
+	assertDeletable,
+	gateWorkspace,
+	userDeleteStatements,
+	workspaceDeleteStatements,
+	type OwnedWorkspace,
+} from "./workspace-deletion";
+
+// retrieveSubscription is mocked so the sub-gate matrix is deterministic and
+// makes NO real network call.
+vi.mock("@/lib/stripe", () => ({ retrieveSubscription: vi.fn() }));
+import { retrieveSubscription } from "@/lib/stripe";
+
+// A build-only drizzle instance (the D1 client is never invoked — we only call
+// `.toSQL()` to render the EXACT statements the service generates).
+const buildDb = createDb({} as never);
+
+// ─── schema + raw exec helpers ────────────────────────────────────────────────
+
+/** Apply every committed migration to a fresh sqlite db to build the real prod
+ * schema (the same source of truth prod uses). */
+function freshDb(foreignKeys: boolean): DatabaseSync {
+	const db = new DatabaseSync(":memory:");
+	db.exec(`PRAGMA foreign_keys=${foreignKeys ? "ON" : "OFF"};`);
+	const dir = join(process.cwd(), "migrations");
+	const files = readdirSync(dir)
+		.filter((f) => f.endsWith(".sql"))
+		.sort();
+	for (const f of files) {
+		const sql = readFileSync(join(dir, f), "utf8")
+			.split("--> statement-breakpoint")
+			.join("\n");
+		db.exec(sql);
+	}
+	return db;
+}
+
+/** Execute a rendered drizzle statement ({sql, params}) against the raw db. */
+function run(
+	db: DatabaseSync,
+	stmt: { toSQL: () => { sql: string; params: unknown[] } },
+) {
+	const { sql, params } = stmt.toSQL();
+	db.prepare(sql).run(...(params as (string | number | null)[]));
+}
+
+function count(db: DatabaseSync, table: string): number {
+	return (
+		db.prepare(`SELECT count(*) AS n FROM "${table}"`).get() as { n: number }
+	).n;
+}
+
+// Seed a complete workspace subtree (one row per table under workspace ws1,
+// owned by user u1) plus an UNRELATED workspace ws2/user u2 that must survive.
+function seedWorkspace(db: DatabaseSync) {
+	const x = (sql: string) => db.exec(sql);
+	x(
+		`INSERT INTO user (id,name,email) VALUES ('u1','U1','u1@x.io'),('u2','U2','u2@x.io')`,
+	);
+	x(
+		`INSERT INTO workspace (id,name,owner_id) VALUES ('ws1','W1','u1'),('ws2','W2','u2')`,
+	);
+	x(
+		`INSERT INTO member (id,workspace_id,user_id,role) VALUES ('m1','ws1','u1','owner'),('m2','ws2','u2','owner')`,
+	);
+	x(
+		`INSERT INTO project (id,workspace_id,name,public_key,inbound_email_local) VALUES ('p1','ws1','P1','pk1','in1'),('p2','ws2','P2','pk2','in2')`,
+	);
+	x(
+		`INSERT INTO conversation (id,project_id,client_id) VALUES ('c1','p1','cl1'),('c2','p2','cl2')`,
+	);
+	x(
+		`INSERT INTO message (id,conversation_id,role,content,sequence) VALUES ('msg1','c1','user','hi',1),('msg2','c2','user','hi',1)`,
+	);
+	x(
+		`INSERT INTO source (id,project_id,kind) VALUES ('s1','p1','url'),('s2','p2','url')`,
+	);
+	x(
+		`INSERT INTO system_prompt (id,project_id,name) VALUES ('sp1','p1','SP'),('sp2','p2','SP')`,
+	);
+	x(
+		`INSERT INTO tag (id,workspace_id,name) VALUES ('t1','ws1','Billing'),('t2','ws2','Bug')`,
+	);
+	x(
+		`INSERT INTO conversation_tag (id,conversation_id,tag_id) VALUES ('ct1','c1','t1'),('ct2','c2','t2')`,
+	);
+	x(
+		`INSERT INTO read_status (id,conversation_id,user_id) VALUES ('rs1','c1','u1'),('rs2','c2','u2')`,
+	);
+	x(
+		`INSERT INTO usage_event (id,workspace_id,project_id,conversation_id,message_id,model) VALUES ('ue1','ws1','p1','c1','msg1','m'),('ue2','ws2','p2','c2','msg2','m')`,
+	);
+}
+
+const WS_CHILD_TABLES = [
+	"member",
+	"project",
+	"conversation",
+	"message",
+	"source",
+	"system_prompt",
+	"tag",
+	"conversation_tag",
+	"read_status",
+	"usage_event",
+];
+
+describe("deleteWorkspaceCascade — explicit deletes (no reliance on FK cascade)", () => {
+	for (const fk of [false, true]) {
+		it(`removes every child row of ws1 with foreign_keys=${fk ? "ON" : "OFF"}, leaving ws2 intact`, () => {
+			const db = freshDb(fk);
+			seedWorkspace(db);
+
+			// Run the REAL generated statements, in order, as a D1 batch would.
+			for (const stmt of workspaceDeleteStatements(buildDb, "ws1")) {
+				run(db, stmt as never);
+			}
+
+			// ws1 and every table under it is empty of ws1's rows…
+			expect(count(db, "workspace")).toBe(1); // only ws2 remains
+			expect(
+				(
+					db
+						.prepare(`SELECT count(*) AS n FROM workspace WHERE id='ws1'`)
+						.get() as { n: number }
+				).n,
+			).toBe(0);
+			for (const t of WS_CHILD_TABLES) {
+				const remaining = db
+					.prepare(`SELECT count(*) AS n FROM "${t}"`)
+					.get() as { n: number };
+				// Exactly the ws2 row(s) survive — ws1's child is gone on its own.
+				expect(remaining.n).toBe(1);
+			}
+			// Spot-check: ws1's specific rows are gone, ws2's are present.
+			expect(
+				(
+					db
+						.prepare(`SELECT count(*) AS n FROM message WHERE id='msg1'`)
+						.get() as { n: number }
+				).n,
+			).toBe(0);
+			expect(
+				(
+					db
+						.prepare(`SELECT count(*) AS n FROM message WHERE id='msg2'`)
+						.get() as { n: number }
+				).n,
+			).toBe(1);
+		});
+	}
+});
+
+describe("userDeleteStatements — explicit user-row deletes, user last, verification swept", () => {
+	function seedUser(db: DatabaseSync) {
+		db.exec(
+			`INSERT INTO user (id,name,email) VALUES ('u1','U1','u1@x.io'),('u2','U2','u2@x.io')`,
+		);
+		db.exec(
+			`INSERT INTO session (id,user_id,token,expires_at) VALUES ('se1','u1','tok1',9999),('se2','u2','tok2',9999)`,
+		);
+		db.exec(
+			`INSERT INTO account (id,user_id,account_id,provider_id,password) VALUES ('a1','u1','u1','credential','HASH'),('a2','u1','goog1','google',NULL),('a3','u2','u2','credential','H2')`,
+		);
+		db.exec(
+			`INSERT INTO passkey (id,public_key,user_id,credential_id,counter,device_type,backed_up) VALUES ('pk1','pub','u1','cred',0,'platform',1)`,
+		);
+		db.exec(
+			`INSERT INTO verification (id,identifier,value,expires_at) VALUES ('v1','u1@x.io','tok',9999),('v2','other@x.io','tok',9999)`,
+		);
+		// u1 authored an admin reply in a SURVIVING conversation (different workspace).
+		db.exec(
+			`INSERT INTO workspace (id,name,owner_id) VALUES ('ws2','W2','u2')`,
+		);
+		db.exec(
+			`INSERT INTO project (id,workspace_id,name,public_key,inbound_email_local) VALUES ('p2','ws2','P2','pk2','in2')`,
+		);
+		db.exec(
+			`INSERT INTO conversation (id,project_id,client_id) VALUES ('c2','p2','cl2')`,
+		);
+		db.exec(
+			`INSERT INTO message (id,conversation_id,role,content,sequence,author_user_id) VALUES ('msg2','c2','admin','reply',1,'u1')`,
+		);
+		db.exec(
+			`INSERT INTO member (id,workspace_id,user_id,role) VALUES ('m2','ws2','u1','agent')`,
+		);
+		db.exec(
+			`INSERT INTO read_status (id,conversation_id,user_id) VALUES ('rs2','c2','u1')`,
+		);
+	}
+
+	it("deletes all of u1's rows, nulls authored messages, sweeps verification, keeps u2 (FK off)", () => {
+		const db = freshDb(false);
+		seedUser(db);
+
+		for (const stmt of userDeleteStatements(buildDb, "u1", "u1@x.io")) {
+			run(db, stmt as never);
+		}
+
+		const c = (t: string, w: string) =>
+			(
+				db.prepare(`SELECT count(*) AS n FROM "${t}" WHERE ${w}`).get() as {
+					n: number;
+				}
+			).n;
+		expect(c("user", "id='u1'")).toBe(0);
+		expect(c("user", "id='u2'")).toBe(1); // unrelated user survives
+		expect(c("session", "user_id='u1'")).toBe(0);
+		expect(c("account", "user_id='u1'")).toBe(0); // BOTH credential + google rows gone
+		expect(c("passkey", "user_id='u1'")).toBe(0);
+		expect(c("member", "user_id='u1'")).toBe(0);
+		expect(c("read_status", "user_id='u1'")).toBe(0);
+		// Verification swept by email; the unrelated identifier remains.
+		expect(c("verification", "identifier='u1@x.io'")).toBe(0);
+		expect(c("verification", "identifier='other@x.io'")).toBe(1);
+		// The authored message survives but is disowned (author nulled), not deleted.
+		expect(c("message", "id='msg2'")).toBe(1);
+		expect(c("message", "id='msg2' AND author_user_id IS NULL")).toBe(1);
+		// u2's credential account is untouched.
+		expect(c("account", "id='a3'")).toBe(1);
+	});
+
+	it("self-only: the user DELETE is keyed to the given id, never a smuggled value", () => {
+		const stmts = userDeleteStatements(buildDb, "u1", "u1@x.io");
+		const userDelete = stmts[stmts.length - 1]!.toSQL();
+		expect(userDelete.params).toContain("u1");
+		expect(userDelete.params).not.toContain("victim");
+	});
+});
+
+describe("sub-gate matrix (live + fail-closed)", () => {
+	const ENV = (secret?: string) =>
+		({ vars: { STRIPE_SECRET_KEY: secret } }) as never;
+	const ws = (over: Partial<OwnedWorkspace>): OwnedWorkspace => ({
+		id: "ws1",
+		plan: "none",
+		stripeSubscriptionId: null,
+		...over,
+	});
+
+	beforeEach(() => {
+		vi.mocked(retrieveSubscription).mockReset();
+		// gateWorkspace logs on the fail-closed path; keep the suite quiet.
+		vi.spyOn(console, "error").mockImplementation(() => {});
+	});
+
+	it("free / no-sub workspace: ALLOW with NO Stripe call", async () => {
+		const r = await gateWorkspace(
+			ws({ plan: "none", stripeSubscriptionId: null }),
+			ENV("sk_x"),
+		);
+		expect(r.blocked).toBe(false);
+		expect(retrieveSubscription).not.toHaveBeenCalled();
+	});
+
+	it.each(["active", "trialing", "past_due", "unpaid", "paused"])(
+		"status %s → BLOCK active_subscription",
+		async (status) => {
+			vi.mocked(retrieveSubscription).mockResolvedValue({
+				id: "sub_1",
+				status,
+			});
+			const r = await gateWorkspace(
+				ws({ stripeSubscriptionId: "sub_1" }),
+				ENV("sk_x"),
+			);
+			expect(r).toMatchObject({ blocked: true, reason: "active_subscription" });
+		},
+	);
+
+	it.each(["canceled", "incomplete", "incomplete_expired"])(
+		"status %s → ALLOW",
+		async (status) => {
+			vi.mocked(retrieveSubscription).mockResolvedValue({
+				id: "sub_1",
+				status,
+			});
+			const r = await gateWorkspace(
+				ws({ stripeSubscriptionId: "sub_1" }),
+				ENV("sk_x"),
+			);
+			expect(r.blocked).toBe(false);
+		},
+	);
+
+	it("Stripe error → fail closed (billing_unverified)", async () => {
+		vi.mocked(retrieveSubscription).mockImplementation(async () => {
+			throw new Error("network");
+		});
+		const r = await gateWorkspace(
+			ws({ stripeSubscriptionId: "sub_1" }),
+			ENV("sk_x"),
+		);
+		expect(r).toMatchObject({ blocked: true, reason: "billing_unverified" });
+	});
+
+	it("missing secret with a sub id → fail closed (billing_unverified), no call", async () => {
+		const r = await gateWorkspace(
+			ws({ stripeSubscriptionId: "sub_1" }),
+			ENV(undefined),
+		);
+		expect(r).toMatchObject({ blocked: true, reason: "billing_unverified" });
+		expect(retrieveSubscription).not.toHaveBeenCalled();
+	});
+
+	it("paid plan but NO sub id (drift) → fail closed (billing_drift), no call", async () => {
+		const r = await gateWorkspace(
+			ws({ plan: "growth", stripeSubscriptionId: null }),
+			ENV("sk_x"),
+		);
+		expect(r).toMatchObject({ blocked: true, reason: "billing_drift" });
+		expect(retrieveSubscription).not.toHaveBeenCalled();
+	});
+
+	it("assertDeletable returns the FIRST blocker across workspaces", async () => {
+		vi.mocked(retrieveSubscription).mockResolvedValue({
+			id: "s",
+			status: "active",
+		});
+		const r = await assertDeletable(
+			[
+				ws({ id: "free", plan: "none", stripeSubscriptionId: null }),
+				ws({ id: "paid", stripeSubscriptionId: "sub_1" }),
+			],
+			ENV("sk_x"),
+		);
+		expect(r).toMatchObject({
+			blocked: true,
+			reason: "active_subscription",
+			workspaceId: "paid",
+		});
+	});
+});

--- a/apps/api/src/lib/workspace-deletion.ts
+++ b/apps/api/src/lib/workspace-deletion.ts
@@ -1,0 +1,316 @@
+// The destructive core of account deletion. Everything here is EXPLICIT and
+// set-based — we never rely on `onDelete: cascade` (FK enforcement is unreliable
+// across the D1 emulator vs prod, and this operation is irreversible). The
+// statement builders are separated from the executors so a test can render the
+// exact generated SQL and prove, under PRAGMA foreign_keys=OFF, that every child
+// row is removed by our own deletes rather than by a cascade.
+
+import { retrieveSubscription } from "@/lib/stripe";
+
+import {
+	account,
+	and,
+	conversation,
+	conversationTag,
+	count,
+	eq,
+	inArray,
+	member,
+	message,
+	ne,
+	passkey,
+	project,
+	readStatus,
+	session,
+	source,
+	systemPrompt,
+	tag,
+	usageEvent,
+	user,
+	verification,
+	workspace,
+	type Database,
+} from "@llmchat/db";
+import { isPaidPlan } from "@llmchat/shared";
+
+import type { AppContext } from "@/env";
+
+type Env = AppContext["Bindings"];
+
+/** A workspace the caller solely owns, with the fields the sub-gate needs. */
+export interface OwnedWorkspace {
+	id: string;
+	plan: string;
+	stripeSubscriptionId: string | null;
+}
+
+// ─── Statement builders (pure: build, don't execute) ──────────────────────────
+
+/**
+ * The 11-step, child→parent, set-based delete set for ONE workspace. Every
+ * statement is `DELETE … WHERE … IN (SELECT …)` (or a direct workspace_id), so
+ * the statement count is constant regardless of data volume. Child→parent order
+ * means it's also correct if FK enforcement is unexpectedly ON (no RESTRICT).
+ */
+export function workspaceDeleteStatements(db: Database, wsId: string) {
+	// Fresh subqueries per use so a builder is never shared/mutated across stmts.
+	const projIds = () =>
+		db
+			.select({ id: project.id })
+			.from(project)
+			.where(eq(project.workspaceId, wsId));
+	const convIds = () =>
+		db
+			.select({ id: conversation.id })
+			.from(conversation)
+			.where(inArray(conversation.projectId, projIds()));
+
+	return [
+		db
+			.delete(conversationTag)
+			.where(inArray(conversationTag.conversationId, convIds())),
+		db.delete(readStatus).where(inArray(readStatus.conversationId, convIds())),
+		db.delete(message).where(inArray(message.conversationId, convIds())),
+		db.delete(source).where(inArray(source.projectId, projIds())),
+		db.delete(systemPrompt).where(inArray(systemPrompt.projectId, projIds())),
+		db.delete(usageEvent).where(eq(usageEvent.workspaceId, wsId)),
+		db.delete(conversation).where(inArray(conversation.projectId, projIds())),
+		db.delete(tag).where(eq(tag.workspaceId, wsId)),
+		db.delete(project).where(eq(project.workspaceId, wsId)),
+		db.delete(member).where(eq(member.workspaceId, wsId)),
+		db.delete(workspace).where(eq(workspace.id, wsId)),
+	];
+}
+
+/**
+ * The user-row delete set, run AFTER all solely-owned workspaces are gone. Nulls
+ * the user off any surviving authored messages (FK has no cascade), removes every
+ * user-referencing row, sweeps email verification tokens, and deletes the user
+ * LAST so a partial failure never orphans an owner.
+ */
+export function userDeleteStatements(
+	db: Database,
+	userId: string,
+	email: string,
+) {
+	return [
+		db
+			.update(message)
+			.set({ authorUserId: null })
+			.where(eq(message.authorUserId, userId)),
+		db.delete(member).where(eq(member.userId, userId)),
+		db.delete(readStatus).where(eq(readStatus.userId, userId)),
+		db.delete(account).where(eq(account.userId, userId)),
+		db.delete(passkey).where(eq(passkey.userId, userId)),
+		db.delete(verification).where(eq(verification.identifier, email)),
+		db.delete(session).where(eq(session.userId, userId)),
+		db.delete(user).where(eq(user.id, userId)),
+	];
+}
+
+// drizzle's `batch` wants a non-empty tuple; our builders are a plain array.
+type BatchInput = Parameters<Database["batch"]>[0];
+
+/** Atomically delete one workspace's data (one D1 batch = one transaction). */
+export function deleteWorkspaceCascade(db: Database, wsId: string) {
+	return db.batch(workspaceDeleteStatements(db, wsId) as unknown as BatchInput);
+}
+
+/** Atomically run the user-row delete set (one D1 batch). */
+export function deleteUserRows(db: Database, userId: string, email: string) {
+	return db.batch(
+		userDeleteStatements(db, userId, email) as unknown as BatchInput,
+	);
+}
+
+// ─── Ownership resolution ─────────────────────────────────────────────────────
+
+export interface Ownership {
+	/** Workspaces the user owns AND no other owner exists → delete entirely. */
+	solelyOwned: OwnedWorkspace[];
+	/** Workspaces the user owns but a DIFFERENT owner also exists → guard/abort. */
+	coOwned: string[];
+}
+
+/**
+ * Split the user's owner memberships into solely-owned (safe to delete) vs
+ * co-owned (another owner exists — must never be silently deleted). Non-owner
+ * memberships need no special handling: the user-delete set drops every `member`
+ * row by userId.
+ */
+export async function resolveOwnership(
+	db: Database,
+	userId: string,
+): Promise<Ownership> {
+	const owned = await db
+		.select({ workspaceId: member.workspaceId })
+		.from(member)
+		.where(and(eq(member.userId, userId), eq(member.role, "owner")));
+
+	const solelyOwned: OwnedWorkspace[] = [];
+	const coOwned: string[] = [];
+	for (const { workspaceId } of owned) {
+		const [{ n }] = await db
+			.select({ n: count() })
+			.from(member)
+			.where(
+				and(
+					eq(member.workspaceId, workspaceId),
+					eq(member.role, "owner"),
+					ne(member.userId, userId),
+				),
+			);
+		if (n > 0) {
+			coOwned.push(workspaceId);
+			continue;
+		}
+		const ws = await db.query.workspace.findFirst({
+			where: (w, { eq: e }) => e(w.id, workspaceId),
+			columns: { id: true, plan: true, stripeSubscriptionId: true },
+		});
+		if (ws) solelyOwned.push(ws);
+	}
+	return { solelyOwned, coOwned };
+}
+
+// ─── Subscription gate (live + fail-closed) ───────────────────────────────────
+
+/** Stripe statuses that mean the workspace still has/owes access → block delete
+ * until canceled. (canceled / incomplete / incomplete_expired ⇒ allow.) */
+const BLOCKING_STATUSES = new Set([
+	"active",
+	"trialing",
+	"past_due",
+	"unpaid",
+	"paused",
+]);
+
+export type GateReason =
+	| "active_subscription"
+	| "billing_unverified"
+	| "billing_drift";
+
+export interface GateResult {
+	blocked: boolean;
+	reason?: GateReason;
+	workspaceId?: string;
+}
+
+/**
+ * Decide whether ONE workspace blocks deletion:
+ * - no sub id AND not a paid plan ⇒ ALLOW with NO Stripe call (a missing
+ *   STRIPE_SECRET_KEY must never block a free user);
+ * - sub id set ⇒ live `retrieveSubscription`: blocking status ⇒ block; missing
+ *   secret or any Stripe error ⇒ FAIL CLOSED ("couldn't verify");
+ * - paid plan but no sub id (data drift) ⇒ FAIL CLOSED ("contact support").
+ */
+export async function gateWorkspace(
+	ws: OwnedWorkspace,
+	env: Env,
+): Promise<GateResult> {
+	const paid = isPaidPlan(ws.plan);
+	if (!ws.stripeSubscriptionId && !paid) return { blocked: false };
+
+	if (ws.stripeSubscriptionId) {
+		const secret = env.vars.STRIPE_SECRET_KEY;
+		if (!secret?.trim()) {
+			return {
+				blocked: true,
+				reason: "billing_unverified",
+				workspaceId: ws.id,
+			};
+		}
+		try {
+			const sub = await retrieveSubscription(secret, ws.stripeSubscriptionId);
+			return BLOCKING_STATUSES.has(sub.status)
+				? { blocked: true, reason: "active_subscription", workspaceId: ws.id }
+				: { blocked: false };
+		} catch (err) {
+			console.error(
+				"account-delete: Stripe verify failed; failing closed",
+				err,
+			);
+			return {
+				blocked: true,
+				reason: "billing_unverified",
+				workspaceId: ws.id,
+			};
+		}
+	}
+
+	// Paid plan, no sub id to verify → conservative block.
+	return { blocked: true, reason: "billing_drift", workspaceId: ws.id };
+}
+
+/** Run the gate across every solely-owned workspace; returns the FIRST blocker
+ * (or unblocked). Any block ⇒ the caller aborts before deleting anything. */
+export async function assertDeletable(
+	workspaces: OwnedWorkspace[],
+	env: Env,
+): Promise<GateResult> {
+	for (const ws of workspaces) {
+		const r = await gateWorkspace(ws, env);
+		if (r.blocked) return r;
+	}
+	return { blocked: false };
+}
+
+// ─── Impact counts (for the danger zone) ──────────────────────────────────────
+
+export interface DeletionImpact {
+	workspaces: number;
+	projects: number;
+	conversations: number;
+	sources: number;
+	members: number;
+}
+
+const EMPTY_IMPACT: DeletionImpact = {
+	workspaces: 0,
+	projects: 0,
+	conversations: 0,
+	sources: 0,
+	members: 0,
+};
+
+/** Counts across the user's solely-owned workspaces — what deletion will remove. */
+export async function ownedWorkspaceImpact(
+	db: Database,
+	wsIds: string[],
+): Promise<DeletionImpact> {
+	if (wsIds.length === 0) return EMPTY_IMPACT;
+	const projIds = () =>
+		db
+			.select({ id: project.id })
+			.from(project)
+			.where(inArray(project.workspaceId, wsIds));
+
+	const [[projects], [members], [conversations], [sources]] = await Promise.all(
+		[
+			db
+				.select({ n: count() })
+				.from(project)
+				.where(inArray(project.workspaceId, wsIds)),
+			db
+				.select({ n: count() })
+				.from(member)
+				.where(inArray(member.workspaceId, wsIds)),
+			db
+				.select({ n: count() })
+				.from(conversation)
+				.where(inArray(conversation.projectId, projIds())),
+			db
+				.select({ n: count() })
+				.from(source)
+				.where(inArray(source.projectId, projIds())),
+		],
+	);
+
+	return {
+		workspaces: wsIds.length,
+		projects: projects?.n ?? 0,
+		members: members?.n ?? 0,
+		conversations: conversations?.n ?? 0,
+		sources: sources?.n ?? 0,
+	};
+}

--- a/apps/api/src/routes/account.delete.e2e.test.ts
+++ b/apps/api/src/routes/account.delete.e2e.test.ts
@@ -1,0 +1,259 @@
+// End-to-end deletion tests: the REAL route + the REAL workspace-deletion service
+// + REAL better-auth password verify, executing against a real sqlite (via the
+// sqlite-proxy driver) seeded with the actual migrations. Only the session and
+// Stripe's network call are mocked. These assert the DATA outcomes the unit tests
+// can't: that the user-row set actually empties on success, and that a blocked
+// multi-workspace delete touches NOTHING.
+
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+
+import { drizzle } from "drizzle-orm/sqlite-proxy";
+import { hashPassword } from "better-auth/crypto";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { db } from "@/lib/db";
+import { schema } from "@llmchat/db";
+
+import { account } from "./account";
+
+vi.mock("@/auth", () => ({
+	createAuth: () => ({
+		api: {
+			getSession: async ({ headers }: { headers: Headers }) => {
+				const id = headers.get("x-test-user");
+				return id ? { user: { id } } : null;
+			},
+		},
+	}),
+}));
+vi.mock("@/lib/db", () => ({ db: vi.fn() }));
+// Only Stripe's network call is mocked; the gate logic itself runs for real.
+vi.mock("@/lib/stripe", () => ({ retrieveSubscription: vi.fn() }));
+import { retrieveSubscription } from "@/lib/stripe";
+
+// ─── real sqlite (via proxy) ──────────────────────────────────────────────────
+
+function applyMigrations(sqlite: DatabaseSync) {
+	sqlite.exec("PRAGMA foreign_keys=OFF;");
+	const dir = join(process.cwd(), "migrations");
+	for (const f of readdirSync(dir)
+		.filter((x) => x.endsWith(".sql"))
+		.sort()) {
+		sqlite.exec(
+			readFileSync(join(dir, f), "utf8")
+				.split("--> statement-breakpoint")
+				.join("\n"),
+		);
+	}
+}
+
+function makeProxy(sqlite: DatabaseSync) {
+	const exec = async (sql: string, params: unknown[], method: string) => {
+		const stmt = sqlite.prepare(sql);
+		if (method === "run") {
+			stmt.run(...(params as never[]));
+			return { rows: [] };
+		}
+		const rows = stmt
+			.all(...(params as never[]))
+			.map((r) => Object.values(r as object));
+		return { rows: method === "get" ? (rows[0] as never) : rows };
+	};
+	const batch = async (
+		queries: { sql: string; params: unknown[]; method: string }[],
+	) =>
+		queries.map((q) => {
+			const stmt = sqlite.prepare(q.sql);
+			if (q.method === "run") {
+				stmt.run(...(q.params as never[]));
+				return { rows: [] };
+			}
+			const rows = stmt
+				.all(...(q.params as never[]))
+				.map((o) => Object.values(o as object));
+			return { rows: q.method === "get" ? (rows[0] as never) : rows };
+		});
+	return drizzle(exec, batch, { schema, casing: "snake_case" });
+}
+
+const n = (sqlite: DatabaseSync, where: string, table: string) =>
+	(
+		sqlite
+			.prepare(`SELECT count(*) AS n FROM "${table}" WHERE ${where}`)
+			.get() as {
+			n: number;
+		}
+	).n;
+
+/** Seed a fully-populated workspace `ws`, owned by `owner`, with ids prefixed by
+ * `p` so multiple workspaces don't collide. */
+function seedWorkspace(
+	sqlite: DatabaseSync,
+	ws: string,
+	owner: string,
+	p: string,
+	opts: { plan?: string; sub?: string | null } = {},
+) {
+	const x = (s: string) => sqlite.exec(s);
+	x(
+		`INSERT INTO workspace (id,name,owner_id,plan,stripe_subscription_id) VALUES ('${ws}','${ws}','${owner}','${opts.plan ?? "none"}',${opts.sub ? `'${opts.sub}'` : "NULL"})`,
+	);
+	x(
+		`INSERT INTO member (id,workspace_id,user_id,role) VALUES ('${p}m','${ws}','${owner}','owner')`,
+	);
+	x(
+		`INSERT INTO project (id,workspace_id,name,public_key,inbound_email_local) VALUES ('${p}p','${ws}','P','${p}pk','${p}in')`,
+	);
+	x(
+		`INSERT INTO conversation (id,project_id,client_id) VALUES ('${p}c','${p}p','cl')`,
+	);
+	x(
+		`INSERT INTO message (id,conversation_id,role,content,sequence) VALUES ('${p}msg','${p}c','user','hi',1)`,
+	);
+	x(`INSERT INTO source (id,project_id,kind) VALUES ('${p}s','${p}p','url')`);
+	x(
+		`INSERT INTO system_prompt (id,project_id,name) VALUES ('${p}sp','${p}p','SP')`,
+	);
+	x(`INSERT INTO tag (id,workspace_id,name) VALUES ('${p}t','${ws}','T')`);
+	x(
+		`INSERT INTO conversation_tag (id,conversation_id,tag_id) VALUES ('${p}ct','${p}c','${p}t')`,
+	);
+	x(
+		`INSERT INTO read_status (id,conversation_id,user_id) VALUES ('${p}rs','${p}c','${owner}')`,
+	);
+	x(
+		`INSERT INTO usage_event (id,workspace_id,project_id,conversation_id,message_id,model) VALUES ('${p}ue','${ws}','${p}p','${p}c','${p}msg','m')`,
+	);
+}
+
+const WS_TABLES = [
+	"workspace",
+	"member",
+	"project",
+	"conversation",
+	"message",
+	"source",
+	"system_prompt",
+	"tag",
+	"conversation_tag",
+	"read_status",
+	"usage_event",
+];
+
+function del(
+	body: unknown,
+	headers: Record<string, string> = { "x-test-user": "u1" },
+) {
+	return account.request(
+		"/account",
+		{
+			method: "DELETE",
+			headers: { ...headers, "content-type": "application/json" },
+			body: JSON.stringify(body),
+		},
+		{ vars: { STRIPE_SECRET_KEY: "sk_test_x" } } as never,
+	);
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("DELETE /account — positive end-to-end (credential user, populated workspace)", () => {
+	it("verifies the password, returns 200, and empties EVERY workspace child + the user's own rows", async () => {
+		const sqlite = new DatabaseSync(":memory:");
+		applyMigrations(sqlite);
+
+		const hash = await hashPassword("correct horse");
+		sqlite.exec(
+			`INSERT INTO user (id,name,email) VALUES ('u1','U1','u1@x.io')`,
+		);
+		// Both a credential account (password) and a linked Google account.
+		sqlite.exec(
+			`INSERT INTO account (id,user_id,account_id,provider_id,password) VALUES ('acc1','u1','u1','credential','${hash}'),('acc2','u1','g1','google',NULL)`,
+		);
+		sqlite.exec(
+			`INSERT INTO passkey (id,public_key,user_id,credential_id,counter,device_type,backed_up) VALUES ('pk1','pub','u1','cr',0,'platform',1)`,
+		);
+		sqlite.exec(
+			`INSERT INTO session (id,user_id,token,expires_at) VALUES ('se1','u1','tok',9999)`,
+		);
+		sqlite.exec(
+			`INSERT INTO verification (id,identifier,value,expires_at) VALUES ('v1','u1@x.io','t',9999)`,
+		);
+		seedWorkspace(sqlite, "ws1", "u1", "a");
+
+		vi.mocked(db).mockReturnValue(makeProxy(sqlite) as never);
+
+		const res = await del({
+			confirmEmail: "u1@x.io",
+			password: "correct horse",
+		});
+		expect(res.status).toBe(200);
+
+		// Every workspace child table is empty…
+		for (const t of WS_TABLES) {
+			expect(
+				(
+					sqlite.prepare(`SELECT count(*) AS n FROM "${t}"`).get() as {
+						n: number;
+					}
+				).n,
+			).toBe(0);
+		}
+		// …and the user's own rows are gone (credential + google), passkey, session.
+		expect(n(sqlite, "id='u1'", "user")).toBe(0);
+		expect(n(sqlite, "user_id='u1'", "account")).toBe(0);
+		expect(n(sqlite, "user_id='u1'", "passkey")).toBe(0);
+		expect(n(sqlite, "user_id='u1'", "session")).toBe(0);
+		// …and the email verification tokens were swept.
+		expect(n(sqlite, "identifier='u1@x.io'", "verification")).toBe(0);
+	});
+});
+
+describe("DELETE /account — abort atomicity (2 owned workspaces, one with an active sub)", () => {
+	it("returns 409 and deletes NOTHING — both workspaces and the user survive intact", async () => {
+		const sqlite = new DatabaseSync(":memory:");
+		applyMigrations(sqlite);
+
+		// OAuth-only user (no credential → no password needed to reach the gate).
+		sqlite.exec(
+			`INSERT INTO user (id,name,email) VALUES ('u1','U1','u1@x.io')`,
+		);
+		sqlite.exec(
+			`INSERT INTO account (id,user_id,account_id,provider_id) VALUES ('acc2','u1','g1','google')`,
+		);
+		sqlite.exec(
+			`INSERT INTO session (id,user_id,token,expires_at) VALUES ('se1','u1','tok',9999)`,
+		);
+		// ws1: active subscription (blocks). ws2: free, populated.
+		seedWorkspace(sqlite, "ws1", "u1", "a", { plan: "growth", sub: "sub_1" });
+		seedWorkspace(sqlite, "ws2", "u1", "b");
+
+		// The live gate sees the sub as active ⇒ block.
+		vi.mocked(retrieveSubscription).mockResolvedValue({
+			id: "sub_1",
+			status: "active",
+		});
+		vi.mocked(db).mockReturnValue(makeProxy(sqlite) as never);
+
+		const res = await del({ confirmEmail: "u1@x.io" });
+		expect(res.status).toBe(409);
+		expect(await res.json()).toMatchObject({ error: "active_subscription" });
+
+		// NOTHING deleted: both workspaces' full subtrees survive…
+		for (const t of WS_TABLES) {
+			const c = (
+				sqlite.prepare(`SELECT count(*) AS n FROM "${t}"`).get() as {
+					n: number;
+				}
+			).n;
+			// workspace/member/project/... each seeded twice (ws1 + ws2).
+			expect(c).toBe(2);
+		}
+		// …and the user + their auth rows are untouched.
+		expect(n(sqlite, "id='u1'", "user")).toBe(1);
+		expect(n(sqlite, "user_id='u1'", "session")).toBe(1);
+		expect(n(sqlite, "user_id='u1'", "account")).toBe(1);
+	});
+});

--- a/apps/api/src/routes/account.test.ts
+++ b/apps/api/src/routes/account.test.ts
@@ -2,14 +2,18 @@ import { SQLiteSyncDialect } from "drizzle-orm/sqlite-core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { db } from "@/lib/db";
+import {
+	assertDeletable,
+	deleteUserRows,
+	deleteWorkspaceCascade,
+	ownedWorkspaceImpact,
+	resolveOwnership,
+} from "@/lib/workspace-deletion";
 
 import { account } from "./account";
 
-// Render a captured drizzle WHERE to SQL so a test can prove the update is keyed
-// to the SESSION user (and never to an id from the request body).
 const dialect = new SQLiteSyncDialect({ casing: "snake_case" });
 
-// Header-driven fake session: `x-test-user` present ⇒ that user is signed in.
 vi.mock("@/auth", () => ({
 	createAuth: () => ({
 		api: {
@@ -23,13 +27,39 @@ vi.mock("@/auth", () => ({
 
 vi.mock("@/lib/db", () => ({ db: vi.fn() }));
 
+// The deletion service is unit-proven in workspace-deletion.test.ts (real SQL,
+// FK-off cascade, sub-gate matrix). Here it's mocked so the ROUTE's orchestration
+// — re-auth, email confirm, co-owner/gate aborts, ordering, self-only — is tested
+// in isolation.
+vi.mock("@/lib/workspace-deletion", () => ({
+	resolveOwnership: vi.fn(),
+	ownedWorkspaceImpact: vi.fn(),
+	assertDeletable: vi.fn(),
+	deleteWorkspaceCascade: vi.fn(),
+	deleteUserRows: vi.fn(),
+}));
+vi.mock("better-auth/crypto", () => ({ verifyPassword: vi.fn() }));
+import { verifyPassword } from "better-auth/crypto";
+
 const ENV = { vars: {}, DB: {} } as unknown as Parameters<
 	typeof account.request
 >[2];
 
 interface State {
-	/** The row query.user.findFirst resolves (undefined ⇒ 404). */
 	user?: { name: string; email: string };
+	/** account.findFirst result for the credential lookup ({password} or none). */
+	credential?: { password: string };
+	ownership?: {
+		solelyOwned: {
+			id: string;
+			plan: string;
+			stripeSubscriptionId: string | null;
+		}[];
+		coOwned: string[];
+	};
+	impact?: Record<string, number>;
+	gate?: { blocked: boolean; reason?: string; workspaceId?: string };
+	verifyOk?: boolean;
 }
 
 let updateSpy: ReturnType<typeof vi.fn>;
@@ -60,10 +90,30 @@ function mockDb(state: State) {
 	const fake = {
 		query: {
 			user: { findFirst: async () => state.user },
+			account: { findFirst: async () => state.credential },
 		},
 		update: updateSpy,
 	};
 	vi.mocked(db).mockReturnValue(fake as unknown as ReturnType<typeof db>);
+
+	vi.mocked(resolveOwnership).mockResolvedValue(
+		state.ownership ?? { solelyOwned: [], coOwned: [] },
+	);
+	vi.mocked(ownedWorkspaceImpact).mockResolvedValue(
+		(state.impact as never) ?? {
+			workspaces: 0,
+			projects: 0,
+			conversations: 0,
+			sources: 0,
+			members: 0,
+		},
+	);
+	vi.mocked(assertDeletable).mockResolvedValue(
+		(state.gate ?? { blocked: false }) as never,
+	);
+	vi.mocked(deleteWorkspaceCascade).mockResolvedValue([] as never);
+	vi.mocked(deleteUserRows).mockResolvedValue([] as never);
+	vi.mocked(verifyPassword).mockResolvedValue(state.verifyOk ?? false);
 }
 
 const ME = { "x-test-user": "u1" };
@@ -83,6 +133,19 @@ function patch(body: unknown, headers: Record<string, string> = ME) {
 		ENV,
 	);
 }
+function del(body: unknown, headers: Record<string, string> = ME) {
+	return account.request(
+		"/account",
+		{
+			method: "DELETE",
+			headers: { ...headers, ...json },
+			body: JSON.stringify(body),
+		},
+		ENV,
+	);
+}
+
+const USER = { name: "Ada", email: "ada@x.io" };
 
 beforeEach(() => vi.clearAllMocks());
 
@@ -92,66 +155,218 @@ describe("GET /account", () => {
 		expect((await get({})).status).toBe(401);
 	});
 
-	it("returns the signed-in user's own profile", async () => {
-		mockDb({ user: { name: "Ada Lovelace", email: "ada@x.io" } });
+	it("returns profile + hasPassword + impact + blocker hints", async () => {
+		mockDb({
+			user: USER,
+			credential: { password: "HASH" },
+			ownership: {
+				solelyOwned: [
+					{ id: "ws1", plan: "growth", stripeSubscriptionId: "sub_1" },
+				],
+				coOwned: [],
+			},
+			impact: {
+				workspaces: 1,
+				projects: 2,
+				conversations: 9,
+				sources: 3,
+				members: 1,
+			},
+		});
 		const res = await get(ME);
 		expect(res.status).toBe(200);
 		expect(await res.json()).toEqual({
-			name: "Ada Lovelace",
+			name: "Ada",
 			email: "ada@x.io",
+			hasPassword: true,
+			impact: {
+				workspaces: 1,
+				projects: 2,
+				conversations: 9,
+				sources: 3,
+				members: 1,
+			},
+			blockers: { activeSubscription: true, drift: false, coOwner: false },
 		});
+	});
+
+	it("hasPassword is false for an OAuth-only user", async () => {
+		mockDb({ user: USER, credential: undefined });
+		const body = (await (await get(ME)).json()) as { hasPassword: boolean };
+		expect(body.hasPassword).toBe(false);
 	});
 });
 
-describe("PATCH /account", () => {
-	it("401s without a session; never updates", async () => {
-		mockDb({});
-		const res = await patch({ name: "New" }, {});
-		expect(res.status).toBe(401);
-		expect(updateSpy).not.toHaveBeenCalled();
-	});
-
-	it("updates the name and returns the profile", async () => {
-		mockDb({ user: { name: "Ada", email: "ada@x.io" } });
-		const res = await patch({ name: "Grace Hopper" });
+describe("PATCH /account (unchanged self-only behavior)", () => {
+	it("updates only name, keyed to the session user; ignores a smuggled id", async () => {
+		mockDb({ user: USER });
+		const res = await patch({ name: "Grace", id: "victim", userId: "victim" });
 		expect(res.status).toBe(200);
-		expect(await res.json()).toEqual({
-			name: "Grace Hopper",
-			email: "ada@x.io",
-		});
-		// Only name (+ updatedAt) is written — no other columns.
 		expect(Object.keys(lastSet ?? {}).sort()).toEqual(["name", "updatedAt"]);
-		expect(lastSet).toMatchObject({ name: "Grace Hopper" });
-	});
-
-	it("400s an empty / whitespace-only name; never updates", async () => {
-		mockDb({ user: { name: "Ada", email: "ada@x.io" } });
-		expect((await patch({ name: "" })).status).toBe(400);
-		expect((await patch({ name: "   " })).status).toBe(400);
-		expect(updateSpy).not.toHaveBeenCalled();
-	});
-
-	it("400s an over-length name (>100); never updates", async () => {
-		mockDb({ user: { name: "Ada", email: "ada@x.io" } });
-		expect((await patch({ name: "x".repeat(101) })).status).toBe(400);
-		expect(updateSpy).not.toHaveBeenCalled();
-	});
-
-	it("is self-only: the update is keyed to the SESSION user, and a smuggled id is ignored", async () => {
-		mockDb({ user: { name: "Ada", email: "ada@x.io" } });
-		// Try to target another user via the body — it must have no effect.
-		const res = await patch({
-			name: "Renamed",
-			id: "victim",
-			userId: "victim",
-		});
-		expect(res.status).toBe(200);
-		// The write is scoped to the session user u1, never "victim".
 		const { params } = dialect.sqlToQuery(lastWhere!);
 		expect(params).toContain("u1");
 		expect(params).not.toContain("victim");
-		// And the smuggled fields never reached the column set.
-		expect(lastSet).not.toHaveProperty("id");
-		expect(lastSet).not.toHaveProperty("userId");
+	});
+
+	it("400s an empty/over-length name", async () => {
+		mockDb({ user: USER });
+		expect((await patch({ name: "   " })).status).toBe(400);
+		expect((await patch({ name: "x".repeat(101) })).status).toBe(400);
+	});
+});
+
+describe("DELETE /account — re-auth + confirm", () => {
+	it("401s without a session; deletes nothing", async () => {
+		mockDb({ user: USER });
+		const res = await del({ confirmEmail: "ada@x.io" }, {});
+		expect(res.status).toBe(401);
+		expect(deleteWorkspaceCascade).not.toHaveBeenCalled();
+		expect(deleteUserRows).not.toHaveBeenCalled();
+	});
+
+	it("400s when the confirmation email doesn't match (case-insensitive); deletes nothing", async () => {
+		mockDb({ user: USER });
+		const res = await del({ confirmEmail: "wrong@x.io" });
+		expect(res.status).toBe(400);
+		expect(await res.json()).toMatchObject({ error: "email_mismatch" });
+		expect(resolveOwnership).not.toHaveBeenCalled();
+		expect(deleteUserRows).not.toHaveBeenCalled();
+	});
+
+	it("accepts a case-insensitive email match", async () => {
+		mockDb({ user: USER, credential: undefined });
+		const res = await del({ confirmEmail: "ADA@X.IO" });
+		expect(res.status).toBe(200);
+	});
+
+	it("403s when a credential user omits the password; deletes nothing", async () => {
+		mockDb({ user: USER, credential: { password: "HASH" } });
+		const res = await del({ confirmEmail: "ada@x.io" });
+		expect(res.status).toBe(403);
+		expect(await res.json()).toMatchObject({ error: "password_required" });
+		expect(deleteUserRows).not.toHaveBeenCalled();
+	});
+
+	it("403s a wrong password (verified via better-auth); deletes nothing", async () => {
+		mockDb({ user: USER, credential: { password: "HASH" }, verifyOk: false });
+		const res = await del({ confirmEmail: "ada@x.io", password: "nope" });
+		expect(res.status).toBe(403);
+		expect(await res.json()).toMatchObject({ error: "invalid_password" });
+		expect(verifyPassword).toHaveBeenCalledWith({
+			hash: "HASH",
+			password: "nope",
+		});
+		expect(deleteUserRows).not.toHaveBeenCalled();
+	});
+
+	it("proceeds for a credential user with the correct password", async () => {
+		mockDb({ user: USER, credential: { password: "HASH" }, verifyOk: true });
+		const res = await del({ confirmEmail: "ada@x.io", password: "right" });
+		expect(res.status).toBe(200);
+		expect(deleteUserRows).toHaveBeenCalledTimes(1);
+	});
+
+	it("OAuth-only user deletes with NO password (verify never called)", async () => {
+		mockDb({ user: USER, credential: undefined });
+		const res = await del({ confirmEmail: "ada@x.io" });
+		expect(res.status).toBe(200);
+		expect(verifyPassword).not.toHaveBeenCalled();
+		expect(deleteUserRows).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe("DELETE /account — gates + ordering", () => {
+	it("409s co_owner; deletes nothing", async () => {
+		mockDb({
+			user: USER,
+			credential: undefined,
+			ownership: { solelyOwned: [], coOwned: ["wsShared"] },
+		});
+		const res = await del({ confirmEmail: "ada@x.io" });
+		expect(res.status).toBe(409);
+		expect(await res.json()).toMatchObject({ error: "co_owner" });
+		expect(assertDeletable).not.toHaveBeenCalled();
+		expect(deleteWorkspaceCascade).not.toHaveBeenCalled();
+		expect(deleteUserRows).not.toHaveBeenCalled();
+	});
+
+	it("409s an active subscription (gate blocked) BEFORE any delete", async () => {
+		mockDb({
+			user: USER,
+			credential: undefined,
+			ownership: {
+				solelyOwned: [
+					{ id: "ws1", plan: "growth", stripeSubscriptionId: "sub_1" },
+				],
+				coOwned: [],
+			},
+			gate: {
+				blocked: true,
+				reason: "active_subscription",
+				workspaceId: "ws1",
+			},
+		});
+		const res = await del({ confirmEmail: "ada@x.io" });
+		expect(res.status).toBe(409);
+		expect(await res.json()).toMatchObject({ error: "active_subscription" });
+		expect(deleteWorkspaceCascade).not.toHaveBeenCalled();
+		expect(deleteUserRows).not.toHaveBeenCalled();
+	});
+
+	it("409s billing_unverified (fail-closed) BEFORE any delete", async () => {
+		mockDb({
+			user: USER,
+			ownership: {
+				solelyOwned: [
+					{ id: "ws1", plan: "growth", stripeSubscriptionId: "sub_1" },
+				],
+				coOwned: [],
+			},
+			gate: { blocked: true, reason: "billing_unverified" },
+		});
+		const res = await del({ confirmEmail: "ada@x.io" });
+		expect(res.status).toBe(409);
+		expect(await res.json()).toMatchObject({ error: "billing_unverified" });
+		expect(deleteUserRows).not.toHaveBeenCalled();
+	});
+
+	it("happy path: cascades every owned workspace, then deletes the user LAST (self-from-session)", async () => {
+		mockDb({
+			user: USER,
+			credential: undefined,
+			ownership: {
+				solelyOwned: [
+					{ id: "wsA", plan: "none", stripeSubscriptionId: null },
+					{ id: "wsB", plan: "none", stripeSubscriptionId: null },
+				],
+				coOwned: [],
+			},
+		});
+		// Even with a smuggled id in the body, deletion targets the SESSION user.
+		const res = await del({ confirmEmail: "ada@x.io", id: "victim" });
+		expect(res.status).toBe(200);
+		expect(deleteWorkspaceCascade).toHaveBeenCalledTimes(2);
+		expect(deleteUserRows).toHaveBeenCalledTimes(1);
+		// user rows are deleted with the SESSION user id + email, never "victim".
+		expect(vi.mocked(deleteUserRows).mock.calls[0]![1]).toBe("u1");
+		expect(vi.mocked(deleteUserRows).mock.calls[0]![2]).toBe("ada@x.io");
+		// Ordering: every workspace cascade runs BEFORE the user delete.
+		const userOrder = vi.mocked(deleteUserRows).mock.invocationCallOrder[0]!;
+		for (const o of vi.mocked(deleteWorkspaceCascade).mock
+			.invocationCallOrder) {
+			expect(o).toBeLessThan(userOrder);
+		}
+	});
+
+	it("idempotent re-run from partial state (no owned workspaces left) still deletes the user, 200", async () => {
+		mockDb({
+			user: USER,
+			credential: undefined,
+			ownership: { solelyOwned: [], coOwned: [] },
+		});
+		const res = await del({ confirmEmail: "ada@x.io" });
+		expect(res.status).toBe(200);
+		expect(deleteWorkspaceCascade).not.toHaveBeenCalled();
+		expect(deleteUserRows).toHaveBeenCalledTimes(1);
 	});
 });

--- a/apps/api/src/routes/account.ts
+++ b/apps/api/src/routes/account.ts
@@ -1,29 +1,59 @@
 import { zValidator } from "@hono/zod-validator";
+import { verifyPassword } from "better-auth/crypto";
 import { Hono } from "hono";
 import { z } from "zod";
 
 import { db } from "@/lib/db";
 import { requireSession } from "@/middleware/session";
+import {
+	assertDeletable,
+	deleteUserRows,
+	deleteWorkspaceCascade,
+	ownedWorkspaceImpact,
+	resolveOwnership,
+} from "@/lib/workspace-deletion";
 
 import { eq, user } from "@llmchat/db";
+import { isPaidPlan } from "@llmchat/shared";
 
 import type { AppContext } from "@/env";
 
 // UPDATE validator: a single required field, NO `.partial()`/`.default()` (the
-// Zod-v4 footgun where a default fires on an absent key). `.trim()` runs before
-// `.min(1)`, so a whitespace-only name fails validation (400). Unknown keys
-// (e.g. an attempt to smuggle an `id`) are stripped by Zod — the handler never
-// reads anything but `name` from the body.
+// Zod-v4 footgun). `.trim()` before `.min(1)` rejects whitespace-only names.
 const updateInput = z.object({
 	name: z.string().trim().min(1).max(100),
 });
 
+// DELETE validator: a confirmation email (compared to the SESSION email, never a
+// target selector) and an optional password (required only when the user has a
+// credential account). No user id is ever accepted.
+const deleteInput = z.object({
+	confirmEmail: z.string().min(1),
+	password: z.string().optional(),
+});
+
+/** Whether the signed-in user has a usable password (a `credential` account with
+ * a non-null hash). Drives both the GET `hasPassword` flag and the DELETE re-auth. */
+async function findCredentialPassword(
+	env: AppContext["Bindings"],
+	userId: string,
+): Promise<string | null> {
+	const cred = await db(env).query.account.findFirst({
+		where: (a, { and, eq: e, isNotNull }) =>
+			and(
+				e(a.userId, userId),
+				e(a.providerId, "credential"),
+				isNotNull(a.password),
+			),
+		columns: { password: true },
+	});
+	return cred?.password ?? null;
+}
+
 /**
  * The caller's OWN account. Every handler derives the user from the session
  * (requireSession sets `userId`); no user id is ever accepted from the request,
- * so these endpoints can only ever read/mutate the signed-in user. PR2 extends
- * GET with deletion impact and adds the destructive DELETE — kept separate so
- * the dangerous path is reviewed in isolation.
+ * so these endpoints can only ever read/mutate/delete the signed-in user.
  */
 export const account = new Hono<AppContext>()
 	.use("*", requireSession)
@@ -34,17 +64,88 @@ export const account = new Hono<AppContext>()
 			columns: { name: true, email: true },
 		});
 		if (!me) return c.json({ error: "not found" }, 404);
-		return c.json({ name: me.name, email: me.email });
+
+		const hasPassword = (await findCredentialPassword(c.env, userId)) !== null;
+		const { solelyOwned, coOwned } = await resolveOwnership(db(c.env), userId);
+		const impact = await ownedWorkspaceImpact(
+			db(c.env),
+			solelyOwned.map((w) => w.id),
+		);
+
+		// Blocker HINTS from stored fields — deliberately NO Stripe call on a page
+		// load. The authoritative live + fail-closed check runs in DELETE. A
+		// properly-canceled workspace has stripeSubscriptionId nulled by the webhook,
+		// so a lingering id ⇒ likely still subscribed; paid plan with no id ⇒ drift.
+		return c.json({
+			name: me.name,
+			email: me.email,
+			hasPassword,
+			impact,
+			blockers: {
+				activeSubscription: solelyOwned.some((w) => !!w.stripeSubscriptionId),
+				drift: solelyOwned.some(
+					(w) => isPaidPlan(w.plan) && !w.stripeSubscriptionId,
+				),
+				coOwner: coOwned.length > 0,
+			},
+		});
 	})
 	.patch("/account", zValidator("json", updateInput), async (c) => {
 		const userId = c.get("userId");
 		const { name } = c.req.valid("json");
-		// Name isn't auth-sensitive, so a direct column update is simplest and
-		// keeps the write keyed to the SESSION user — never an id from the body.
+		// Direct column update, keyed to the SESSION user — never an id from the body.
 		const [updated] = await db(c.env)
 			.update(user)
 			.set({ name: name.trim(), updatedAt: new Date() })
 			.where(eq(user.id, userId))
 			.returning({ name: user.name, email: user.email });
 		return c.json({ name: updated!.name, email: updated!.email });
+	})
+	// Permanently delete the caller's account + every workspace they solely own.
+	// Irreversible. Order is fixed: confirm → re-auth → ownership/co-owner guard →
+	// live sub-gate (fail-closed) → per-workspace cascade → user rows (user LAST).
+	// Every step is self-from-session and explicit (never relies on FK cascade).
+	.delete("/account", zValidator("json", deleteInput), async (c) => {
+		const userId = c.get("userId");
+		const { confirmEmail, password } = c.req.valid("json");
+		const d = db(c.env);
+
+		const me = await d.query.user.findFirst({
+			where: (u, { eq: e }) => e(u.id, userId),
+			columns: { email: true },
+		});
+		if (!me) return c.json({ error: "not found" }, 404);
+
+		// 1. Type-to-confirm: the email must match the session user's (case-insensitive).
+		if (confirmEmail.trim().toLowerCase() !== me.email.toLowerCase()) {
+			return c.json({ error: "email_mismatch" }, 400);
+		}
+
+		// 2. Re-auth: if a credential account exists, verify the password with
+		//    Better-Auth's native verify (never hand-rolled). OAuth-only ⇒ skip.
+		const credentialHash = await findCredentialPassword(c.env, userId);
+		if (credentialHash) {
+			if (!password) return c.json({ error: "password_required" }, 403);
+			const ok = await verifyPassword({ hash: credentialHash, password });
+			if (!ok) return c.json({ error: "invalid_password" }, 403);
+		}
+
+		// 3. Ownership + co-owner guard — never silently delete a shared workspace.
+		const { solelyOwned, coOwned } = await resolveOwnership(d, userId);
+		if (coOwned.length > 0) return c.json({ error: "co_owner" }, 409);
+
+		// 4. Live, fail-closed subscription gate — BEFORE any delete.
+		const gate = await assertDeletable(solelyOwned, c.env);
+		if (gate.blocked) return c.json({ error: gate.reason }, 409);
+
+		// 5. Per-workspace atomic cascade (explicit, child→parent).
+		for (const ws of solelyOwned) {
+			await deleteWorkspaceCascade(d, ws.id);
+		}
+		// 6. User rows — user deleted LAST (deleteUserRows nulls authored messages,
+		//    removes member/read_status/account/passkey/session + sweeps verification
+		//    tokens by email, then deletes the user).
+		await deleteUserRows(d, userId, me.email);
+
+		return c.json({ ok: true });
 	});

--- a/apps/dashboard/src/app/settings/account/_components/DeleteAccountDialog.test.tsx
+++ b/apps/dashboard/src/app/settings/account/_components/DeleteAccountDialog.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+import { DeleteAccountDialog } from "./DeleteAccountDialog";
+
+beforeAll(() => {
+	Element.prototype.scrollIntoView = vi.fn();
+	Element.prototype.hasPointerCapture ??= () => false;
+});
+
+function setup(
+	props: Partial<React.ComponentProps<typeof DeleteAccountDialog>> = {},
+) {
+	const onConfirm = vi.fn();
+	const onOpenChange = vi.fn();
+	const utils = render(
+		<DeleteAccountDialog
+			open
+			onOpenChange={onOpenChange}
+			email="ada@example.io"
+			requirePassword={false}
+			pending={false}
+			onConfirm={onConfirm}
+			{...props}
+		/>,
+	);
+	return { onConfirm, onOpenChange, ...utils };
+}
+
+const confirmBtn = () =>
+	screen.getByRole("button", { name: /delete account/i });
+
+describe("DeleteAccountDialog", () => {
+	it("arms only on a case-insensitive email match, then confirms with the trimmed email", async () => {
+		const user = userEvent.setup();
+		const { onConfirm } = setup();
+		expect(confirmBtn()).toBeDisabled();
+		await user.type(
+			screen.getByLabelText("Confirm email"),
+			"  ADA@EXAMPLE.IO  ",
+		);
+		expect(confirmBtn()).toBeEnabled();
+		await user.click(confirmBtn());
+		expect(onConfirm).toHaveBeenCalledWith({
+			confirmEmail: "ADA@EXAMPLE.IO",
+			password: undefined,
+		});
+	});
+
+	it("requires a password when requirePassword and includes it on confirm", async () => {
+		const user = userEvent.setup();
+		const { onConfirm } = setup({ requirePassword: true });
+		await user.type(screen.getByLabelText("Confirm email"), "ada@example.io");
+		expect(confirmBtn()).toBeDisabled(); // password still empty
+		await user.type(screen.getByLabelText("Password"), "pw");
+		await user.click(confirmBtn());
+		expect(onConfirm).toHaveBeenCalledWith({
+			confirmEmail: "ada@example.io",
+			password: "pw",
+		});
+	});
+
+	it("resets the typed fields when the dialog closes (no pre-armed reopen)", async () => {
+		const user = userEvent.setup();
+		const { onOpenChange, rerender } = setup();
+		await user.type(screen.getByLabelText("Confirm email"), "ada@example.io");
+		expect(confirmBtn()).toBeEnabled();
+		// Cancel → onOpenChange(false) fires; the dialog clears its state.
+		await user.click(screen.getByRole("button", { name: "Cancel" }));
+		expect(onOpenChange).toHaveBeenCalledWith(false);
+		// Reopen → the field is empty again and confirm is disabled.
+		rerender(
+			<DeleteAccountDialog
+				open
+				onOpenChange={onOpenChange}
+				email="ada@example.io"
+				requirePassword={false}
+				pending={false}
+				onConfirm={vi.fn()}
+			/>,
+		);
+		expect(screen.getByLabelText("Confirm email")).toHaveValue("");
+		expect(confirmBtn()).toBeDisabled();
+	});
+});

--- a/apps/dashboard/src/app/settings/account/_components/DeleteAccountDialog.tsx
+++ b/apps/dashboard/src/app/settings/account/_components/DeleteAccountDialog.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { useState } from "react";
+
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+export interface DeleteAccountDialogProps {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	/** The user's email — the confirmation must match it (case-insensitive). */
+	email: string;
+	/** When true, the user has a password and must re-enter it to confirm. */
+	requirePassword: boolean;
+	pending: boolean;
+	onConfirm: (input: { confirmEmail: string; password?: string }) => void;
+}
+
+/**
+ * Final confirmation for the irreversible account deletion: type-the-email +,
+ * when the user has a password, re-enter it. Both are reset whenever the dialog
+ * closes so a prior attempt can't pre-arm the destructive button. The server is
+ * authoritative — it re-confirms the email, re-verifies the password, and
+ * re-checks the subscription/co-owner gates — this is just the front-line gate.
+ */
+export function DeleteAccountDialog({
+	open,
+	onOpenChange,
+	email,
+	requirePassword,
+	pending,
+	onConfirm,
+}: DeleteAccountDialogProps) {
+	const [confirmEmail, setConfirmEmail] = useState("");
+	const [password, setPassword] = useState("");
+
+	const emailMatches =
+		confirmEmail.trim().toLowerCase() === email.toLowerCase();
+	const passwordOk = !requirePassword || password.length > 0;
+	const armed = emailMatches && passwordOk && !pending;
+
+	function handleOpenChange(next: boolean) {
+		if (!next) {
+			setConfirmEmail("");
+			setPassword("");
+		}
+		onOpenChange(next);
+	}
+
+	return (
+		<AlertDialog open={open} onOpenChange={handleOpenChange}>
+			<AlertDialogContent>
+				<AlertDialogHeader>
+					<AlertDialogTitle>Delete your account?</AlertDialogTitle>
+					<AlertDialogDescription>
+						This permanently deletes your account and every workspace you solely
+						own — all projects, conversations, messages, sources, tags, and
+						usage history. This cannot be undone.
+					</AlertDialogDescription>
+				</AlertDialogHeader>
+
+				<form
+					className="flex flex-col gap-4"
+					onSubmit={(e) => {
+						e.preventDefault();
+						if (armed) {
+							onConfirm({
+								confirmEmail: confirmEmail.trim(),
+								password: requirePassword ? password : undefined,
+							});
+						}
+					}}
+				>
+					<div className="flex flex-col gap-1.5">
+						<Label htmlFor="confirm-email">
+							Type{" "}
+							<span className="font-semibold text-foreground">{email}</span> to
+							confirm
+						</Label>
+						<Input
+							id="confirm-email"
+							value={confirmEmail}
+							onChange={(e) => setConfirmEmail(e.target.value)}
+							autoComplete="off"
+							aria-label="Confirm email"
+						/>
+					</div>
+
+					{requirePassword && (
+						<div className="flex flex-col gap-1.5">
+							<Label htmlFor="confirm-password">Your password</Label>
+							<Input
+								id="confirm-password"
+								type="password"
+								value={password}
+								onChange={(e) => setPassword(e.target.value)}
+								autoComplete="current-password"
+								aria-label="Password"
+							/>
+						</div>
+					)}
+
+					<AlertDialogFooter>
+						<AlertDialogCancel type="button">Cancel</AlertDialogCancel>
+						<AlertDialogAction
+							type="submit"
+							disabled={!armed}
+							className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+						>
+							{pending ? "Deleting…" : "Delete account"}
+						</AlertDialogAction>
+					</AlertDialogFooter>
+				</form>
+			</AlertDialogContent>
+		</AlertDialog>
+	);
+}

--- a/apps/dashboard/src/app/settings/account/page.test.tsx
+++ b/apps/dashboard/src/app/settings/account/page.test.tsx
@@ -1,37 +1,71 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { api } from "@/lib/api";
 
 import AccountSettingsPage from "./page";
 
+import type { Account } from "@/lib/account";
+
+beforeAll(() => {
+	Element.prototype.scrollIntoView = vi.fn();
+	Element.prototype.hasPointerCapture ??= () => false;
+});
+
+const replace = vi.fn();
+vi.mock("next/navigation", () => ({ useRouter: () => ({ replace }) }));
+
+const signOut = vi.fn(async () => {});
+vi.mock("@/lib/auth-client", () => ({ signOut: () => signOut() }));
+vi.mock("@/lib/analytics", () => ({ resetAnalytics: vi.fn() }));
+
 const toastSuccess = vi.fn();
+const toastError = vi.fn();
 vi.mock("sonner", () => ({
-	toast: { success: (m: string) => toastSuccess(m), error: vi.fn() },
+	toast: {
+		success: (m: string) => toastSuccess(m),
+		error: (m: string) => toastError(m),
+	},
 }));
 
-// Only the transport is mocked; describeApiError stays real.
 vi.mock("@/lib/api", async (orig) => ({
 	...(await orig<typeof import("@/lib/api")>()),
 	api: vi.fn(),
 }));
 
 let calls: { path: string; method: string; body?: unknown }[];
-let profile: { name: string; email: string };
 
-function setupApi() {
+function baseAccount(over: Partial<Account> = {}): Account {
+	return {
+		name: "Ada Lovelace",
+		email: "ada@example.io",
+		hasPassword: false,
+		impact: {
+			workspaces: 1,
+			projects: 2,
+			conversations: 9,
+			sources: 3,
+			members: 1,
+		},
+		blockers: { activeSubscription: false, drift: false, coOwner: false },
+		...over,
+	};
+}
+
+function setupApi(account: Account) {
 	calls = [];
-	profile = { name: "Ada Lovelace", email: "ada@example.io" };
+	let current = account;
 	vi.mocked(api).mockImplementation(
 		async (path: string, opts: { method?: string; body?: unknown } = {}) => {
 			const method = opts.method ?? "GET";
 			calls.push({ path, method, body: opts.body });
 			if (path === "/api/account" && method === "PATCH") {
-				profile = { ...profile, name: (opts.body as { name: string }).name };
+				current = { ...current, name: (opts.body as { name: string }).name };
 			}
-			return profile;
+			if (path === "/api/account" && method === "DELETE") return { ok: true };
+			return current;
 		},
 	);
 }
@@ -48,17 +82,18 @@ function renderPage() {
 }
 
 beforeEach(() => {
+	replace.mockClear();
+	signOut.mockClear();
 	toastSuccess.mockClear();
-	setupApi();
+	toastError.mockClear();
+	setupApi(baseAccount());
 });
 
-describe("AccountSettingsPage", () => {
-	it("shows the name (editable) and the email (read-only) with the support note", async () => {
+describe("AccountSettingsPage — profile (PR1)", () => {
+	it("shows the name (editable) and the read-only email + support note", async () => {
 		renderPage();
 		const nameInput = await screen.findByLabelText("Name");
 		expect(nameInput).toHaveValue("Ada Lovelace");
-		expect(nameInput).not.toHaveAttribute("readonly");
-
 		const emailInput = screen.getByLabelText("Email (read-only)");
 		expect(emailInput).toHaveValue("ada@example.io");
 		expect(emailInput).toHaveAttribute("readonly");
@@ -67,49 +102,144 @@ describe("AccountSettingsPage", () => {
 		).toBeInTheDocument();
 	});
 
-	it("has a Billing link to the billing page", async () => {
-		renderPage();
-		await screen.findByLabelText("Name");
-		const link = screen.getByRole("link", { name: /billing/i });
-		expect(link).toHaveAttribute("href", "/settings/billing");
-	});
-
-	it("disables Save until the name changes, then PATCHes and toasts", async () => {
+	it("saves the name (PATCH + toast)", async () => {
 		const user = userEvent.setup();
 		renderPage();
 		const nameInput = await screen.findByLabelText("Name");
-
-		// Unchanged → Save is disabled.
-		expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
-
 		await user.clear(nameInput);
 		await user.type(nameInput, "Grace Hopper");
-		const saveBtn = screen.getByRole("button", { name: "Save" });
-		expect(saveBtn).toBeEnabled();
-		await user.click(saveBtn);
-
-		await waitFor(() => {
-			const patch = calls.find((c) => c.method === "PATCH");
-			expect(patch).toBeTruthy();
-			expect(patch!.path).toBe("/api/account");
-			expect(patch!.body).toEqual({ name: "Grace Hopper" });
-		});
+		await user.click(screen.getByRole("button", { name: "Save" }));
+		await waitFor(() =>
+			expect(calls.find((c) => c.method === "PATCH")?.body).toEqual({
+				name: "Grace Hopper",
+			}),
+		);
 		await waitFor(() =>
 			expect(toastSuccess).toHaveBeenCalledWith("Name updated"),
 		);
-		// The field reflects the saved value and Save goes disabled again.
-		expect(nameInput).toHaveValue("Grace Hopper");
-		await waitFor(() =>
-			expect(screen.getByRole("button", { name: "Save" })).toBeDisabled(),
-		);
+	});
+});
+
+describe("AccountSettingsPage — danger zone", () => {
+	it("states the deletion impact with the real counts", async () => {
+		renderPage();
+		await screen.findByLabelText("Name");
+		expect(
+			screen.getByText(
+				/permanently removes 1 workspace, 2 projects, 9 conversations, 3 sources, and 1 team member/i,
+			),
+		).toBeInTheDocument();
 	});
 
-	it("does not save a whitespace-only name (Save stays disabled)", async () => {
-		const user = userEvent.setup();
+	it("active subscription → disables delete, shows a Billing link", async () => {
+		setupApi(
+			baseAccount({
+				blockers: { activeSubscription: true, drift: false, coOwner: false },
+			}),
+		);
 		renderPage();
-		const nameInput = await screen.findByLabelText("Name");
-		await user.clear(nameInput);
-		await user.type(nameInput, "   ");
-		expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+		await screen.findByLabelText("Name");
+		expect(screen.getByText(/cancel your subscription/i)).toBeInTheDocument();
+		expect(
+			screen.getByRole("button", { name: "Delete account" }),
+		).toBeDisabled();
+		// A Billing link exists in the danger zone (in addition to the Billing card).
+		expect(
+			screen.getAllByRole("link", { name: /billing/i }).length,
+		).toBeGreaterThanOrEqual(2);
+	});
+
+	it("co-owner → guard message + disabled delete", async () => {
+		setupApi(
+			baseAccount({
+				blockers: { activeSubscription: false, drift: false, coOwner: true },
+			}),
+		);
+		renderPage();
+		await screen.findByLabelText("Name");
+		expect(
+			screen.getByText(/share ownership of a workspace/i),
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole("button", { name: "Delete account" }),
+		).toBeDisabled();
+	});
+
+	it("drift → contact-support message + disabled delete", async () => {
+		setupApi(
+			baseAccount({
+				blockers: { activeSubscription: false, drift: true, coOwner: false },
+			}),
+		);
+		renderPage();
+		await screen.findByLabelText("Name");
+		expect(
+			screen.getByText(/couldn't confirm your billing status/i),
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole("button", { name: "Delete account" }),
+		).toBeDisabled();
+	});
+});
+
+describe("AccountSettingsPage — delete flow", () => {
+	it("OAuth-only: type-email → confirm → DELETE, signOut, redirect to sign-in", async () => {
+		const user = userEvent.setup();
+		setupApi(baseAccount({ hasPassword: false }));
+		renderPage();
+		await screen.findByLabelText("Name");
+
+		await user.click(screen.getByRole("button", { name: "Delete account" }));
+		const dialog = await screen.findByRole("alertdialog");
+		// No password field for an OAuth-only user.
+		expect(within(dialog).queryByLabelText("Password")).not.toBeInTheDocument();
+
+		const confirmBtn = within(dialog).getByRole("button", {
+			name: /delete account/i,
+		});
+		expect(confirmBtn).toBeDisabled(); // until the email matches
+		await user.type(
+			within(dialog).getByLabelText("Confirm email"),
+			"ada@example.io",
+		);
+		expect(confirmBtn).toBeEnabled();
+		await user.click(confirmBtn);
+
+		await waitFor(() => {
+			const d = calls.find((c) => c.method === "DELETE");
+			expect(d).toBeTruthy();
+			expect(d!.body).toEqual({ confirmEmail: "ada@example.io" });
+		});
+		await waitFor(() => expect(signOut).toHaveBeenCalled());
+		await waitFor(() => expect(replace).toHaveBeenCalledWith("/sign-in"));
+	});
+
+	it("credential user: requires the password field before confirm arms", async () => {
+		const user = userEvent.setup();
+		setupApi(baseAccount({ hasPassword: true }));
+		renderPage();
+		await screen.findByLabelText("Name");
+
+		await user.click(screen.getByRole("button", { name: "Delete account" }));
+		const dialog = await screen.findByRole("alertdialog");
+		await user.type(
+			within(dialog).getByLabelText("Confirm email"),
+			"ada@example.io",
+		);
+		// Email matches but password is still empty → confirm stays disabled.
+		const confirmBtn = within(dialog).getByRole("button", {
+			name: /delete account/i,
+		});
+		expect(confirmBtn).toBeDisabled();
+		await user.type(within(dialog).getByLabelText("Password"), "hunter2");
+		expect(confirmBtn).toBeEnabled();
+		await user.click(confirmBtn);
+		await waitFor(() => {
+			const d = calls.find((c) => c.method === "DELETE");
+			expect(d!.body).toEqual({
+				confirmEmail: "ada@example.io",
+				password: "hunter2",
+			});
+		});
 	});
 });

--- a/apps/dashboard/src/app/settings/account/page.tsx
+++ b/apps/dashboard/src/app/settings/account/page.tsx
@@ -3,6 +3,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { CreditCard, Info } from "lucide-react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { toast } from "sonner";
 
@@ -19,22 +20,57 @@ import { Label } from "@/components/ui/label";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
 	ACCOUNT_KEY,
+	deleteAccount,
 	fetchAccount,
 	updateAccountName,
 	type Account,
+	type DeletionImpact,
 } from "@/lib/account";
-import { describeApiError } from "@/lib/api";
+import { ApiError, describeApiError } from "@/lib/api";
+import { resetAnalytics } from "@/lib/analytics";
+import { signOut } from "@/lib/auth-client";
+
+import { DeleteAccountDialog } from "./_components/DeleteAccountDialog";
 
 const NAME_MAX = 100;
 
+function plural(n: number, word: string) {
+	return `${n} ${word}${n === 1 ? "" : "s"}`;
+}
+
+function impactSentence(i: DeletionImpact): string {
+	return `Deleting your account permanently removes ${plural(i.workspaces, "workspace")}, ${plural(i.projects, "project")}, ${plural(i.conversations, "conversation")}, ${plural(i.sources, "source")}, and ${plural(i.members, "team member")}. This can't be undone.`;
+}
+
+/** Map a DELETE /account failure to a clear sentence. */
+function deleteErrorMessage(e: unknown): string {
+	if (e instanceof ApiError) {
+		switch (e.code) {
+			case "email_mismatch":
+				return "The email you typed doesn't match your account.";
+			case "password_required":
+			case "invalid_password":
+				return "Incorrect password.";
+			case "co_owner":
+				return "You share ownership of a workspace. Remove the other owner first.";
+			case "active_subscription":
+				return "Cancel your subscription in Billing before deleting your account.";
+			case "billing_unverified":
+				return "We couldn't verify your billing status — please try again.";
+			case "billing_drift":
+				return "We couldn't confirm your billing status. Contact support.";
+		}
+	}
+	return describeApiError(e, "Couldn't delete your account");
+}
+
 export default function AccountSettingsPage() {
 	const qc = useQueryClient();
+	const router = useRouter();
 	const accountQ = useQuery({ queryKey: ACCOUNT_KEY, queryFn: fetchAccount });
+	const acct = accountQ.data;
 
-	// Draft name, seeded from the loaded profile. Keyed on the loaded value so a
-	// background refetch that changes the server name re-seeds the field (when the
-	// user hasn't started editing — see `dirty`).
-	const loadedName = accountQ.data?.name ?? "";
+	const loadedName = acct?.name ?? "";
 	const [draft, setDraft] = useState<string | null>(null);
 	const name = draft ?? loadedName;
 	const trimmed = name.trim();
@@ -42,14 +78,39 @@ export default function AccountSettingsPage() {
 
 	const save = useMutation({
 		mutationFn: () => updateAccountName(trimmed),
-		onSuccess: (data: Account) => {
-			qc.setQueryData(ACCOUNT_KEY, data);
+		onSuccess: (data: { name: string; email: string }) => {
+			qc.setQueryData<Account>(ACCOUNT_KEY, (prev) =>
+				prev ? { ...prev, name: data.name } : prev,
+			);
 			setDraft(null);
 			toast.success("Name updated");
 		},
 		onError: (e) =>
 			toast.error(describeApiError(e, "Couldn't update your name")),
 	});
+
+	const [deleteOpen, setDeleteOpen] = useState(false);
+	const remove = useMutation({
+		mutationFn: (body: { confirmEmail: string; password?: string }) =>
+			deleteAccount(body),
+		onSuccess: async () => {
+			setDeleteOpen(false);
+			toast.success("Your account has been deleted");
+			// No dead-cookie window: sign out (clears the cookie), drop all cached
+			// state, and land on sign-in.
+			await signOut();
+			resetAnalytics();
+			qc.clear();
+			router.replace("/sign-in");
+		},
+		onError: (e) => toast.error(deleteErrorMessage(e)),
+	});
+
+	const blockers = acct?.blockers;
+	const blocked = Boolean(
+		blockers &&
+		(blockers.coOwner || blockers.activeSubscription || blockers.drift),
+	);
 
 	return (
 		<div className="mx-auto w-full max-w-[800px] space-y-6 p-6">
@@ -108,7 +169,7 @@ export default function AccountSettingsPage() {
 								<Label htmlFor="account-email">Email</Label>
 								<Input
 									id="account-email"
-									value={accountQ.data?.email ?? ""}
+									value={acct?.email ?? ""}
 									readOnly
 									disabled
 									aria-label="Email (read-only)"
@@ -139,6 +200,62 @@ export default function AccountSettingsPage() {
 					</Button>
 				</CardContent>
 			</Card>
+
+			<Card className="border-destructive/40">
+				<CardHeader>
+					<CardTitle className="text-destructive">Danger zone</CardTitle>
+					<CardDescription>
+						Permanently delete your account and all of its data.
+					</CardDescription>
+				</CardHeader>
+				<CardContent className="space-y-3">
+					{acct && (
+						<p className="text-sm text-muted-foreground">
+							{impactSentence(acct.impact)}
+						</p>
+					)}
+
+					{blockers?.coOwner ? (
+						<p className="rounded-lg border bg-muted/40 p-3 text-sm text-muted-foreground">
+							You share ownership of a workspace. Transfer or remove the other
+							owner before deleting your account.
+						</p>
+					) : blockers?.activeSubscription ? (
+						<div className="flex flex-col items-start gap-3 rounded-lg border bg-muted/40 p-3 text-sm text-muted-foreground">
+							<span>
+								Cancel your subscription before deleting your account.
+							</span>
+							<Button asChild variant="outline" size="sm">
+								<Link href="/settings/billing">Go to Billing</Link>
+							</Button>
+						</div>
+					) : blockers?.drift ? (
+						<p className="rounded-lg border bg-muted/40 p-3 text-sm text-muted-foreground">
+							We couldn&apos;t confirm your billing status. Please contact
+							support before deleting your account.
+						</p>
+					) : null}
+
+					<Button
+						variant="destructive"
+						disabled={!acct || blocked || remove.isPending}
+						onClick={() => setDeleteOpen(true)}
+					>
+						Delete account
+					</Button>
+				</CardContent>
+			</Card>
+
+			{acct && (
+				<DeleteAccountDialog
+					open={deleteOpen}
+					onOpenChange={setDeleteOpen}
+					email={acct.email}
+					requirePassword={acct.hasPassword}
+					pending={remove.isPending}
+					onConfirm={(body) => remove.mutate(body)}
+				/>
+			)}
 		</div>
 	);
 }

--- a/apps/dashboard/src/lib/account.ts
+++ b/apps/dashboard/src/lib/account.ts
@@ -1,9 +1,32 @@
 import { api } from "@/lib/api";
 
+/** What account deletion will permanently remove (counts across solely-owned
+ * workspaces). */
+export interface DeletionImpact {
+	workspaces: number;
+	projects: number;
+	conversations: number;
+	sources: number;
+	members: number;
+}
+
+/** Reasons deletion is currently blocked (hints from the GET; DELETE re-verifies
+ * the subscription live + fail-closed). */
+export interface AccountBlockers {
+	activeSubscription: boolean;
+	drift: boolean;
+	coOwner: boolean;
+}
+
 /** The signed-in user's own profile (session-scoped; no id is ever sent). */
 export interface Account {
 	name: string;
 	email: string;
+	/** True when the user has a password (a credential account) — drives the
+	 * conditional password field in the delete dialog. */
+	hasPassword: boolean;
+	impact: DeletionImpact;
+	blockers: AccountBlockers;
 }
 
 /** react-query key for the account profile. */
@@ -14,5 +37,15 @@ export function fetchAccount() {
 }
 
 export function updateAccountName(name: string) {
-	return api<Account>("/api/account", { method: "PATCH", body: { name } });
+	return api<{ name: string; email: string }>("/api/account", {
+		method: "PATCH",
+		body: { name },
+	});
+}
+
+export function deleteAccount(body: {
+	confirmEmail: string;
+	password?: string;
+}) {
+	return api<{ ok: true }>("/api/account", { method: "DELETE", body });
 }


### PR DESCRIPTION
**PR2 of 2.** The irreversible core: permanently delete the caller's account + every workspace they solely own. Built to the locked design + the two pre-build audits. (PR1 #60 shipped the non-destructive page.) Does **not** pull the parked `feat/delete-workspace` branch (reused its type-to-confirm dialog *pattern* only); **no** standalone `DELETE /workspaces/:id`.

## API
- **`lib/stripe.ts`** — `retrieveSubscription(secret, id)` (GET, same `fetch`/`formEncode` pattern).
- **`lib/workspace-deletion.ts`** (new) — the destructive core, **explicit + set-based, never `onDelete: cascade`**:
  - `workspaceDeleteStatements` (11-step, child→parent, `DELETE … WHERE … IN (SELECT …)` — constant statement count) and `userDeleteStatements` (null authored messages → member → read_status → account → passkey → **verification sweep by email** → session → **user LAST**), executed via `db.batch` (atomic per workspace).
  - `resolveOwnership` (solely-owned vs **co-owned**), `gateWorkspace`/`assertDeletable` (live + fail-closed), `ownedWorkspaceImpact`.
  - **Sub-gate:** no sub id & not paid → **ALLOW, no Stripe call**; sub id set → live `retrieveSubscription` (`{active,trialing,past_due,unpaid,paused}` → block; `{canceled,incomplete,incomplete_expired}` → allow); Stripe error / missing secret → **fail-closed `billing_unverified`**; paid-but-no-subId drift → **fail-closed `billing_drift`**.
- **`routes/account.ts`** — `GET` extended (profile + impact + blocker **hints** + `hasPassword`; deliberately **no Stripe call on page load** — DELETE re-verifies live). `DELETE /account` is **self-from-session, no id input**: email-confirm → re-auth (`better-auth/crypto` `verifyPassword` when a `credential` account exists; OAuth-only skips) → co-owner `409` → live sub-gate `409` → per-workspace cascade → user rows last.

## Dashboard
Danger zone with impact counts + the three blocked states (active-sub → Billing link + disabled confirm; co-owner guard; drift → contact support). `DeleteAccountDialog` (type-email + **conditional** password, reset-on-close, destructive). On success: `signOut()` + `qc.clear()` + `router.replace("/sign-in")` — **no dead-cookie window**.

## Proof gate (the de-risker)
`workspace-deletion.test.ts` applies the real migrations to **node:sqlite with `PRAGMA foreign_keys=OFF`** (and an ON variant), seeds every table under a workspace, renders the **actual generated SQL** (`.toSQL()`) of the service's statements, runs them, and asserts **every child table empties on its own** (and an unrelated workspace survives) — proving the explicit deletes don't rely on cascade. Plus: user-delete proof (all user rows gone, authored message **disowned not deleted**, verification swept, `u2` intact), **self-only** (user `DELETE` keyed to the session id, never `victim`), full **sub-gate matrix** (every status; free path makes **no** Stripe call; Stripe-error & missing-secret fail closed; drift fail closed), and `assertDeletable` first-blocker.

Route orchestration (`account.test.ts`): 401; email mismatch 400 (nothing deleted); credential no-password 403; wrong-password 403 (verified via better-auth); correct-password proceeds; OAuth-only deletes with no password; **co-owner 409** (no deletes); **active-sub / billing_unverified 409 before any delete**; happy path cascades each workspace **then user last** (ordering asserted) with the **session** id (smuggled `id` ignored); **idempotent re-run** from partial state.

Dashboard RTL: impact sentence; the three blocked states (disabled + Billing link); type-email arms confirm; conditional password; success → DELETE + `signOut` + redirect; dialog reset-on-close.

## Tests / gates
API **278** (+27), dashboard **310** (+7); `pnpm build` 5/5, lint, prettier `--check`, secret scan — all clean. Unrelated drift (`.agents/*`, `skills-lock.json`, `consent.ts`, `docs/`) left unstaged.

## Accepted residuals (documented in code + here)
- **F1** in-flight `escalate`/`rating`/`csat` orphan rows — invisible (workspace gone), no exposure.
- **S1** orphaned Stripe customer — harmless; deletion stays DB-local (the sub is already canceled by the gate).
- **O1** OAuth grant not revoked provider-side — standard; tokens are deleted locally.
- The optional `auth` `user.delete.before` hook is **intentionally skipped** — a raw drizzle delete doesn't trigger Better-Auth hooks, and this endpoint owns the ordering explicitly.

### Confirm-with-Luca/Ploy (non-blocking)
D1 / Ploy-emulator `db.batch()` atomicity (the explicit deletes are correct regardless; atomicity only affects partial-failure windows, which are idempotently retryable and never delete the user before its workspaces).

🤖 Generated with [Claude Code](https://claude.com/claude-code)