### PR TITLE
feat(workspaces): create + delete workspaces

### DIFF
--- a/apps/api/src/routes/projects.paywall.e2e.test.ts
+++ b/apps/api/src/routes/projects.paywall.e2e.test.ts
@@ -1,0 +1,128 @@
+// Paywall-after-create end-to-end: proves that creating a workspace grants NO
+// free building capacity. A workspace is provisioned through the REAL
+// provisionWorkspace (so it gets the schema's plan=none default, exactly like
+// POST /api/workspaces does), then the REAL projects route + REAL resolveAccess
+// gate run against it over a real sqlite. The build must still 402 — workspace
+// creation can't be used to slip past the subscription wall.
+
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+
+import { drizzle } from "drizzle-orm/sqlite-proxy";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { db } from "@/lib/db";
+import { provisionWorkspace } from "@/lib/provisioning";
+import { schema } from "@llmchat/db";
+
+import { projects } from "./projects";
+
+// Header-driven fake session so requireSession/requireWorkspace/requireRole run
+// for real without standing up Better Auth.
+vi.mock("@/auth", () => ({
+	createAuth: () => ({
+		api: {
+			getSession: async ({ headers }: { headers: Headers }) => {
+				const id = headers.get("x-test-user");
+				return id ? { user: { id } } : null;
+			},
+		},
+	}),
+}));
+vi.mock("@/lib/db", () => ({ db: vi.fn() }));
+
+function applyMigrations(sqlite: DatabaseSync) {
+	sqlite.exec("PRAGMA foreign_keys=OFF;");
+	const dir = join(process.cwd(), "migrations");
+	for (const f of readdirSync(dir)
+		.filter((x) => x.endsWith(".sql"))
+		.sort()) {
+		sqlite.exec(
+			readFileSync(join(dir, f), "utf8")
+				.split("--> statement-breakpoint")
+				.join("\n"),
+		);
+	}
+}
+
+function makeProxy(sqlite: DatabaseSync) {
+	const exec = async (sql: string, params: unknown[], method: string) => {
+		const stmt = sqlite.prepare(sql);
+		if (method === "run") {
+			stmt.run(...(params as never[]));
+			return { rows: [] };
+		}
+		const rows = stmt
+			.all(...(params as never[]))
+			.map((r) => Object.values(r as object));
+		return { rows: method === "get" ? (rows[0] as never) : rows };
+	};
+	const batch = async (
+		queries: { sql: string; params: unknown[]; method: string }[],
+	) =>
+		queries.map((q) => {
+			const stmt = sqlite.prepare(q.sql);
+			if (q.method === "run") {
+				stmt.run(...(q.params as never[]));
+				return { rows: [] };
+			}
+			const rows = stmt
+				.all(...(q.params as never[]))
+				.map((o) => Object.values(o as object));
+			return { rows: q.method === "get" ? (rows[0] as never) : rows };
+		});
+	return drizzle(exec, batch, { schema, casing: "snake_case" });
+}
+
+// No INTERNAL_ACCOUNT_EMAILS ⇒ no exemption path; the gate sees the real plan.
+const ENV = { vars: {} } as never;
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("paywall: a freshly created workspace cannot build (no free capacity)", () => {
+	it("provisions plan=none, then POST /projects 402s subscription_required and inserts nothing", async () => {
+		const sqlite = new DatabaseSync(":memory:");
+		applyMigrations(sqlite);
+		sqlite.exec(
+			`INSERT INTO user (id,name,email) VALUES ('u1','U1','u1@x.io')`,
+		);
+
+		const proxy = makeProxy(sqlite);
+		vi.mocked(db).mockReturnValue(proxy as never);
+
+		// Create the workspace exactly like POST /api/workspaces does.
+		const ws = await provisionWorkspace(proxy as never, "u1", "Fresh");
+
+		// Sanity: the new workspace really is unpaid (schema default).
+		const planRow = sqlite
+			.prepare(`SELECT plan FROM workspace WHERE id = ?`)
+			.get(ws.id) as { plan: string };
+		expect(planRow.plan).toBe("none");
+
+		// The owner of this brand-new workspace tries to build a project.
+		const res = await projects.request(
+			"/projects",
+			{
+				method: "POST",
+				headers: {
+					"x-test-user": "u1",
+					"x-workspace-id": ws.id,
+					"content-type": "application/json",
+				},
+				body: JSON.stringify({ name: "Bot" }),
+			},
+			ENV,
+		);
+
+		// Hard server-side paywall — owner role is fine, but no subscription ⇒ 402.
+		expect(res.status).toBe(402);
+		expect(await res.json()).toMatchObject({ error: "subscription_required" });
+
+		// Nothing was created — creating a workspace bought zero build capacity.
+		const projectCount = (
+			sqlite.prepare(`SELECT count(*) AS n FROM project`).get() as { n: number }
+		).n;
+		expect(projectCount).toBe(0);
+	});
+});

--- a/apps/api/src/routes/workspaces.delete.e2e.test.ts
+++ b/apps/api/src/routes/workspaces.delete.e2e.test.ts
@@ -1,0 +1,223 @@
+// End-to-end workspace-delete test: the REAL route + the REAL workspace-deletion
+// cascade, executing against a real sqlite (via the sqlite-proxy driver) seeded
+// with the actual migrations. Only the session and Stripe's network call are
+// mocked. This asserts the DATA outcome the unit test can't: that deleting ONE
+// workspace empties that workspace's whole subtree while a SECOND workspace and
+// the user survive completely untouched.
+
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+
+import { drizzle } from "drizzle-orm/sqlite-proxy";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { db } from "@/lib/db";
+import { schema } from "@llmchat/db";
+
+import { workspaces } from "./workspaces";
+
+vi.mock("@/auth", () => ({
+	createAuth: () => ({
+		api: {
+			getSession: async ({ headers }: { headers: Headers }) => {
+				const id = headers.get("x-test-user");
+				return id ? { user: { id } } : null;
+			},
+		},
+	}),
+}));
+vi.mock("@/lib/db", () => ({ db: vi.fn() }));
+// Only Stripe's network call is mocked; the gate logic itself runs for real. A
+// free (plan=none, no sub) workspace never reaches it.
+vi.mock("@/lib/stripe", () => ({ retrieveSubscription: vi.fn() }));
+import { retrieveSubscription } from "@/lib/stripe";
+
+// ─── real sqlite (via proxy) ──────────────────────────────────────────────────
+
+function applyMigrations(sqlite: DatabaseSync) {
+	sqlite.exec("PRAGMA foreign_keys=OFF;");
+	const dir = join(process.cwd(), "migrations");
+	for (const f of readdirSync(dir)
+		.filter((x) => x.endsWith(".sql"))
+		.sort()) {
+		sqlite.exec(
+			readFileSync(join(dir, f), "utf8")
+				.split("--> statement-breakpoint")
+				.join("\n"),
+		);
+	}
+}
+
+function makeProxy(sqlite: DatabaseSync) {
+	const exec = async (sql: string, params: unknown[], method: string) => {
+		const stmt = sqlite.prepare(sql);
+		if (method === "run") {
+			stmt.run(...(params as never[]));
+			return { rows: [] };
+		}
+		const rows = stmt
+			.all(...(params as never[]))
+			.map((r) => Object.values(r as object));
+		return { rows: method === "get" ? (rows[0] as never) : rows };
+	};
+	const batch = async (
+		queries: { sql: string; params: unknown[]; method: string }[],
+	) =>
+		queries.map((q) => {
+			const stmt = sqlite.prepare(q.sql);
+			if (q.method === "run") {
+				stmt.run(...(q.params as never[]));
+				return { rows: [] };
+			}
+			const rows = stmt
+				.all(...(q.params as never[]))
+				.map((o) => Object.values(o as object));
+			return { rows: q.method === "get" ? (rows[0] as never) : rows };
+		});
+	return drizzle(exec, batch, { schema, casing: "snake_case" });
+}
+
+const total = (sqlite: DatabaseSync, table: string) =>
+	(
+		sqlite.prepare(`SELECT count(*) AS n FROM "${table}"`).get() as {
+			n: number;
+		}
+	).n;
+const n = (sqlite: DatabaseSync, where: string, table: string) =>
+	(
+		sqlite
+			.prepare(`SELECT count(*) AS n FROM "${table}" WHERE ${where}`)
+			.get() as {
+			n: number;
+		}
+	).n;
+
+/** Seed a fully-populated workspace `ws`, owned by `owner`, ids prefixed by `p`. */
+function seedWorkspace(
+	sqlite: DatabaseSync,
+	ws: string,
+	owner: string,
+	p: string,
+	opts: { plan?: string; sub?: string | null } = {},
+) {
+	const x = (s: string) => sqlite.exec(s);
+	x(
+		`INSERT INTO workspace (id,name,owner_id,plan,stripe_subscription_id) VALUES ('${ws}','${ws}','${owner}','${opts.plan ?? "none"}',${opts.sub ? `'${opts.sub}'` : "NULL"})`,
+	);
+	x(
+		`INSERT INTO member (id,workspace_id,user_id,role) VALUES ('${p}m','${ws}','${owner}','owner')`,
+	);
+	x(
+		`INSERT INTO project (id,workspace_id,name,public_key,inbound_email_local) VALUES ('${p}p','${ws}','P','${p}pk','${p}in')`,
+	);
+	x(
+		`INSERT INTO conversation (id,project_id,client_id) VALUES ('${p}c','${p}p','cl')`,
+	);
+	x(
+		`INSERT INTO message (id,conversation_id,role,content,sequence) VALUES ('${p}msg','${p}c','user','hi',1)`,
+	);
+	x(`INSERT INTO source (id,project_id,kind) VALUES ('${p}s','${p}p','url')`);
+	x(
+		`INSERT INTO system_prompt (id,project_id,name) VALUES ('${p}sp','${p}p','SP')`,
+	);
+	x(`INSERT INTO tag (id,workspace_id,name) VALUES ('${p}t','${ws}','T')`);
+	x(
+		`INSERT INTO conversation_tag (id,conversation_id,tag_id) VALUES ('${p}ct','${p}c','${p}t')`,
+	);
+	x(
+		`INSERT INTO read_status (id,conversation_id,user_id) VALUES ('${p}rs','${p}c','${owner}')`,
+	);
+	x(
+		`INSERT INTO usage_event (id,workspace_id,project_id,conversation_id,message_id,model) VALUES ('${p}ue','${ws}','${p}p','${p}c','${p}msg','m')`,
+	);
+}
+
+const WS_TABLES = [
+	"workspace",
+	"member",
+	"project",
+	"conversation",
+	"message",
+	"source",
+	"system_prompt",
+	"tag",
+	"conversation_tag",
+	"read_status",
+	"usage_event",
+];
+
+function del(
+	id: string,
+	headers: Record<string, string> = { "x-test-user": "u1" },
+) {
+	return workspaces.request(
+		`/workspaces/${id}`,
+		{ method: "DELETE", headers },
+		{ vars: { STRIPE_SECRET_KEY: "sk_test_x" } } as never,
+	);
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("DELETE /workspaces/:id — end-to-end cascade (2 owned workspaces)", () => {
+	it("empties ONLY the target workspace's subtree; the other workspace + the user survive", async () => {
+		const sqlite = new DatabaseSync(":memory:");
+		applyMigrations(sqlite);
+
+		sqlite.exec(
+			`INSERT INTO user (id,name,email) VALUES ('u1','U1','u1@x.io')`,
+		);
+		sqlite.exec(
+			`INSERT INTO session (id,user_id,token,expires_at) VALUES ('se1','u1','tok',9999)`,
+		);
+		// Two free workspaces, both owned by u1 (so the last-workspace guard passes).
+		seedWorkspace(sqlite, "ws1", "u1", "a");
+		seedWorkspace(sqlite, "ws2", "u1", "b");
+
+		vi.mocked(db).mockReturnValue(makeProxy(sqlite) as never);
+
+		const res = await del("ws1");
+		expect(res.status).toBe(200);
+		expect(await res.json()).toMatchObject({ ok: true });
+		// A free workspace short-circuits the sub-gate — no Stripe call.
+		expect(retrieveSubscription).not.toHaveBeenCalled();
+
+		// Exactly ONE of each remains — ws2's subtree, fully intact.
+		for (const t of WS_TABLES) expect(total(sqlite, t)).toBe(1);
+		expect(n(sqlite, "id='ws1'", "workspace")).toBe(0);
+		expect(n(sqlite, "id='ws2'", "workspace")).toBe(1);
+		expect(n(sqlite, "workspace_id='ws1'", "member")).toBe(0);
+		expect(n(sqlite, "workspace_id='ws2'", "member")).toBe(1);
+
+		// The user is never touched.
+		expect(n(sqlite, "id='u1'", "user")).toBe(1);
+		expect(n(sqlite, "user_id='u1'", "session")).toBe(1);
+	});
+
+	it("a blocked active-sub delete touches NOTHING — both workspaces survive intact", async () => {
+		const sqlite = new DatabaseSync(":memory:");
+		applyMigrations(sqlite);
+
+		sqlite.exec(
+			`INSERT INTO user (id,name,email) VALUES ('u1','U1','u1@x.io')`,
+		);
+		// ws1: active subscription (blocks). ws2: free.
+		seedWorkspace(sqlite, "ws1", "u1", "a", { plan: "growth", sub: "sub_1" });
+		seedWorkspace(sqlite, "ws2", "u1", "b");
+
+		// The live gate sees the sub as active ⇒ block.
+		vi.mocked(retrieveSubscription).mockResolvedValue({
+			id: "sub_1",
+			status: "active",
+		});
+		vi.mocked(db).mockReturnValue(makeProxy(sqlite) as never);
+
+		const res = await del("ws1");
+		expect(res.status).toBe(409);
+		expect(await res.json()).toMatchObject({ error: "active_subscription" });
+
+		// Nothing deleted — both subtrees survive.
+		for (const t of WS_TABLES) expect(total(sqlite, t)).toBe(2);
+	});
+});

--- a/apps/api/src/routes/workspaces.test.ts
+++ b/apps/api/src/routes/workspaces.test.ts
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { db } from "@/lib/db";
+import {
+	assertDeletable,
+	deleteWorkspaceCascade,
+} from "@/lib/workspace-deletion";
+
+import { workspaces } from "./workspaces";
+
+vi.mock("@/auth", () => ({
+	createAuth: () => ({
+		api: {
+			getSession: async ({ headers }: { headers: Headers }) => {
+				const id = headers.get("x-test-user");
+				return id ? { user: { id } } : null;
+			},
+		},
+	}),
+}));
+vi.mock("@/lib/db", () => ({ db: vi.fn() }));
+// The cascade + sub-gate are proven in workspace-deletion.test.ts; mocked here so
+// the ROUTE's guards/orchestration are tested in isolation.
+vi.mock("@/lib/workspace-deletion", () => ({
+	assertDeletable: vi.fn(),
+	deleteWorkspaceCascade: vi.fn(),
+}));
+vi.mock("@/lib/provisioning", () => ({
+	provisionWorkspace: vi.fn(async () => ({ id: "ws_new", name: "New" })),
+}));
+
+const ENV = { vars: {}, DB: {} } as unknown as Parameters<
+	typeof workspaces.request
+>[2];
+
+interface State {
+	/** member.findFirst owner lookup (undefined ⇒ not owner ⇒ 403). */
+	owner?: Record<string, unknown>;
+	/** workspace.findFirst (undefined ⇒ 404). */
+	workspace?: Record<string, unknown>;
+	/** The user's total membership count (last-workspace guard). */
+	memberships?: number;
+	gate?: { blocked: boolean; reason?: string };
+}
+
+function mockDb(state: State) {
+	const fake = {
+		query: {
+			member: { findFirst: async () => state.owner },
+			workspace: { findFirst: async () => state.workspace },
+		},
+		select: () => ({
+			from: () => ({ where: async () => [{ n: state.memberships ?? 2 }] }),
+		}),
+	};
+	vi.mocked(db).mockReturnValue(fake as unknown as ReturnType<typeof db>);
+	vi.mocked(assertDeletable).mockResolvedValue(
+		(state.gate ?? { blocked: false }) as never,
+	);
+	vi.mocked(deleteWorkspaceCascade).mockResolvedValue([] as never);
+}
+
+const ME = { "x-test-user": "u1" };
+function del(id = "ws1", headers: Record<string, string> = ME) {
+	return workspaces.request(
+		`/workspaces/${id}`,
+		{ method: "DELETE", headers },
+		ENV,
+	);
+}
+
+const OWNER = { id: "m1", role: "owner" };
+const WS = { id: "ws1", plan: "none", stripeSubscriptionId: null };
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("DELETE /workspaces/:id", () => {
+	it("401s without a session", async () => {
+		mockDb({});
+		expect((await del("ws1", {})).status).toBe(401);
+	});
+
+	it("403s a non-owner; never cascades", async () => {
+		mockDb({ owner: undefined, workspace: WS });
+		const res = await del();
+		expect(res.status).toBe(403);
+		expect(deleteWorkspaceCascade).not.toHaveBeenCalled();
+	});
+
+	it("404s a workspace that doesn't exist", async () => {
+		mockDb({ owner: OWNER, workspace: undefined });
+		expect((await del()).status).toBe(404);
+		expect(deleteWorkspaceCascade).not.toHaveBeenCalled();
+	});
+
+	it("409s deleting the user's last workspace; never cascades", async () => {
+		mockDb({ owner: OWNER, workspace: WS, memberships: 1 });
+		const res = await del();
+		expect(res.status).toBe(409);
+		expect(await res.json()).toMatchObject({ error: "last_workspace" });
+		expect(deleteWorkspaceCascade).not.toHaveBeenCalled();
+	});
+
+	it("409s an active subscription (gate blocked) BEFORE any delete", async () => {
+		mockDb({
+			owner: OWNER,
+			workspace: { id: "ws1", plan: "growth", stripeSubscriptionId: "sub_1" },
+			memberships: 2,
+			gate: { blocked: true, reason: "active_subscription" },
+		});
+		const res = await del();
+		expect(res.status).toBe(409);
+		expect(await res.json()).toMatchObject({ error: "active_subscription" });
+		expect(deleteWorkspaceCascade).not.toHaveBeenCalled();
+	});
+
+	it("owner deletes a free, non-last workspace → invokes the cascade with the id", async () => {
+		mockDb({ owner: OWNER, workspace: WS, memberships: 2 });
+		const res = await del("ws1");
+		expect(res.status).toBe(200);
+		expect(deleteWorkspaceCascade).toHaveBeenCalledTimes(1);
+		// Called with (db, "ws1") — the path id.
+		expect(vi.mocked(deleteWorkspaceCascade).mock.calls[0]![1]).toBe("ws1");
+	});
+});
+
+describe("POST /workspaces (create, existing — sanity)", () => {
+	it("provisions a workspace for the session user", async () => {
+		mockDb({});
+		const res = await workspaces.request(
+			"/workspaces",
+			{
+				method: "POST",
+				headers: { ...ME, "content-type": "application/json" },
+				body: JSON.stringify({ name: "Acme" }),
+			},
+			ENV,
+		);
+		expect(res.status).toBe(200);
+		expect(await res.json()).toMatchObject({ workspace: { id: "ws_new" } });
+	});
+});

--- a/apps/api/src/routes/workspaces.ts
+++ b/apps/api/src/routes/workspaces.ts
@@ -4,9 +4,13 @@ import { z } from "zod";
 
 import { db } from "@/lib/db";
 import { provisionWorkspace } from "@/lib/provisioning";
+import {
+	assertDeletable,
+	deleteWorkspaceCascade,
+} from "@/lib/workspace-deletion";
 import { requireSession } from "@/middleware/session";
 
-import { eq, member, workspace } from "@llmchat/db";
+import { count, eq, member, workspace } from "@llmchat/db";
 
 import type { AppContext } from "@/env";
 
@@ -30,4 +34,41 @@ export const workspaces = new Hono<AppContext>()
 			const ws = await provisionWorkspace(db(c.env), userId, name);
 			return c.json({ workspace: ws });
 		},
-	);
+	)
+	// Delete a workspace + all its data. OWNER-of-this-workspace only — the role is
+	// keyed off the PATH id (not the x-workspace header), so you can only delete a
+	// workspace you own. Reuses the PR2 deletion service: the live + fail-closed
+	// subscription gate, then the explicit set-based cascade. Never deletes the
+	// user or other workspaces.
+	.delete("/workspaces/:id", async (c) => {
+		const userId = c.get("userId");
+		const { id } = c.req.param();
+
+		const owner = await db(c.env).query.member.findFirst({
+			where: (m, { and, eq: e }) =>
+				and(e(m.userId, userId), e(m.workspaceId, id), e(m.role, "owner")),
+		});
+		if (!owner) return c.json({ error: "forbidden" }, 403);
+
+		const ws = await db(c.env).query.workspace.findFirst({
+			where: (w, { eq: e }) => e(w.id, id),
+			columns: { id: true, plan: true, stripeSubscriptionId: true },
+		});
+		if (!ws) return c.json({ error: "not found" }, 404);
+
+		// Last-workspace guard: never strand the user with no workspace — they must
+		// create another (or delete their whole account) instead. Counts the user's
+		// total memberships, not just owned ones.
+		const [{ n }] = await db(c.env)
+			.select({ n: count() })
+			.from(member)
+			.where(eq(member.userId, userId));
+		if (n <= 1) return c.json({ error: "last_workspace" }, 409);
+
+		// Live, fail-closed subscription gate, scoped to THIS workspace only.
+		const gate = await assertDeletable([ws], c.env);
+		if (gate.blocked) return c.json({ error: gate.reason }, 409);
+
+		await deleteWorkspaceCascade(db(c.env), id);
+		return c.json({ ok: true });
+	});

--- a/apps/dashboard/src/app/settings/workspaces/_components/CreateWorkspaceDialog.tsx
+++ b/apps/dashboard/src/app/settings/workspaces/_components/CreateWorkspaceDialog.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { describeApiError } from "@/lib/api";
+import { useWorkspace } from "@/lib/workspace";
+import { WORKSPACES_KEY } from "@/lib/workspace-utils";
+import { createWorkspace } from "@/lib/workspaces";
+
+const NAME_MAX = 100;
+
+export interface CreateWorkspaceDialogProps {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+}
+
+/**
+ * Create-a-workspace flow, shared by the sidebar switcher and the
+ * /settings/workspaces page. On success it switches into the new workspace and
+ * sends the user to onboarding — the workspace is plan=none, so they land on the
+ * "choose a plan to launch" paywall (escapable via #62), which is the right next
+ * step rather than dropping them into a half-configured workspace.
+ */
+export function CreateWorkspaceDialog({
+	open,
+	onOpenChange,
+}: CreateWorkspaceDialogProps) {
+	const qc = useQueryClient();
+	const router = useRouter();
+	const { setWorkspaceId } = useWorkspace();
+	const [name, setName] = useState("");
+	const trimmed = name.trim();
+
+	const create = useMutation({
+		mutationFn: () => createWorkspace(trimmed),
+		onSuccess: async ({ workspace }) => {
+			// Make the new workspace visible everywhere, then switch into it.
+			await qc.invalidateQueries({ queryKey: WORKSPACES_KEY });
+			setWorkspaceId(workspace.id);
+			onOpenChange(false);
+			setName("");
+			toast.success(`Workspace "${workspace.name}" created`);
+			router.push("/onboarding");
+		},
+		onError: (e) =>
+			toast.error(describeApiError(e, "Couldn't create the workspace")),
+	});
+
+	function handleOpenChange(next: boolean) {
+		if (!next) setName("");
+		onOpenChange(next);
+	}
+
+	return (
+		<Dialog open={open} onOpenChange={handleOpenChange}>
+			<DialogContent>
+				<DialogHeader>
+					<DialogTitle>Create a workspace</DialogTitle>
+					<DialogDescription>
+						A workspace is a separate billing account with its own projects and
+						team. You&apos;ll choose a plan after creating it.
+					</DialogDescription>
+				</DialogHeader>
+
+				<form
+					className="flex flex-col gap-4"
+					onSubmit={(e) => {
+						e.preventDefault();
+						if (trimmed && !create.isPending) create.mutate();
+					}}
+				>
+					<div className="flex flex-col gap-1.5">
+						<Label htmlFor="workspace-name">Name</Label>
+						<Input
+							id="workspace-name"
+							value={name}
+							maxLength={NAME_MAX}
+							onChange={(e) => setName(e.target.value)}
+							placeholder="Acme Inc."
+							autoComplete="off"
+							autoFocus
+						/>
+					</div>
+
+					<DialogFooter>
+						<Button
+							type="button"
+							variant="outline"
+							onClick={() => handleOpenChange(false)}
+						>
+							Cancel
+						</Button>
+						<Button type="submit" disabled={!trimmed || create.isPending}>
+							{create.isPending ? "Creating…" : "Create workspace"}
+						</Button>
+					</DialogFooter>
+				</form>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/apps/dashboard/src/app/settings/workspaces/_components/DeleteWorkspaceDialog.tsx
+++ b/apps/dashboard/src/app/settings/workspaces/_components/DeleteWorkspaceDialog.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import { useState } from "react";
+
+import {
+	AlertDialog,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+/** Why deletion is pre-blocked, surfaced before the user even types the name. */
+export type DeleteBlock = "active_subscription" | "last_workspace" | null;
+
+export interface DeleteWorkspaceDialogProps {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	/** The workspace name — the confirmation must match it exactly. */
+	workspaceName: string;
+	pending: boolean;
+	/** A pre-known blocker (active sub / last workspace) → disables confirm and
+	 * shows guidance. The server re-checks regardless. */
+	block?: DeleteBlock;
+	/** A failure message to surface inline (so deletion never fails silently). */
+	error?: string | null;
+	/** Switch into this workspace and open its Billing page (to cancel the sub). */
+	onManageBilling?: () => void;
+	onConfirm: () => void;
+}
+
+/**
+ * GitHub-repo-delete-style confirmation: type the workspace NAME to arm the
+ * irreversible delete. Pre-known blockers (an active subscription, or this being
+ * the user's last workspace) disable the confirm and explain the fix. The
+ * confirm is a plain <Button>, NOT AlertDialogAction — AlertDialogAction
+ * auto-closes the dialog on click and (under React 18) unmounts the form before
+ * the native submit fires, so the request never goes out (the dead-button bug).
+ */
+export function DeleteWorkspaceDialog({
+	open,
+	onOpenChange,
+	workspaceName,
+	pending,
+	block = null,
+	error,
+	onManageBilling,
+	onConfirm,
+}: DeleteWorkspaceDialogProps) {
+	const [confirmName, setConfirmName] = useState("");
+
+	const nameMatches = confirmName === workspaceName;
+	const armed = nameMatches && !block && !pending;
+
+	function handleOpenChange(next: boolean) {
+		if (!next) setConfirmName("");
+		onOpenChange(next);
+	}
+
+	return (
+		<AlertDialog open={open} onOpenChange={handleOpenChange}>
+			<AlertDialogContent>
+				<AlertDialogHeader>
+					<AlertDialogTitle>Delete this workspace?</AlertDialogTitle>
+					<AlertDialogDescription>
+						This permanently deletes{" "}
+						<span className="font-semibold text-foreground">
+							{workspaceName}
+						</span>{" "}
+						and everything in it — all projects, conversations, messages,
+						sources, tags, and usage history. This cannot be undone.
+					</AlertDialogDescription>
+				</AlertDialogHeader>
+
+				{block === "active_subscription" ? (
+					<div className="flex flex-col items-start gap-3 rounded-lg border bg-muted/40 p-3 text-sm text-muted-foreground">
+						<span>
+							This workspace has an active subscription. Cancel it in Billing
+							before deleting the workspace.
+						</span>
+						{onManageBilling && (
+							<Button variant="outline" size="sm" onClick={onManageBilling}>
+								Go to Billing
+							</Button>
+						)}
+					</div>
+				) : block === "last_workspace" ? (
+					<p className="rounded-lg border bg-muted/40 p-3 text-sm text-muted-foreground">
+						This is your only workspace. Create another first, or delete your
+						account instead.
+					</p>
+				) : (
+					<form
+						className="flex flex-col gap-4"
+						onSubmit={(e) => {
+							e.preventDefault();
+							if (armed) onConfirm();
+						}}
+					>
+						<div className="flex flex-col gap-1.5">
+							<Label htmlFor="confirm-workspace-name">
+								Type{" "}
+								<span className="font-semibold text-foreground">
+									{workspaceName}
+								</span>{" "}
+								to confirm
+							</Label>
+							<Input
+								id="confirm-workspace-name"
+								value={confirmName}
+								onChange={(e) => setConfirmName(e.target.value)}
+								autoComplete="off"
+								aria-label="Confirm workspace name"
+							/>
+						</div>
+
+						{/* Surface any failure inline so deletion never fails silently. */}
+						{error && (
+							<p role="alert" className="text-sm text-destructive">
+								{error}
+							</p>
+						)}
+
+						<AlertDialogFooter>
+							<AlertDialogCancel type="button">Cancel</AlertDialogCancel>
+							{/*
+							 * A plain submit Button — NOT AlertDialogAction. AlertDialogAction
+							 * auto-closes the dialog on click; under React 18 that flush
+							 * unmounts this <form> before the browser dispatches the native
+							 * `submit`, so onConfirm never ran and no DELETE was issued. This
+							 * button submits without closing — the dialog stays mounted
+							 * through the async delete and closes only on success.
+							 */}
+							<Button type="submit" variant="destructive" disabled={!armed}>
+								{pending ? "Deleting…" : "Delete workspace"}
+							</Button>
+						</AlertDialogFooter>
+					</form>
+				)}
+
+				{/* When blocked, the form (and its footer) is hidden — give a way out. */}
+				{block && (
+					<AlertDialogFooter>
+						<AlertDialogCancel type="button">Close</AlertDialogCancel>
+					</AlertDialogFooter>
+				)}
+			</AlertDialogContent>
+		</AlertDialog>
+	);
+}

--- a/apps/dashboard/src/app/settings/workspaces/layout.tsx
+++ b/apps/dashboard/src/app/settings/workspaces/layout.tsx
@@ -1,0 +1,9 @@
+import { DashboardGate } from "@/components/dashboard-gate";
+
+export default function WorkspacesLayout({
+	children,
+}: {
+	children: React.ReactNode;
+}) {
+	return <DashboardGate>{children}</DashboardGate>;
+}

--- a/apps/dashboard/src/app/settings/workspaces/page.tsx
+++ b/apps/dashboard/src/app/settings/workspaces/page.tsx
@@ -1,0 +1,175 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { Check, Plus } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { toast } from "sonner";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useWorkspace } from "@/lib/workspace";
+import { WORKSPACES_KEY, type WorkspaceSummary } from "@/lib/workspace-utils";
+import { deleteWorkspace, deleteWorkspaceErrorMessage } from "@/lib/workspaces";
+
+import { CreateWorkspaceDialog } from "./_components/CreateWorkspaceDialog";
+import {
+	DeleteWorkspaceDialog,
+	type DeleteBlock,
+} from "./_components/DeleteWorkspaceDialog";
+
+function roleLabel(role: WorkspaceSummary["role"]) {
+	return role[0].toUpperCase() + role.slice(1);
+}
+
+export default function WorkspacesSettingsPage() {
+	const qc = useQueryClient();
+	const router = useRouter();
+	const { workspaces, workspaceId, setWorkspaceId, isLoading } = useWorkspace();
+
+	const [createOpen, setCreateOpen] = useState(false);
+	const [deleting, setDeleting] = useState<WorkspaceSummary | null>(null);
+
+	const remove = useMutation({
+		mutationFn: (id: string) => deleteWorkspace(id),
+		onSuccess: async (_data, id) => {
+			setDeleting(null);
+			toast.success("Workspace deleted");
+			// If they deleted the workspace they were in, switch into another one they
+			// belong to and drop now-stale per-workspace caches so nothing renders the
+			// deleted context. /settings/workspaces is an onboarding escape route, so
+			// staying here is safe even if the next workspace has no plan.
+			if (id === workspaceId) {
+				const next = workspaces.find((w) => w.id !== id);
+				qc.removeQueries({ queryKey: ["projects"] });
+				qc.removeQueries({ queryKey: ["billing-usage"] });
+				if (next) setWorkspaceId(next.id);
+			}
+			await qc.invalidateQueries({ queryKey: WORKSPACES_KEY });
+		},
+		onError: (e) => toast.error(deleteWorkspaceErrorMessage(e)),
+	});
+
+	// Pre-known blocker for the open delete dialog (the server re-checks live).
+	const block: DeleteBlock = !deleting
+		? null
+		: workspaces.length <= 1
+			? "last_workspace"
+			: deleting.plan !== "none"
+				? "active_subscription"
+				: null;
+
+	return (
+		<div className="mx-auto w-full max-w-[800px] space-y-6 p-6">
+			<header className="flex items-start justify-between gap-4">
+				<div>
+					<h1 className="font-display text-2xl font-semibold tracking-tight-display">
+						Workspaces
+					</h1>
+					<p className="mt-0.5 text-sm text-muted-foreground">
+						Each workspace is a separate billing account with its own projects
+						and team.
+					</p>
+				</div>
+				<Button onClick={() => setCreateOpen(true)} className="shrink-0">
+					<Plus />
+					Create workspace
+				</Button>
+			</header>
+
+			<Card>
+				<CardHeader>
+					<CardTitle>Your workspaces</CardTitle>
+					<CardDescription>
+						Workspaces you belong to. Only an owner can delete a workspace.
+					</CardDescription>
+				</CardHeader>
+				<CardContent>
+					{isLoading ? (
+						<div className="space-y-3">
+							<Skeleton className="h-14 w-full" />
+							<Skeleton className="h-14 w-full" />
+						</div>
+					) : (
+						<ul className="divide-y divide-border rounded-lg border">
+							{workspaces.map((w) => {
+								const current = w.id === workspaceId;
+								const owner = w.role === "owner";
+								return (
+									<li
+										key={w.id}
+										className="flex items-center justify-between gap-3 p-3"
+									>
+										<div className="flex min-w-0 flex-col gap-1">
+											<div className="flex items-center gap-2">
+												<span className="truncate font-medium">{w.name}</span>
+												{current && (
+													<Badge variant="secondary" className="gap-1">
+														<Check className="size-3" />
+														Current
+													</Badge>
+												)}
+											</div>
+											<span className="text-xs text-muted-foreground">
+												{roleLabel(w.role)}
+											</span>
+										</div>
+										<div className="flex shrink-0 items-center gap-2">
+											{!current && (
+												<Button
+													variant="outline"
+													size="sm"
+													onClick={() => setWorkspaceId(w.id)}
+												>
+													Switch
+												</Button>
+											)}
+											{owner && (
+												<Button
+													variant="ghost"
+													size="sm"
+													className="text-destructive hover:text-destructive"
+													onClick={() => setDeleting(w)}
+												>
+													Delete
+												</Button>
+											)}
+										</div>
+									</li>
+								);
+							})}
+						</ul>
+					)}
+				</CardContent>
+			</Card>
+
+			<CreateWorkspaceDialog open={createOpen} onOpenChange={setCreateOpen} />
+
+			{deleting && (
+				<DeleteWorkspaceDialog
+					open={!!deleting}
+					onOpenChange={(o) => !o && setDeleting(null)}
+					workspaceName={deleting.name}
+					pending={remove.isPending}
+					block={block}
+					error={
+						remove.isError ? deleteWorkspaceErrorMessage(remove.error) : null
+					}
+					onManageBilling={() => {
+						setWorkspaceId(deleting.id);
+						router.push("/settings/billing");
+					}}
+					onConfirm={() => remove.mutate(deleting.id)}
+				/>
+			)}
+		</div>
+	);
+}

--- a/apps/dashboard/src/app/settings/workspaces/workspaces-page.e2e.test.tsx
+++ b/apps/dashboard/src/app/settings/workspaces/workspaces-page.e2e.test.tsx
@@ -12,7 +12,7 @@ import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { WorkspaceProvider } from "@/lib/workspace";
+import { WorkspaceProvider, useWorkspace } from "@/lib/workspace";
 import type { Plan, WorkspaceRole } from "@/lib/workspace-utils";
 
 import WorkspacesSettingsPage from "./page";
@@ -83,7 +83,7 @@ function renderPage(current = "ws1") {
 	const client = new QueryClient({
 		defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
 	});
-	render(
+	return render(
 		<QueryClientProvider client={client}>
 			<WorkspaceProvider>
 				<WorkspacesSettingsPage />
@@ -223,5 +223,112 @@ describe("WorkspacesSettingsPage", () => {
 			within(dialog).queryByRole("button", { name: /delete workspace/i }),
 		).not.toBeInTheDocument();
 		expect(callsFor("DELETE").length).toBe(0);
+	});
+});
+
+// ─── refresh after deleting the current workspace ─────────────────────────────
+// The concern: after deleting the workspace you're in, a page refresh must NOT
+// re-activate the deleted workspace (which would 400/403 every per-workspace
+// request). Two independent guarantees protect this — (1) delete-current
+// persists the new selection to localStorage, and (2) even a stale persisted id
+// self-heals via resolveWorkspaceId. These tests prove BOTH survive an actual
+// remount (a fresh QueryClient = a real page refresh, with the deleted workspace
+// gone from the server's list).
+
+/** Surfaces the provider's resolved active workspace so a refresh can be asserted. */
+function ActiveWorkspaceProbe() {
+	const { workspaceId, isLoading } = useWorkspace();
+	return (
+		<div data-testid="active-ws">
+			{isLoading ? "loading" : (workspaceId ?? "none")}
+		</div>
+	);
+}
+
+/** GET /api/workspaces returns whatever `getList()` yields at call time, so the
+ * post-delete refresh can serve a list with the deleted workspace removed. */
+function stubFetchDynamic(getList: () => WS[]) {
+	fetchMock = vi.fn((url: string, init: { method?: string } = {}) => {
+		const method = init.method ?? "GET";
+		if (url.includes("/api/workspaces") && method === "DELETE") {
+			return new Promise((res) => {
+				resolveDelete = () => res(jsonRes({ ok: true }));
+			});
+		}
+		return Promise.resolve(
+			jsonRes({
+				workspaces: getList().map((w) => ({
+					workspace: { id: w.id, name: w.name, plan: w.plan },
+					role: w.role,
+				})),
+			}),
+		);
+	});
+	vi.stubGlobal("fetch", fetchMock);
+}
+
+/** Mount just the provider + probe with a fresh cache — i.e. a page refresh. */
+function refresh() {
+	const client = new QueryClient({
+		defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+	});
+	return render(
+		<QueryClientProvider client={client}>
+			<WorkspaceProvider>
+				<ActiveWorkspaceProbe />
+			</WorkspaceProvider>
+		</QueryClientProvider>,
+	);
+}
+
+describe("refresh after deleting the current workspace", () => {
+	it("persists the new selection — a refresh loads the surviving workspace, never the deleted one", async () => {
+		const user = userEvent.setup();
+		let list: WS[] = [...TWO]; // ws1 (current) + ws2
+		stubFetchDynamic(() => list);
+
+		const first = renderPage("ws1");
+		await screen.findByText("Acme");
+
+		// Delete the current workspace (ws1).
+		const acmeRow = screen.getByText("Acme").closest("li")!;
+		await user.click(within(acmeRow).getByRole("button", { name: "Delete" }));
+		const dialog = await screen.findByRole("alertdialog");
+		await user.type(
+			within(dialog).getByLabelText("Confirm workspace name"),
+			"Acme",
+		);
+		await user.click(
+			within(dialog).getByRole("button", { name: /delete workspace/i }),
+		);
+		await waitFor(() => expect(callsFor("DELETE").length).toBe(1));
+		resolveDelete(undefined);
+		await waitFor(() => expect(localStorage.getItem(KEY)).toBe("ws2"));
+
+		// The server no longer has ws1; refresh the app.
+		list = [TWO[1]!]; // only ws2 survives
+		first.unmount();
+		refresh();
+
+		// The provider activates the surviving workspace, never the deleted ws1.
+		await waitFor(() =>
+			expect(screen.getByTestId("active-ws")).toHaveTextContent("ws2"),
+		);
+		expect(screen.getByTestId("active-ws")).not.toHaveTextContent("ws1");
+	});
+
+	it("self-heals a stale persisted id — even if localStorage still points at the deleted workspace, a refresh resolves a valid one", async () => {
+		// Belt-and-suspenders: simulate the persisted selection somehow still being
+		// the deleted id on refresh (the resolveWorkspaceId backstop, unit-tested in
+		// workspace-utils.test.ts at the integration level here).
+		localStorage.setItem(KEY, "ws1"); // the now-deleted workspace
+		stubFetchDynamic(() => [TWO[1]!]); // server only returns ws2
+
+		refresh();
+
+		await waitFor(() =>
+			expect(screen.getByTestId("active-ws")).toHaveTextContent("ws2"),
+		);
+		expect(screen.getByTestId("active-ws")).not.toHaveTextContent("ws1");
 	});
 });

--- a/apps/dashboard/src/app/settings/workspaces/workspaces-page.e2e.test.tsx
+++ b/apps/dashboard/src/app/settings/workspaces/workspaces-page.e2e.test.tsx
@@ -1,0 +1,227 @@
+// Through-the-dialog tests: the REAL WorkspacesSettingsPage + REAL Create/Delete
+// dialogs + REAL WorkspaceProvider + REAL api()/fetch (only window.fetch and the
+// router are stubbed). This exercises the button → fetch path end to end — the
+// gap that let a dead destructive button ship past a mocked-`api` test. It
+// asserts the DELETE/POST actually fire, that clicking confirm does NOT close the
+// delete dialog (the AlertDialogAction auto-close regression), that deleting the
+// current workspace switches context, and that the blocked states gate the
+// request entirely.
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { WorkspaceProvider } from "@/lib/workspace";
+import type { Plan, WorkspaceRole } from "@/lib/workspace-utils";
+
+import WorkspacesSettingsPage from "./page";
+
+beforeAll(() => {
+	Element.prototype.scrollIntoView = vi.fn();
+	Element.prototype.hasPointerCapture ??= () => false;
+});
+
+const push = vi.fn();
+vi.mock("next/navigation", () => ({
+	useRouter: () => ({ push, replace: vi.fn() }),
+}));
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+// NOTE: @/lib/api is NOT mocked — the real api()/fetch path is exercised.
+
+const KEY = "llmchat_workspace_id";
+
+interface WS {
+	id: string;
+	name: string;
+	plan: Plan;
+	role: WorkspaceRole;
+}
+
+function jsonRes(body: unknown) {
+	return {
+		ok: true,
+		status: 200,
+		json: async () => body,
+		text: async () => JSON.stringify(body),
+	};
+}
+
+let fetchMock: ReturnType<typeof vi.fn>;
+/** Resolve the in-flight DELETE on demand so we can observe the pending (dialog
+ * stays open) state. */
+let resolveDelete: (v: unknown) => void;
+
+function stubFetch(workspaces: WS[]) {
+	fetchMock = vi.fn((url: string, init: { method?: string } = {}) => {
+		const method = init.method ?? "GET";
+		if (url.includes("/api/workspaces") && method === "DELETE") {
+			return new Promise((res) => {
+				resolveDelete = () => res(jsonRes({ ok: true }));
+			});
+		}
+		if (url.includes("/api/workspaces") && method === "POST") {
+			return Promise.resolve(
+				jsonRes({ workspace: { id: "wsNew", name: "New" } }),
+			);
+		}
+		// GET /api/workspaces — the provider's list.
+		return Promise.resolve(
+			jsonRes({
+				workspaces: workspaces.map((w) => ({
+					workspace: { id: w.id, name: w.name, plan: w.plan },
+					role: w.role,
+				})),
+			}),
+		);
+	});
+	vi.stubGlobal("fetch", fetchMock);
+}
+
+function renderPage(current = "ws1") {
+	localStorage.setItem(KEY, current);
+	const client = new QueryClient({
+		defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+	});
+	render(
+		<QueryClientProvider client={client}>
+			<WorkspaceProvider>
+				<WorkspacesSettingsPage />
+			</WorkspaceProvider>
+		</QueryClientProvider>,
+	);
+}
+
+const callsFor = (method: string) =>
+	fetchMock.mock.calls.filter(
+		([url, init]) =>
+			String(url).includes("/api/workspaces") &&
+			(init?.method ?? "GET") === method,
+	);
+
+beforeEach(() => {
+	push.mockClear();
+	localStorage.clear();
+});
+
+const TWO: WS[] = [
+	{ id: "ws1", name: "Acme", plan: "none", role: "owner" },
+	{ id: "ws2", name: "Globex", plan: "none", role: "owner" },
+];
+
+describe("WorkspacesSettingsPage", () => {
+	it("lists the workspaces and marks the current one", async () => {
+		stubFetch(TWO);
+		renderPage("ws1");
+
+		const acme = await screen.findByText("Acme");
+		expect(acme).toBeInTheDocument();
+		expect(screen.getByText("Globex")).toBeInTheDocument();
+		// The current workspace carries a "Current" badge; the other shows "Switch".
+		expect(screen.getByText("Current")).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "Switch" })).toBeInTheDocument();
+	});
+
+	it("deleting the CURRENT workspace fires DELETE, keeps the dialog open while pending, then switches context", async () => {
+		const user = userEvent.setup();
+		stubFetch(TWO);
+		renderPage("ws1");
+		await screen.findByText("Acme");
+
+		// Open the delete dialog for the current workspace (Acme / ws1).
+		const acmeRow = screen.getByText("Acme").closest("li")!;
+		await user.click(within(acmeRow).getByRole("button", { name: "Delete" }));
+
+		const dialog = await screen.findByRole("alertdialog");
+		await user.type(
+			within(dialog).getByLabelText("Confirm workspace name"),
+			"Acme",
+		);
+		await user.click(
+			within(dialog).getByRole("button", { name: /delete workspace/i }),
+		);
+
+		// A real DELETE /api/workspaces/ws1 fired…
+		await waitFor(() => expect(callsFor("DELETE").length).toBe(1));
+		expect(String(callsFor("DELETE")[0]![0])).toContain("/api/workspaces/ws1");
+
+		// …and the dialog did NOT close on click — it stays open showing "Deleting…"
+		// while the request is in flight (the AlertDialogAction auto-close regression).
+		expect(screen.getByRole("alertdialog")).toBeInTheDocument();
+		expect(
+			within(screen.getByRole("alertdialog")).getByRole("button", {
+				name: /deleting/i,
+			}),
+		).toBeInTheDocument();
+
+		// Resolve the delete → context switches to the remaining workspace (ws2).
+		resolveDelete(undefined);
+		await waitFor(() => expect(localStorage.getItem(KEY)).toBe("ws2"));
+	});
+
+	it("creating a workspace POSTs the name and routes to onboarding", async () => {
+		const user = userEvent.setup();
+		stubFetch(TWO);
+		renderPage("ws1");
+		await screen.findByText("Acme");
+
+		await user.click(screen.getByRole("button", { name: /create workspace/i }));
+		const dialog = await screen.findByRole("dialog");
+		await user.type(within(dialog).getByLabelText("Name"), "Initech");
+		await user.click(
+			within(dialog).getByRole("button", { name: /create workspace/i }),
+		);
+
+		await waitFor(() => expect(callsFor("POST").length).toBe(1));
+		expect(JSON.parse(callsFor("POST")[0]![1].body)).toEqual({
+			name: "Initech",
+		});
+		await waitFor(() => expect(push).toHaveBeenCalledWith("/onboarding"));
+	});
+
+	it("blocks deleting the user's LAST workspace — guard message, no name field, no request", async () => {
+		const user = userEvent.setup();
+		stubFetch([TWO[0]!]); // only one workspace
+		renderPage("ws1");
+		await screen.findByText("Acme");
+
+		const acmeRow = screen.getByText("Acme").closest("li")!;
+		await user.click(within(acmeRow).getByRole("button", { name: "Delete" }));
+
+		const dialog = await screen.findByRole("alertdialog");
+		expect(within(dialog).getByText(/only workspace/i)).toBeInTheDocument();
+		// No confirm path at all — the destructive button + name field are hidden.
+		expect(
+			within(dialog).queryByLabelText("Confirm workspace name"),
+		).not.toBeInTheDocument();
+		expect(
+			within(dialog).queryByRole("button", { name: /delete workspace/i }),
+		).not.toBeInTheDocument();
+		expect(callsFor("DELETE").length).toBe(0);
+	});
+
+	it("blocks deleting a workspace with an active subscription — cancel-first guidance, no request", async () => {
+		const user = userEvent.setup();
+		stubFetch([
+			{ id: "ws1", name: "Acme", plan: "none", role: "owner" },
+			{ id: "ws2", name: "Globex", plan: "growth", role: "owner" },
+		]);
+		renderPage("ws1");
+		await screen.findByText("Globex");
+
+		const globexRow = screen.getByText("Globex").closest("li")!;
+		await user.click(within(globexRow).getByRole("button", { name: "Delete" }));
+
+		const dialog = await screen.findByRole("alertdialog");
+		expect(
+			within(dialog).getByText(/active subscription/i),
+		).toBeInTheDocument();
+		expect(
+			within(dialog).getByRole("button", { name: /go to billing/i }),
+		).toBeInTheDocument();
+		expect(
+			within(dialog).queryByRole("button", { name: /delete workspace/i }),
+		).not.toBeInTheDocument();
+		expect(callsFor("DELETE").length).toBe(0);
+	});
+});

--- a/apps/dashboard/src/components/app-sidebar.tsx
+++ b/apps/dashboard/src/components/app-sidebar.tsx
@@ -14,8 +14,11 @@ import {
 	LogOut,
 	MessagesSquare,
 	Plus,
+	Settings2,
 	UserCog,
 } from "lucide-react";
+
+import { CreateWorkspaceDialog } from "@/app/settings/workspaces/_components/CreateWorkspaceDialog";
 
 import { api } from "@/lib/api";
 import { useSignOut } from "@/lib/use-sign-out";
@@ -106,6 +109,7 @@ export function AppSidebar({ userEmail }: { userEmail: string }) {
 	const router = useRouter();
 	const { workspaces, workspaceId, setWorkspaceId, role } = useWorkspace();
 	const handleSignOut = useSignOut();
+	const [createWorkspaceOpen, setCreateWorkspaceOpen] = useState(false);
 	const initials = userEmail.slice(0, 2).toUpperCase();
 	const roleLabel = role ? role[0].toUpperCase() + role.slice(1) : "Member";
 
@@ -349,27 +353,37 @@ export function AppSidebar({ userEmail }: { userEmail: string }) {
 										Account
 									</Link>
 								</DropdownMenuItem>
+								<DropdownMenuSeparator />
+								<DropdownMenuLabel className="text-xs text-muted-foreground">
+									Workspaces
+								</DropdownMenuLabel>
 								{workspaces.length > 1 && (
-									<>
-										<DropdownMenuSeparator />
-										<DropdownMenuLabel className="text-xs text-muted-foreground">
-											Workspaces
-										</DropdownMenuLabel>
-										<DropdownMenuGroup>
-											{workspaces.map((w) => (
-												<DropdownMenuItem
-													key={w.id}
-													onClick={() => setWorkspaceId(w.id)}
-												>
-													<span className="truncate">{w.name}</span>
-													{w.id === workspaceId && (
-														<Check className="ml-auto" />
-													)}
-												</DropdownMenuItem>
-											))}
-										</DropdownMenuGroup>
-									</>
+									<DropdownMenuGroup>
+										{workspaces.map((w) => (
+											<DropdownMenuItem
+												key={w.id}
+												onClick={() => setWorkspaceId(w.id)}
+											>
+												<span className="truncate">{w.name}</span>
+												{w.id === workspaceId && <Check className="ml-auto" />}
+											</DropdownMenuItem>
+										))}
+									</DropdownMenuGroup>
 								)}
+								<DropdownMenuGroup>
+									<DropdownMenuItem
+										onClick={() => setCreateWorkspaceOpen(true)}
+									>
+										<Plus />
+										Create workspace
+									</DropdownMenuItem>
+									<DropdownMenuItem asChild>
+										<Link href="/settings/workspaces">
+											<Settings2 />
+											Manage workspaces
+										</Link>
+									</DropdownMenuItem>
+								</DropdownMenuGroup>
 								<DropdownMenuSeparator />
 								<DropdownMenuItem onClick={handleSignOut}>
 									<LogOut />
@@ -383,6 +397,11 @@ export function AppSidebar({ userEmail }: { userEmail: string }) {
 					</SidebarMenuItem>
 				</SidebarMenu>
 			</SidebarFooter>
+
+			<CreateWorkspaceDialog
+				open={createWorkspaceOpen}
+				onOpenChange={setCreateWorkspaceOpen}
+			/>
 		</Sidebar>
 	);
 }

--- a/apps/dashboard/src/lib/use-onboarding-redirect.test.tsx
+++ b/apps/dashboard/src/lib/use-onboarding-redirect.test.tsx
@@ -70,6 +70,28 @@ describe("useOnboardingRedirect", () => {
 		expect(replace).not.toHaveBeenCalled();
 	});
 
+	it("does NOT bounce a no-plan user off /settings/workspaces (the new escape route)", async () => {
+		pathname = "/settings/workspaces";
+		renderHook(() => useOnboardingRedirect(true), { wrapper });
+		await new Promise((r) => setTimeout(r, 20));
+		expect(replace).not.toHaveBeenCalled();
+	});
+
+	// Paywall not bypassed: the workspaces escape entry must not also open the
+	// product routes. /settings/projects is NOT a prefix of any escape route, so a
+	// no-plan (⇒ no-project) user is still redirected to onboarding.
+	it("STILL redirects a no-plan user away from /settings/projects", async () => {
+		pathname = "/settings/projects";
+		renderHook(() => useOnboardingRedirect(true), { wrapper });
+		await waitFor(() => expect(replace).toHaveBeenCalledWith("/onboarding"));
+	});
+
+	it("STILL redirects a no-plan user away from a project detail route", async () => {
+		pathname = "/settings/projects/p1";
+		renderHook(() => useOnboardingRedirect(true), { wrapper });
+		await waitFor(() => expect(replace).toHaveBeenCalledWith("/onboarding"));
+	});
+
 	it("does not redirect even a brand-new user away from the escape routes", async () => {
 		workspaceState = { workspaces: [], workspaceId: null, isLoading: false };
 		pathname = "/settings/account";

--- a/apps/dashboard/src/lib/use-onboarding-redirect.ts
+++ b/apps/dashboard/src/lib/use-onboarding-redirect.ts
@@ -15,7 +15,11 @@ const DISMISSED_KEY = "Clanker Support:onboarding:dismissed";
  * or leave the account, or pay). They still can't USE the product (inbox /
  * projects) without a plan, so the paywall isn't bypassed.
  */
-const ESCAPE_PREFIXES = ["/settings/account", "/settings/billing"];
+const ESCAPE_PREFIXES = [
+	"/settings/account",
+	"/settings/billing",
+	"/settings/workspaces",
+];
 
 /** Marks onboarding as dismissed so the redirect below stops firing. */
 export function dismissOnboarding() {

--- a/apps/dashboard/src/lib/workspaces.ts
+++ b/apps/dashboard/src/lib/workspaces.ts
@@ -1,0 +1,37 @@
+import { ApiError, api, describeApiError } from "@/lib/api";
+
+/** Create a new workspace owned by the signed-in user. The server provisions it
+ * with plan=none (the user picks a plan on entry). */
+export function createWorkspace(name: string) {
+	return api<{ workspace: { id: string; name: string } }>("/api/workspaces", {
+		method: "POST",
+		body: { name },
+	});
+}
+
+/** Permanently delete a workspace + all of its data. Owner-of-this-workspace
+ * only; the server re-checks the subscription gate and the last-workspace guard
+ * live (fail-closed), so a stale client can't force a delete. */
+export function deleteWorkspace(id: string) {
+	return api<{ ok: true }>(`/api/workspaces/${id}`, { method: "DELETE" });
+}
+
+/** Map a DELETE /workspaces/:id failure to a clear, actionable sentence. The
+ * server is authoritative: it re-runs the gates, so these mirror its codes. */
+export function deleteWorkspaceErrorMessage(e: unknown): string {
+	if (e instanceof ApiError) {
+		switch (e.code) {
+			case "forbidden":
+				return "Only an owner of this workspace can delete it.";
+			case "last_workspace":
+				return "This is your only workspace. Create another, or delete your account instead.";
+			case "active_subscription":
+				return "Cancel this workspace's subscription in Billing before deleting it.";
+			case "billing_unverified":
+				return "We couldn't verify this workspace's billing status — please try again.";
+			case "billing_drift":
+				return "We couldn't confirm this workspace's billing status. Contact support.";
+		}
+	}
+	return describeApiError(e, "Couldn't delete the workspace");
+}


### PR DESCRIPTION
## What

Adds **workspace management** — create and delete workspaces — closing the loop opened by account-deletion (#61) and the paywall escape hatch (#62).

### API — `DELETE /api/workspaces/:id`
- **Owner-of-this-workspace only**, keyed off the **path id** (not the `x-workspace-id` header) — you can only delete a workspace you own.
- Reuses PR2's deletion service: the **live, fail-closed subscription gate** (`assertDeletable`, scoped to the one workspace) then the explicit set-based **`deleteWorkspaceCascade`**.
- **Last-workspace guard** → `409 last_workspace` ("create another or delete your account instead").
- **Active subscription** → `409 active_subscription` ("cancel this workspace's subscription first").
- Never deletes the user or other workspaces. No migration (reuses existing tables + cascade).
- Create (`POST /workspaces`) and list (`GET /workspaces`) already existed — only delete is new.

### Dashboard
- **`/settings/workspaces`** page (consistent with account/billing): lists the user's workspaces with name, role, and which is current; **Create** + owner-only **Delete**.
- **Create**: "+ Create workspace" in the sidebar switcher dropdown **and** the page → name dialog → `POST` → switch into the new (plan=none) workspace → onboarding paywall (now escapable via #62).
- **Delete dialog**: GitHub-repo-style **type-the-name** confirm. Confirm is a plain `<Button>` (not `AlertDialogAction`, which auto-closes and drops the request — the dead-button bug fixed in #63). Inline error surfacing; **blocked states** for active-sub (cancel-first + Billing link, disabled confirm) and last-workspace (guard message).
- **Active-workspace switch**: deleting the workspace you're in switches context to a remaining one and drops stale per-workspace caches; deleting another just updates the list.
- Added `/settings/workspaces` to the onboarding-redirect escape list so a no-plan active workspace doesn't bounce off the page.

## Tests
- **API unit** (`workspaces.test.ts`): 403 non-owner, 404 missing, 409 last-workspace (nothing cascaded), 409 active-sub (gate reused, nothing cascaded), owner-delete invokes the cascade with the path id.
- **API e2e** (`workspaces.delete.e2e.test.ts`, real route + cascade over sqlite-proxy): deleting one of two workspaces **empties only that subtree**; the other workspace + the user survive; a blocked active-sub delete touches nothing.
- **Dashboard e2e** (`workspaces-page.e2e.test.tsx`, real page + dialogs + fetch): real `DELETE`/`POST` fire; **dialog stays open while pending** (the `AlertDialogAction` regression guard); delete-current switches context; last-workspace + active-sub blocked states gate the request entirely.

All gates green: `pnpm test` (api + dashboard + widget), `pnpm lint`, `pnpm format`, both typechecks, secret scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)