### PR TITLE
fix(dashboard): workspace delete must not be optimistic (destructive path)

### DIFF
--- a/apps/dashboard/src/app/settings/workspaces/page.tsx
+++ b/apps/dashboard/src/app/settings/workspaces/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { Check, Plus } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
@@ -16,7 +16,6 @@ import {
 	CardTitle,
 } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
-import { useOptimisticMutation } from "@/lib/optimistic";
 import { useWorkspace } from "@/lib/workspace";
 import { WORKSPACES_KEY, type WorkspaceSummary } from "@/lib/workspace-utils";
 import { deleteWorkspace, deleteWorkspaceErrorMessage } from "@/lib/workspaces";
@@ -39,23 +38,20 @@ export default function WorkspacesSettingsPage() {
 	const [createOpen, setCreateOpen] = useState(false);
 	const [deleting, setDeleting] = useState<WorkspaceSummary | null>(null);
 
-	// Optimistic delete: the workspace row leaves the list the instant the action
-	// fires; a failure re-inserts it (and toasts). The cache shape is the API's
-	// join rows ({ workspace, role }), so the drop filters on `workspace.id`.
-	// Settle invalidates WORKSPACES_KEY to reconcile with the server.
-	const remove = useOptimisticMutation<string>({
-		queryKey: WORKSPACES_KEY,
-		apply: (prev, id) => {
-			if (!prev || typeof prev !== "object") return prev;
-			const rec = prev as { workspaces?: { workspace: { id: string } }[] };
-			if (!Array.isArray(rec.workspaces)) return prev;
-			return {
-				...rec,
-				workspaces: rec.workspaces.filter((w) => w.workspace.id !== id),
-			};
-		},
-		mutationFn: (id) => deleteWorkspace(id),
-		onSuccess: (_data, id) => {
+	// Workspace delete is deliberately NOT optimistic. This is a modal,
+	// server-confirmed destructive op: the confirm dialog stays open showing
+	// "Deleting…" until the server acknowledges, so a failed delete surfaces
+	// instead of the user thinking it worked. Removing the row from the
+	// WORKSPACES_KEY cache in onMutate (the optimistic pattern) would feed back
+	// through useWorkspace and shrink `workspaces` mid-flight — flipping the
+	// `block` below to "last_workspace" when deleting one of two, which replaces
+	// the in-progress confirm form with a misleading "this is your only
+	// workspace" blocker. Optimism fits non-modal toggles (pin/star/archive);
+	// here the modal occludes the list, so there's no instant-feedback to gain.
+	// The list reconciles via invalidate AFTER the server confirms.
+	const remove = useMutation({
+		mutationFn: (id: string) => deleteWorkspace(id),
+		onSuccess: async (_data, id) => {
 			setDeleting(null);
 			toast.success("Workspace deleted");
 			// If they deleted the workspace they were in, switch into another one they
@@ -68,6 +64,7 @@ export default function WorkspacesSettingsPage() {
 				qc.removeQueries({ queryKey: ["billing-usage"] });
 				if (next) setWorkspaceId(next.id);
 			}
+			await qc.invalidateQueries({ queryKey: WORKSPACES_KEY });
 		},
 		onError: (e) => toast.error(deleteWorkspaceErrorMessage(e)),
 	});

--- a/apps/dashboard/src/app/settings/workspaces/workspaces-page.e2e.test.tsx
+++ b/apps/dashboard/src/app/settings/workspaces/workspaces-page.e2e.test.tsx
@@ -154,6 +154,15 @@ describe("WorkspacesSettingsPage", () => {
 			}),
 		).toBeInTheDocument();
 
+		// Regression guard: delete must NOT be optimistic. If the row were dropped
+		// from the workspace cache in onMutate, `workspaces.length` would fall to 1
+		// mid-flight and the dialog would flip to the "this is your only workspace"
+		// blocker — hiding the pending state and lying about a destructive op that
+		// hasn't been confirmed yet. The confirm form (and "Deleting…") must remain.
+		expect(
+			within(screen.getByRole("alertdialog")).queryByText(/only workspace/i),
+		).not.toBeInTheDocument();
+
 		// Resolve the delete → context switches to the remaining workspace (ws2).
 		resolveDelete(undefined);
 		await waitFor(() => expect(localStorage.getItem(KEY)).toBe("ws2"));


### PR DESCRIPTION
## Diagnosis (before the fix)

`81a6b6e` ("optimistic project save + workspace delete") made workspace delete optimistic, which **regressed the destructive confirm flow** — this is a real bug, not a stale test.

- `useWorkspace` derives `workspaces` from the `WORKSPACES_KEY` query cache.
- The optimistic `onMutate` dropped the deleted row from that cache **the instant delete fired**, before the server confirmed.
- The page computes `block = workspaces.length <= 1 ? "last_workspace" : …`. Deleting **one of two** workspaces shrank the list to 1 mid-flight → `block` flipped to `"last_workspace"` → the dialog swapped its confirm form (and the **"Deleting…"** pending state) for a misleading **"this is your only workspace"** blocker, behind which the row had already vanished. If the DELETE then failed, the user had already been shown the wrong message for an unconfirmed destructive op.

The confirm dialog is intentionally kept open until the server acknowledges, precisely so a failed delete surfaces instead of reading as success. Optimistic list-removal is the right pattern for **non-modal, non-destructive** toggles (pin/star/archive) — here the modal occludes the list (no instant-feedback to gain) and the cache mutation only corrupts the dialog's derived state.

## Fix

Restore the plain (non-optimistic) `useMutation`: the row leaves the list via `invalidateQueries(WORKSPACES_KEY)` **after** the server confirms (`onSuccess`). Context-switch + stale-cache cleanup unchanged. The optimistic **project-save** from the same commit is a separate, non-destructive file and is **untouched**.

A code comment now documents why delete must not be optimistic, so it isn't "optimized" again.

## Tests

- The existing e2e (`deleting the CURRENT workspace … keeps the dialog open while pending`) — which **failed on `main`** — now passes.
- Added a **regression guard**: while the delete is in flight, the `"only workspace"` blocker must **not** appear (the exact symptom of the optimistic bug).
- Full dashboard suite green (47 files / 330 tests).

Gates: prettier ✅, oxlint ✅, tsc ✅, tests ✅.

## Context
This is the pre-existing red test flagged on #67 (the restyle pilot). It's independent of #67 — that PR can land on its own merits; this one un-reds `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)