### PR TITLE
fix(onboarding): escape hatch on the paywall (account menu + guard allowlist)

### DIFF
--- a/apps/dashboard/src/app/onboarding/_components/OnboardingAccountMenu.tsx
+++ b/apps/dashboard/src/app/onboarding/_components/OnboardingAccountMenu.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { ChevronsUpDown, LogOut, UserCog } from "lucide-react";
+import Link from "next/link";
+
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { Button } from "@/components/ui/button";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuLabel,
+	DropdownMenuSeparator,
+	DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { useSignOut } from "@/lib/use-sign-out";
+
+/**
+ * The escape hatch on the onboarding/paywall screen (which has no sidebar): a
+ * small top-right account control so a signed-in, no-plan user can reach their
+ * account settings or sign out instead of being stranded on the paywall. It does
+ * NOT let them use the product — the paywall + the server-side 402 still gate
+ * that — only manage or leave their account.
+ */
+export function OnboardingAccountMenu({ email }: { email: string }) {
+	const handleSignOut = useSignOut();
+	const initials = email.slice(0, 2).toUpperCase();
+
+	return (
+		<DropdownMenu>
+			<DropdownMenuTrigger asChild>
+				<Button
+					variant="outline"
+					aria-label="Account menu"
+					className="h-auto gap-2 bg-background/70 py-1.5 pl-1.5 pr-2 backdrop-blur"
+				>
+					<Avatar className="size-7 rounded-md">
+						<AvatarFallback className="rounded-md text-xs">
+							{initials}
+						</AvatarFallback>
+					</Avatar>
+					{/* Email hidden on the smallest screens to keep the control compact;
+					    the avatar + chevron remain tappable. */}
+					<span className="hidden max-w-[12rem] truncate text-sm font-medium sm:inline">
+						{email}
+					</span>
+					<ChevronsUpDown className="size-4 shrink-0 opacity-50" />
+				</Button>
+			</DropdownMenuTrigger>
+			<DropdownMenuContent align="end" className="min-w-56">
+				<DropdownMenuLabel className="truncate text-xs text-muted-foreground">
+					{email}
+				</DropdownMenuLabel>
+				<DropdownMenuSeparator />
+				<DropdownMenuItem asChild>
+					<Link href="/settings/account">
+						<UserCog />
+						Account settings
+					</Link>
+				</DropdownMenuItem>
+				<DropdownMenuItem onClick={handleSignOut}>
+					<LogOut />
+					Sign out
+				</DropdownMenuItem>
+			</DropdownMenuContent>
+		</DropdownMenu>
+	);
+}

--- a/apps/dashboard/src/app/onboarding/page.test.tsx
+++ b/apps/dashboard/src/app/onboarding/page.test.tsx
@@ -1,16 +1,22 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { planEntitlements } from "@llmchat/shared";
 
 import { api, ApiError } from "@/lib/api";
-import { useSession } from "@/lib/auth-client";
+import { signOut, useSession } from "@/lib/auth-client";
 import { fetchUsage } from "@/lib/billing";
 import { useOnboardingState } from "@/lib/use-onboarding";
 
 import OnboardingPage from "./page";
+
+beforeAll(() => {
+	// Radix DropdownMenu (the account menu) needs these in jsdom.
+	Element.prototype.scrollIntoView = vi.fn();
+	Element.prototype.hasPointerCapture ??= () => false;
+});
 
 const push = vi.fn();
 const replace = vi.fn();
@@ -19,7 +25,10 @@ vi.mock("next/navigation", () => ({
 	useRouter: () => ({ push, replace }),
 	useSearchParams: () => searchParams,
 }));
-vi.mock("@/lib/auth-client", () => ({ useSession: vi.fn() }));
+vi.mock("@/lib/auth-client", () => ({
+	useSession: vi.fn(),
+	signOut: vi.fn(() => Promise.resolve()),
+}));
 vi.mock("@/lib/use-onboarding", () => ({ useOnboardingState: vi.fn() }));
 vi.mock("sonner", () => ({
 	toast: { error: vi.fn(), warning: vi.fn(), success: vi.fn() },
@@ -130,6 +139,55 @@ describe("OnboardingPage (form redesign)", () => {
 		).toBeInTheDocument();
 		// The build form must not be reachable while unpaid.
 		expect(screen.queryByLabelText(/agent name/i)).not.toBeInTheDocument();
+	});
+
+	it("offers an escape hatch on the paywall: account menu with account link + sign out", async () => {
+		const u = user();
+		vi.mocked(fetchUsage).mockResolvedValue({
+			plan: "none",
+			exempt: false,
+			entitlements: planEntitlements("none"),
+			usage: { projects: 0, members: 1, responsesThisMonth: 0 },
+			availablePlans: ["starter", "growth", "scale"],
+			monthStartUnix: 0,
+		});
+		renderPage();
+		await screen.findByRole("heading", {
+			name: /choose a plan to launch your agent/i,
+		});
+
+		// The account control is present on the paywall (not stranded).
+		await u.click(screen.getByRole("button", { name: /account menu/i }));
+
+		// Account settings → the page a no-plan user can actually reach.
+		const accountLink = screen.getByRole("menuitem", {
+			name: /account settings/i,
+		});
+		expect(accountLink).toHaveAttribute("href", "/settings/account");
+
+		// Sign out — the guaranteed escape: ends the session + lands on sign-in.
+		await u.click(screen.getByRole("menuitem", { name: /sign out/i }));
+		await waitFor(() => expect(signOut).toHaveBeenCalled());
+		await waitFor(() => expect(replace).toHaveBeenCalledWith("/sign-in"));
+	});
+
+	it("keeps the account menu trigger visible on mobile (no responsive hide)", async () => {
+		vi.mocked(fetchUsage).mockResolvedValue({
+			plan: "none",
+			exempt: false,
+			entitlements: planEntitlements("none"),
+			usage: { projects: 0, members: 1, responsesThisMonth: 0 },
+			availablePlans: ["starter", "growth", "scale"],
+			monthStartUnix: 0,
+		});
+		renderPage();
+		await screen.findByRole("heading", {
+			name: /choose a plan to launch your agent/i,
+		});
+		// Only the email label inside collapses on small screens; the trigger itself
+		// carries no `hidden` class, so it stays tappable on mobile.
+		const trigger = screen.getByRole("button", { name: /account menu/i });
+		expect(trigger.className).not.toMatch(/(^|\s)hidden(\s|$)/);
 	});
 
 	it("lets an exempt internal workspace skip the paywall and build", async () => {

--- a/apps/dashboard/src/app/onboarding/page.tsx
+++ b/apps/dashboard/src/app/onboarding/page.tsx
@@ -22,6 +22,7 @@ import { useWorkspace } from "@/lib/workspace";
 
 import { initialDraft, type BotDraft } from "./_components/bot-form";
 import { LivePreview } from "./_components/LivePreview";
+import { OnboardingAccountMenu } from "./_components/OnboardingAccountMenu";
 import { panelVisibility, type MobileView } from "./_components/mobile-view";
 import { OnboardingForm } from "./_components/OnboardingForm";
 import { OnboardingPaywall } from "./_components/OnboardingPaywall";
@@ -209,6 +210,12 @@ function OnboardingFlow() {
 			<div className="pointer-events-none absolute inset-0 -z-10" aria-hidden>
 				<div className="absolute left-1/2 top-[-8rem] h-[36rem] w-[60rem] -translate-x-1/2 rounded-full bg-indigo-500/10 blur-3xl dark:bg-indigo-500/20" />
 				<div className="absolute right-[-6rem] top-1/3 h-[28rem] w-[28rem] rounded-full bg-violet-600/10 blur-3xl dark:bg-violet-600/15" />
+			</div>
+
+			{/* Escape hatch: a no-plan user stranded on the paywall can still reach
+			    their account or sign out. Shown on every onboarding screen. */}
+			<div className="absolute right-3 top-3 z-20 sm:right-5 sm:top-5">
+				<OnboardingAccountMenu email={session.user.email} />
 			</div>
 
 			<div className="mx-auto flex min-h-svh w-full max-w-5xl flex-col gap-10 px-4 py-10 sm:px-6">

--- a/apps/dashboard/src/components/app-sidebar.tsx
+++ b/apps/dashboard/src/components/app-sidebar.tsx
@@ -18,8 +18,7 @@ import {
 } from "lucide-react";
 
 import { api } from "@/lib/api";
-import { signOut } from "@/lib/auth-client";
-import { track, resetAnalytics, ANALYTICS_EVENTS } from "@/lib/analytics";
+import { useSignOut } from "@/lib/use-sign-out";
 import { useWorkspace } from "@/lib/workspace";
 import { BrandLogo } from "@/components/brand-logo";
 import { RoleGate } from "@/components/role-gate";
@@ -106,6 +105,7 @@ export function AppSidebar({ userEmail }: { userEmail: string }) {
 	const pathname = usePathname();
 	const router = useRouter();
 	const { workspaces, workspaceId, setWorkspaceId, role } = useWorkspace();
+	const handleSignOut = useSignOut();
 	const initials = userEmail.slice(0, 2).toUpperCase();
 	const roleLabel = role ? role[0].toUpperCase() + role.slice(1) : "Member";
 
@@ -371,15 +371,7 @@ export function AppSidebar({ userEmail }: { userEmail: string }) {
 									</>
 								)}
 								<DropdownMenuSeparator />
-								<DropdownMenuItem
-									onClick={() => {
-										track(ANALYTICS_EVENTS.signedOut);
-										signOut().then(() => {
-											resetAnalytics();
-											router.replace("/sign-in");
-										});
-									}}
-								>
+								<DropdownMenuItem onClick={handleSignOut}>
 									<LogOut />
 									Sign out
 								</DropdownMenuItem>

--- a/apps/dashboard/src/lib/use-onboarding-redirect.test.tsx
+++ b/apps/dashboard/src/lib/use-onboarding-redirect.test.tsx
@@ -1,0 +1,86 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useOnboardingRedirect } from "./use-onboarding-redirect";
+
+const replace = vi.fn();
+let pathname = "/inbox";
+vi.mock("next/navigation", () => ({
+	useRouter: () => ({ replace }),
+	usePathname: () => pathname,
+}));
+
+let workspaceState: {
+	workspaces: { id: string }[];
+	workspaceId: string | null;
+	isLoading: boolean;
+};
+vi.mock("@/lib/workspace", () => ({ useWorkspace: () => workspaceState }));
+
+// The projects query returns an empty list, so a no-project user would be sent
+// to onboarding on a non-escape route.
+vi.mock("@/lib/api", () => ({ api: vi.fn(async () => ({ projects: [] })) }));
+
+function wrapper({ children }: { children: ReactNode }) {
+	const client = new QueryClient({
+		defaultOptions: { queries: { retry: false } },
+	});
+	return createElement(QueryClientProvider, { client }, children);
+}
+
+beforeEach(() => {
+	replace.mockClear();
+	localStorage.clear();
+	pathname = "/inbox";
+	workspaceState = {
+		workspaces: [{ id: "ws1" }],
+		workspaceId: "ws1",
+		isLoading: false,
+	};
+});
+afterEach(() => vi.clearAllMocks());
+
+describe("useOnboardingRedirect", () => {
+	it("redirects a no-project user to /onboarding from a normal route", async () => {
+		pathname = "/inbox";
+		renderHook(() => useOnboardingRedirect(true), { wrapper });
+		await waitFor(() => expect(replace).toHaveBeenCalledWith("/onboarding"));
+	});
+
+	it("redirects a brand-new (no-workspace) user to /onboarding", async () => {
+		workspaceState = { workspaces: [], workspaceId: null, isLoading: false };
+		renderHook(() => useOnboardingRedirect(true), { wrapper });
+		await waitFor(() => expect(replace).toHaveBeenCalledWith("/onboarding"));
+	});
+
+	it("does NOT bounce a no-plan user off /settings/account (the escape hatch)", async () => {
+		pathname = "/settings/account";
+		renderHook(() => useOnboardingRedirect(true), { wrapper });
+		// Give the effect + the projects query time to resolve, then assert no bounce.
+		await new Promise((r) => setTimeout(r, 20));
+		expect(replace).not.toHaveBeenCalled();
+	});
+
+	it("does NOT bounce a no-plan user off /settings/billing", async () => {
+		pathname = "/settings/billing";
+		renderHook(() => useOnboardingRedirect(true), { wrapper });
+		await new Promise((r) => setTimeout(r, 20));
+		expect(replace).not.toHaveBeenCalled();
+	});
+
+	it("does not redirect even a brand-new user away from the escape routes", async () => {
+		workspaceState = { workspaces: [], workspaceId: null, isLoading: false };
+		pathname = "/settings/account";
+		renderHook(() => useOnboardingRedirect(true), { wrapper });
+		await new Promise((r) => setTimeout(r, 20));
+		expect(replace).not.toHaveBeenCalled();
+	});
+
+	it("is inert when disabled", async () => {
+		renderHook(() => useOnboardingRedirect(false), { wrapper });
+		await new Promise((r) => setTimeout(r, 20));
+		expect(replace).not.toHaveBeenCalled();
+	});
+});

--- a/apps/dashboard/src/lib/use-onboarding-redirect.ts
+++ b/apps/dashboard/src/lib/use-onboarding-redirect.ts
@@ -1,13 +1,21 @@
 "use client";
 
 import { useEffect } from "react";
-import { useRouter } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import { useQuery } from "@tanstack/react-query";
 
 import { api } from "@/lib/api";
 import { useWorkspace } from "@/lib/workspace";
 
 const DISMISSED_KEY = "Clanker Support:onboarding:dismissed";
+
+/**
+ * Routes a no-plan / no-project user may reach WITHOUT being bounced back to
+ * onboarding — the account + billing pages, the paywall's escape hatch (manage
+ * or leave the account, or pay). They still can't USE the product (inbox /
+ * projects) without a plan, so the paywall isn't bypassed.
+ */
+const ESCAPE_PREFIXES = ["/settings/account", "/settings/billing"];
 
 /** Marks onboarding as dismissed so the redirect below stops firing. */
 export function dismissOnboarding() {
@@ -21,6 +29,7 @@ export function dismissOnboarding() {
  */
 export function useOnboardingRedirect(enabled: boolean) {
 	const router = useRouter();
+	const pathname = usePathname();
 	const { workspaces, workspaceId, isLoading } = useWorkspace();
 
 	const projects = useQuery({
@@ -36,6 +45,8 @@ export function useOnboardingRedirect(enabled: boolean) {
 		if (!enabled || typeof window === "undefined") return;
 		if (localStorage.getItem(DISMISSED_KEY)) return;
 		if (isLoading) return;
+		// Escape hatch: never bounce a no-plan user off their account/billing pages.
+		if (ESCAPE_PREFIXES.some((p) => pathname.startsWith(p))) return;
 
 		// Brand-new user — no workspace exists yet.
 		if (workspaces.length === 0) {
@@ -58,5 +69,6 @@ export function useOnboardingRedirect(enabled: boolean) {
 		projects.isSuccess,
 		projects.data,
 		router,
+		pathname,
 	]);
 }

--- a/apps/dashboard/src/lib/use-sign-out.ts
+++ b/apps/dashboard/src/lib/use-sign-out.ts
@@ -1,0 +1,26 @@
+"use client";
+
+import { useQueryClient } from "@tanstack/react-query";
+import { useRouter } from "next/navigation";
+import { useCallback } from "react";
+
+import { ANALYTICS_EVENTS, resetAnalytics, track } from "@/lib/analytics";
+import { signOut } from "@/lib/auth-client";
+
+/**
+ * Sign out from anywhere: end the session, reset analytics, drop ALL cached
+ * (workspace/query) state, and land on /sign-in. The single escape hatch reused
+ * by the sidebar account menu and the onboarding paywall, so the two can't drift.
+ */
+export function useSignOut() {
+	const router = useRouter();
+	const qc = useQueryClient();
+	return useCallback(() => {
+		track(ANALYTICS_EVENTS.signedOut);
+		void signOut().then(() => {
+			resetAnalytics();
+			qc.clear();
+			router.replace("/sign-in");
+		});
+	}, [router, qc]);
+}


### PR DESCRIPTION
## Problem
A signed-in user with no plan lands on `/onboarding`'s **"Choose a plan to launch your agent"** paywall — which has **no sidebar**, so there was no way to sign out or reach their account. Dead end.

## Fix
- **`lib/use-sign-out.ts`** (new) — a shared sign-out hook: `signOut()` → reset analytics → **clear all query/workspace caches** (`qc.clear()`) → `router.replace("/sign-in")`. `app-sidebar` is refactored to use it, so the sidebar and the new paywall menu are the **same** logic (can't drift). *(This also adds cache-clear to the sidebar sign-out, which it lacked.)*
- **`OnboardingAccountMenu`** (new) — a small **top-right** account control on every onboarding screen: shows the signed-in **email**, links to **`/settings/account`**, and **Sign out**. Responsive — the email label collapses on the smallest screens; the avatar/trigger stays tappable.
- **`use-onboarding-redirect`** (the critical guard) — no longer bounces a no-plan/no-project user off **`/settings/account`** or **`/settings/billing`** (an allowlist of escape routes — manage/leave the account, or pay). So the "Account settings" link actually lands instead of bouncing back to the paywall.

## Doesn't bypass the paywall
The escape routes are **account/billing management only** — `/inbox` and `/settings/projects` still redirect to onboarding, and `POST /api/projects` still returns **402 `subscription_required`** server-side. A no-plan user can manage or leave their account, **not use the product**.

## Both paths escape (confirmed)
- **Sign out** — leaves the app to `/sign-in` regardless of plan/guard.
- **Account settings** — reaches `/settings/account` (guard allowlist) without a bounce; from there Billing and (now-merged) delete-account are available.

## Files touched (7)
`lib/use-sign-out.ts` (new), `lib/use-onboarding-redirect.ts` (+ `.test.tsx` new), `components/app-sidebar.tsx` (use the hook), `app/onboarding/_components/OnboardingAccountMenu.tsx` (new), `app/onboarding/page.tsx` (wire the menu), `app/onboarding/page.test.tsx` (tests).

## Tests (dashboard 318, +8)
- **guard** (`use-onboarding-redirect.test.tsx`): redirects a no-project user and a brand-new user to `/onboarding` from a normal route; **does NOT bounce** off `/settings/account` or `/settings/billing` (even a brand-new user); inert when disabled.
- **paywall** (`page.test.tsx`): the account menu is present on the paywall; **Account settings** menuitem points to `/settings/account`; **Sign out** calls `signOut()` + `router.replace("/sign-in")`; the trigger stays visible on mobile (no responsive `hidden`).

`pnpm build` 5/5, lint, prettier `--check`, secret scan — clean. Unrelated drift (`.agents/*`, `skills-lock.json`, `consent.ts`, `docs/`) left unstaged.

### RTL stand-ins for screenshots (no headless browser)
- Paywall heading "Choose a plan to launch your agent" + the **Account menu** button in the top-right.
- Open menu → email label, **Account settings** (`href="/settings/account"`), **Sign out**.
- Guard: `replace("/onboarding")` fired on `/inbox`, **not** fired on `/settings/account` / `/settings/billing`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)