### PR TITLE
perf(dashboard): speed up Account navigation

### DIFF
--- a/apps/dashboard/src/components/app-sidebar.tsx
+++ b/apps/dashboard/src/components/app-sidebar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
@@ -20,6 +20,7 @@ import {
 
 import { CreateWorkspaceDialog } from "@/app/settings/workspaces/_components/CreateWorkspaceDialog";
 
+import { ACCOUNT_KEY, fetchAccount } from "@/lib/account";
 import { api } from "@/lib/api";
 import { useSignOut } from "@/lib/use-sign-out";
 import { useWorkspace } from "@/lib/workspace";
@@ -109,7 +110,13 @@ export function AppSidebar({ userEmail }: { userEmail: string }) {
 	const router = useRouter();
 	const { workspaces, workspaceId, setWorkspaceId, role } = useWorkspace();
 	const handleSignOut = useSignOut();
+	const qc = useQueryClient();
 	const [createWorkspaceOpen, setCreateWorkspaceOpen] = useState(false);
+
+	// Warm the account page's React Query cache as soon as the user menu opens,
+	// so the page renders with data instead of a skeleton after navigating.
+	const prefetchAccount = () =>
+		qc.prefetchQuery({ queryKey: ACCOUNT_KEY, queryFn: fetchAccount });
 	const initials = userEmail.slice(0, 2).toUpperCase();
 	const roleLabel = role ? role[0].toUpperCase() + role.slice(1) : "Member";
 
@@ -318,7 +325,11 @@ export function AppSidebar({ userEmail }: { userEmail: string }) {
 			<SidebarFooter>
 				<SidebarMenu>
 					<SidebarMenuItem>
-						<DropdownMenu>
+						<DropdownMenu
+							onOpenChange={(open) => {
+								if (open) prefetchAccount();
+							}}
+						>
 							<DropdownMenuTrigger asChild>
 								<SidebarMenuButton
 									size="lg"
@@ -348,7 +359,12 @@ export function AppSidebar({ userEmail }: { userEmail: string }) {
 								</DropdownMenuLabel>
 								<DropdownMenuSeparator />
 								<DropdownMenuItem asChild>
-									<Link href="/settings/account">
+									<Link
+										href="/settings/account"
+										prefetch
+										onMouseEnter={prefetchAccount}
+										onFocus={prefetchAccount}
+									>
 										<UserCog />
 										Account
 									</Link>


### PR DESCRIPTION
## Why

Clicking **Account** in the dashboard user menu felt slow. Two causes stacked up:

1. The Account link lives inside a Radix dropdown that only mounts when the menu opens, so Next.js had no chance to prefetch the route bundle ahead of time.
2. `settings/account/page.tsx` is a client component that fetches its data with React Query (`fetchAccount`) **after** navigation, showing a `<Skeleton>` until the request returns. Route prefetch never warms that data, so even a fast navigation still waited on the network.

## What

In `apps/dashboard/src/components/app-sidebar.tsx`:

- Force-prefetch the `/settings/account` route on the user-menu `<Link>`.
- Warm the React Query account cache (`qc.prefetchQuery({ queryKey: ACCOUNT_KEY, queryFn: fetchAccount })`) the moment the user menu opens (`onOpenChange`) — earliest signal, most lead time.
- Also prefetch on `onMouseEnter` / `onFocus` of the Account item (covers keyboard nav). `prefetchQuery` is a no-op when data is already fresh, so no double-fetching.

Net effect: by the time you click Account, both the route bundle and its data are already loading, so the page renders with data instead of a skeleton.

## Notes

- Route prefetch only runs in production builds (Next.js disables it in `pnpm dev`); the React Query warming works in dev too since it's our own code.
- `pnpm test` shows one **pre-existing** failure in `workspaces-page.e2e.test.tsx` that also fails on `main` with this change stashed — unrelated to this PR (that test doesn't render `AppSidebar`). tsc, oxlint, and prettier all pass on the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)