### PR TITLE
feat(dashboard): inbox/conversations restyle (restyle PR2)

### DIFF
--- a/apps/api/src/routes/conversations.test.ts
+++ b/apps/api/src/routes/conversations.test.ts
@@ -361,40 +361,58 @@ describe("inbox archived filter", () => {
 		expect(sql).toContain('"project_id"');
 	});
 
-	it("archived=true returns only archived rows (archived_at is not null)", async () => {
+	it("status=resolved returns only archived rows (archived_at is not null)", async () => {
 		mockDb({ role: "agent", project: PROJECT, conversationRows: [] });
-		const res = await get("/projects/p1/conversations?archived=true", MEMBER);
+		const res = await get("/projects/p1/conversations?status=resolved", MEMBER);
 		expect(res.status).toBe(200);
 		const sql = whereSql();
 		expect(sql).toContain('"archived_at" is not null');
 	});
 
-	it("archived=false is treated as the active view", async () => {
+	it("status=open (the default) is the active view (archived_at is null)", async () => {
 		mockDb({ role: "agent", project: PROJECT, conversationRows: [] });
-		await get("/projects/p1/conversations?archived=false", MEMBER);
+		await get("/projects/p1/conversations?status=open", MEMBER);
 		const sql = whereSql();
 		expect(sql).toContain('"archived_at" is null');
 		expect(sql).not.toContain("is not null");
 	});
 
-	it("composes with search — archived view AND a text match in the same WHERE", async () => {
+	it("status=escalated filters on escalated_at (a query view, no status column)", async () => {
+		mockDb({ role: "agent", project: PROJECT, conversationRows: [] });
+		await get("/projects/p1/conversations?status=escalated", MEMBER);
+		const sql = whereSql();
+		expect(sql).toContain('"escalated_at" is not null');
+	});
+
+	it("status=all adds no status predicate (neither archived nor escalated)", async () => {
+		mockDb({ role: "agent", project: PROJECT, conversationRows: [] });
+		await get("/projects/p1/conversations?status=all", MEMBER);
+		const sql = whereSql();
+		expect(sql).not.toContain('"archived_at"');
+		expect(sql).not.toContain('"escalated_at"');
+	});
+
+	it("composes with search — status view AND a text match in the same WHERE", async () => {
 		mockDb({
 			role: "agent",
 			project: PROJECT,
 			conversationRows: [],
 			bodyMatchIds: ["cZ"],
 		});
-		await get("/projects/p1/conversations?archived=true&search=refund", MEMBER);
+		await get(
+			"/projects/p1/conversations?status=resolved&search=refund",
+			MEMBER,
+		);
 		const sql = whereSql();
-		// The archived predicate and the search OR-group coexist, project-scoped.
+		// The status predicate and the search OR-group coexist, project-scoped.
 		expect(sql).toContain('"archived_at" is not null');
 		expect(sql).toContain("like");
 		expect(sql).toContain('"project_id"');
 	});
 
-	it("is role-gated: a non-member can't list archived (403, no query)", async () => {
+	it("is role-gated: a non-member can't list (403, no query)", async () => {
 		mockDb({}); // not a member
-		const res = await get("/projects/p1/conversations?archived=true", MEMBER);
+		const res = await get("/projects/p1/conversations?status=resolved", MEMBER);
 		expect(res.status).toBe(403);
 		expect(lastConversationWhere).toBeNull();
 	});
@@ -481,7 +499,7 @@ describe("inbox keyset pagination", () => {
 		mockDb({ role: "agent", project: PROJECT, conversationRows: [] });
 		const cursor = encodeCursor({ updatedAt: 250, id: "cMid" });
 		await get(
-			`/projects/p1/conversations?archived=true&cursor=${cursor}`,
+			`/projects/p1/conversations?status=resolved&cursor=${cursor}`,
 			MEMBER,
 		);
 		const sql = whereSql();
@@ -657,7 +675,7 @@ describe("inbox tag filter (tagIds)", () => {
 		});
 		const cursor = encodeCursor({ updatedAt: 250, id: "cMid" });
 		await get(
-			`/projects/p1/conversations?tagIds=t1&archived=true&search=refund&cursor=${cursor}`,
+			`/projects/p1/conversations?tagIds=t1&status=resolved&search=refund&cursor=${cursor}`,
 			MEMBER,
 		);
 		const sql = whereSql();

--- a/apps/api/src/routes/conversations.ts
+++ b/apps/api/src/routes/conversations.ts
@@ -53,7 +53,17 @@ export const conversations = new Hono<AppContext>()
 			"query",
 			z.object({
 				search: z.string().optional(),
-				archived: z.enum(["true", "false"]).optional(),
+				// Derived status filter (query-only; no status column on the row):
+				//   open      -> archivedAt IS NULL     (the default / active view)
+				//   resolved  -> archivedAt IS NOT NULL (archiving IS resolving)
+				//   escalated -> escalatedAt IS NOT NULL
+				//   all       -> no status predicate
+				// These are FILTER VIEWS, not mutually-exclusive states: an escalated
+				// conversation can also be resolved. Don't "fix" the overlap into an
+				// enum — there is no status column.
+				status: z
+					.enum(["open", "resolved", "escalated", "all"])
+					.default("open"),
 				limit: z.coerce.number().int().min(1).max(100).default(30),
 				// Opaque keyset cursor (see lib/cursor). A garbage value decodes to
 				// null below and just serves the first page — never a 400.
@@ -65,7 +75,7 @@ export const conversations = new Hono<AppContext>()
 		),
 		async (c) => {
 			const { projectId } = c.req.param();
-			const { search, archived, limit, cursor, tagIds } = c.req.valid("query");
+			const { search, status, limit, cursor, tagIds } = c.req.valid("query");
 			const workspaceId = c.get("workspaceId");
 			const userId = c.get("userId");
 
@@ -79,15 +89,21 @@ export const conversations = new Hono<AppContext>()
 
 			const term = search?.trim() ?? "";
 
-			// Active vs archived split, server-side and explicit: archived rows have
-			// a non-null archivedAt. Default (param absent or "false") is the active
-			// view. This goes into the WHERE before LIMIT/OFFSET and composes with
-			// the search OR-group below, so search runs within the chosen view.
+			// Derived status filter, server-side and explicit. Goes into the WHERE
+			// before LIMIT/OFFSET and composes with the search OR-group + keyset
+			// cursor below, so search/paging run within the chosen view. `all` adds
+			// no predicate. See the `status` enum comment above for the mapping.
+			const statusPredicate =
+				status === "resolved"
+					? isNotNull(conversation.archivedAt)
+					: status === "escalated"
+						? isNotNull(conversation.escalatedAt)
+						: status === "open"
+							? isNull(conversation.archivedAt)
+							: undefined; // "all"
 			const conditions = [
 				eq(conversation.projectId, projectId),
-				archived === "true"
-					? isNotNull(conversation.archivedAt)
-					: isNull(conversation.archivedAt),
+				...(statusPredicate ? [statusPredicate] : []),
 			];
 
 			// Content search: a conversation matches on visitor name, email, OR any

--- a/apps/dashboard/src/app/inbox/_components/ConversationList.test.tsx
+++ b/apps/dashboard/src/app/inbox/_components/ConversationList.test.tsx
@@ -35,7 +35,7 @@ function setup(
 			selectedId={null}
 			onSelect={onSelect}
 			search=""
-			showArchived={false}
+			status="open"
 			{...props}
 		/>,
 	);
@@ -62,7 +62,7 @@ describe("ConversationList", () => {
 				selectedId={null}
 				onSelect={vi.fn()}
 				search=""
-				showArchived={false}
+				status="open"
 			/>,
 		);
 		expect(screen.getByLabelText("Unread")).toBeInTheDocument();
@@ -73,7 +73,7 @@ describe("ConversationList", () => {
 				selectedId={null}
 				onSelect={vi.fn()}
 				search=""
-				showArchived={false}
+				status="open"
 			/>,
 		);
 		expect(screen.queryByLabelText("Unread")).not.toBeInTheDocument();
@@ -86,7 +86,7 @@ describe("ConversationList", () => {
 				selectedId="a"
 				onSelect={vi.fn()}
 				search=""
-				showArchived={false}
+				status="open"
 			/>,
 		);
 		expect(screen.queryByLabelText("Unread")).not.toBeInTheDocument();
@@ -158,7 +158,7 @@ describe("ConversationList", () => {
 				selectedId={null}
 				onSelect={vi.fn()}
 				search="zzz"
-				showArchived={false}
+				status="open"
 			/>,
 		);
 		expect(
@@ -171,10 +171,10 @@ describe("ConversationList", () => {
 				selectedId={null}
 				onSelect={vi.fn()}
 				search=""
-				showArchived
+				status="resolved"
 			/>,
 		);
-		expect(screen.getByText(/no archived conversations/i)).toBeInTheDocument();
+		expect(screen.getByText(/no resolved conversations/i)).toBeInTheDocument();
 	});
 
 	it("keeps rows reachable for selection", () => {

--- a/apps/dashboard/src/app/inbox/_components/ConversationList.tsx
+++ b/apps/dashboard/src/app/inbox/_components/ConversationList.tsx
@@ -2,11 +2,11 @@
 
 import { MessageCircle } from "lucide-react";
 
-import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
 
 import { initials, pluralize, timeAgo } from "./format";
 import { Highlighted } from "./highlight";
+import type { StatusFilter } from "./status";
 import { TagChip } from "./TagChip";
 import type { Conversation, SearchMatch } from "./types";
 
@@ -16,6 +16,13 @@ const MATCH_LABEL: Record<SearchMatch["field"], string | null> = {
 	body: null,
 	name: "Name",
 	email: "Email",
+};
+
+const EMPTY_COPY: Record<StatusFilter, string> = {
+	open: "No open conversations",
+	resolved: "No resolved conversations",
+	escalated: "No escalated conversations",
+	all: "No conversations yet",
 };
 
 function ConversationRow({
@@ -38,26 +45,24 @@ function ConversationRow({
 			onClick={onSelect}
 			aria-current={selected}
 			className={cn(
-				"flex w-full items-start gap-3 rounded-lg px-3 py-2.5 text-left transition-colors",
+				"flex w-full items-start gap-3 rounded-[10px] px-3 py-2.5 text-left transition-colors",
 				selected
-					? "bg-primary/10 ring-1 ring-inset ring-primary/20"
-					: "hover:bg-muted/60",
+					? "bg-ck-accent/10 ring-1 ring-inset ring-ck-accent/25"
+					: "hover:bg-ck-navhover",
 			)}
 		>
 			<div className="relative shrink-0">
 				<span
 					className={cn(
-						"flex size-9 items-center justify-center rounded-full text-xs font-semibold",
-						selected
-							? "bg-primary text-primary-foreground"
-							: "bg-muted text-muted-foreground",
+						"flex size-9 items-center justify-center rounded-full text-xs font-bold",
+						selected ? "bg-ck-accent text-white" : "bg-ck-chip text-ck-muted",
 					)}
 				>
 					{initials(conversation.name)}
 				</span>
 				{unread && !selected && (
 					<span
-						className="absolute -left-0.5 -top-0.5 size-2.5 rounded-full bg-primary ring-2 ring-card"
+						className="absolute -left-0.5 -top-0.5 size-2.5 rounded-full bg-ck-accent ring-2 ring-ck-sidebar"
 						aria-label="Unread"
 					/>
 				)}
@@ -68,20 +73,20 @@ function ConversationRow({
 					<span
 						className={cn(
 							"truncate text-sm",
-							unread && !selected ? "font-semibold" : "font-medium",
-							selected ? "text-primary" : "text-foreground",
+							unread && !selected ? "font-bold" : "font-semibold",
+							"text-ck-text",
 						)}
 					>
 						{conversation.name ?? "Anonymous"}
 					</span>
-					<span className="shrink-0 text-[11px] text-muted-foreground">
+					<span className="shrink-0 text-[11px] text-ck-faint">
 						{timeAgo(conversation.updatedAt)}
 					</span>
 				</div>
 				{conversation.match && search ? (
-					<p className="truncate text-xs text-muted-foreground">
+					<p className="truncate text-xs text-ck-muted">
 						{MATCH_LABEL[conversation.match.field] && (
-							<span className="mr-1 font-medium uppercase tracking-wide text-[10px] text-muted-foreground/70">
+							<span className="mr-1 text-[10px] font-medium uppercase tracking-wide text-ck-faint">
 								{MATCH_LABEL[conversation.match.field]}
 							</span>
 						)}
@@ -92,8 +97,8 @@ function ConversationRow({
 						className={cn(
 							"truncate text-xs",
 							unread && !selected
-								? "font-medium text-foreground"
-								: "text-muted-foreground",
+								? "font-medium text-ck-text"
+								: "text-ck-muted",
 						)}
 					>
 						{conversation.firstMessage?.trim() ||
@@ -103,14 +108,14 @@ function ConversationRow({
 				)}
 				<div className="mt-0.5 flex flex-wrap items-center gap-1.5">
 					{escalated && (
-						<Badge variant="warning" className="h-4 px-1.5 text-[10px]">
+						<span className="inline-flex h-4 items-center rounded-full bg-ck-warn/15 px-1.5 text-[10px] font-semibold text-ck-warn">
 							Escalated
-						</Badge>
+						</span>
 					)}
 					{conversation.tags?.map((t) => (
 						<TagChip key={t.id} tag={t} />
 					))}
-					<span className="text-[11px] text-muted-foreground/70">
+					<span className="text-[11px] text-ck-faint">
 						{pluralize(conversation.messageCount, "message")}
 					</span>
 				</div>
@@ -125,7 +130,7 @@ export interface ConversationListProps {
 	onSelect: (id: string) => void;
 	/** Read-only context for the empty-state copy; filtering lives in the toolbar. */
 	search: string;
-	showArchived: boolean;
+	status: StatusFilter;
 }
 
 export function ConversationList({
@@ -133,20 +138,18 @@ export function ConversationList({
 	selectedId,
 	onSelect,
 	search,
-	showArchived,
+	status,
 }: ConversationListProps) {
 	return (
 		<div className="flex min-h-0 flex-1 flex-col">
 			<div className="min-h-0 flex-1 overflow-y-auto p-1.5">
 				{conversations.length === 0 ? (
 					<div className="flex flex-col items-center justify-center gap-2 px-4 py-12 text-center">
-						<MessageCircle className="size-8 text-muted-foreground/40" />
-						<p className="text-xs text-muted-foreground">
-							{showArchived
-								? "No archived conversations"
-								: search
-									? "No conversations match your search"
-									: "No conversations yet"}
+						<MessageCircle className="size-8 text-ck-disabled" />
+						<p className="text-xs text-ck-faint">
+							{search
+								? "No conversations match your search"
+								: EMPTY_COPY[status]}
 						</p>
 					</div>
 				) : (
@@ -165,10 +168,9 @@ export function ConversationList({
 				)}
 			</div>
 
-			<div className="border-t px-4 py-2">
-				<p className="text-[11px] text-muted-foreground">
+			<div className="border-t border-ck-border px-4 py-2">
+				<p className="text-[11px] text-ck-faint">
 					{pluralize(conversations.length, "conversation")}
-					{showArchived ? " archived" : ""}
 				</p>
 			</div>
 		</div>

--- a/apps/dashboard/src/app/inbox/_components/DetailPanel.test.tsx
+++ b/apps/dashboard/src/app/inbox/_components/DetailPanel.test.tsx
@@ -30,35 +30,47 @@ beforeAll(() => {
 	Element.prototype.hasPointerCapture ??= () => false;
 });
 
-function setup(overrides: Partial<Conversation> = {}) {
-	const onArchive = vi.fn();
+function setup(
+	overrides: Partial<Conversation> = {},
+	props: { deleting?: boolean } = {},
+) {
+	const onResolve = vi.fn();
 	const onDelete = vi.fn();
 	render(
 		<DetailPanel
 			conversation={conv(overrides)}
-			onArchive={onArchive}
+			onResolve={onResolve}
 			onDelete={onDelete}
-			archiving={false}
-			deleting={false}
+			resolving={false}
+			deleting={props.deleting ?? false}
 		/>,
 	);
-	return { onArchive, onDelete };
+	return { onResolve, onDelete };
 }
 
 describe("DetailPanel", () => {
-	it("renders contact, session, and a friendly device string from the user agent", () => {
+	it("renders only real captured fields (device parsed from the UA, real IP)", () => {
 		setup();
-		// Email shows in both the header and the contact field.
 		expect(screen.getAllByText("ada@example.com").length).toBeGreaterThan(0);
 		expect(screen.getByText("Chrome on macOS")).toBeInTheDocument();
 		expect(screen.getByText("203.0.113.7")).toBeInTheDocument();
 		expect(screen.getByText("4")).toBeInTheDocument(); // message count
 	});
 
-	it("falls back to Unknown when device/IP data is missing (never invents)", () => {
+	it("falls back to a literal placeholder when device/IP are missing (never invents)", () => {
 		setup({ userAgent: null, ipAddress: null });
-		// Device and IP both read "Unknown".
 		expect(screen.getAllByText("Unknown").length).toBeGreaterThanOrEqual(2);
+	});
+
+	it("renders the roadmap visitor-context as an honest empty block — em-dashes, never a value", () => {
+		setup();
+		expect(
+			screen.getByText(/not captured yet — never show a guessed value/i),
+		).toBeInTheDocument();
+		expect(screen.getByText("Location")).toBeInTheDocument();
+		expect(screen.getByText("Referrer")).toBeInTheDocument();
+		// Every roadmap field renders an em-dash, not a fabricated value.
+		expect(screen.getAllByText("—").length).toBeGreaterThanOrEqual(7);
 	});
 
 	it("shows the escalated block only when escalated", () => {
@@ -66,25 +78,31 @@ describe("DetailPanel", () => {
 		expect(screen.getByText(/escalated to a human/i)).toBeInTheDocument();
 	});
 
-	it("shows 'Not rated' when the conversation has no CSAT", () => {
-		setup({ csatRating: null });
-		expect(screen.getByText(/not rated/i)).toBeInTheDocument();
-	});
-
-	it("shows the CSAT score when the conversation is rated", () => {
+	it("shows the CSAT score honestly when rated", () => {
 		setup({ csatRating: 4 });
 		expect(screen.getByText(/4 \/ 5/)).toBeInTheDocument();
 		expect(screen.queryByText(/not rated/i)).not.toBeInTheDocument();
 	});
 
-	it("archives directly but confirms before deleting", async () => {
+	it("Resolve fires directly", async () => {
 		const user = userEvent.setup();
-		const { onArchive, onDelete } = setup();
+		const { onResolve } = setup();
+		await user.click(screen.getByRole("button", { name: /^resolve$/i }));
+		expect(onResolve).toHaveBeenCalledTimes(1);
+	});
 
-		await user.click(screen.getByRole("button", { name: /^archive$/i }));
-		expect(onArchive).toHaveBeenCalledTimes(1);
+	it("offers Reopen (not Unarchive) for a resolved conversation", () => {
+		setup({ archivedAt: "2026-06-16T05:02:00.000Z" });
+		expect(screen.getByRole("button", { name: /reopen/i })).toBeInTheDocument();
+		expect(screen.queryByRole("button", { name: /unarchive/i })).toBeNull();
+	});
 
-		// Delete is guarded by a confirm dialog — the trigger alone doesn't delete.
+	// Delete is a plain Button inside a controlled dialog (NOT AlertDialogAction):
+	// the trigger opens the confirm; the confirm's plain Delete button fires.
+	it("confirms before deleting, then the plain Delete button fires onDelete", async () => {
+		const user = userEvent.setup();
+		const { onDelete } = setup();
+
 		await user.click(
 			screen.getByRole("button", { name: /delete conversation/i }),
 		);
@@ -94,10 +112,14 @@ describe("DetailPanel", () => {
 		expect(onDelete).toHaveBeenCalledTimes(1);
 	});
 
-	it("offers Unarchive for an archived conversation", () => {
-		setup({ archivedAt: "2026-06-16T05:02:00.000Z" });
+	it("shows 'Deleting…' while the delete is pending (dialog stays open)", async () => {
+		const user = userEvent.setup();
+		setup({}, { deleting: true });
+		await user.click(
+			screen.getByRole("button", { name: /delete conversation/i }),
+		);
 		expect(
-			screen.getByRole("button", { name: /unarchive/i }),
+			screen.getByRole("button", { name: /deleting/i }),
 		).toBeInTheDocument();
 	});
 });

--- a/apps/dashboard/src/app/inbox/_components/DetailPanel.tsx
+++ b/apps/dashboard/src/app/inbox/_components/DetailPanel.tsx
@@ -1,32 +1,30 @@
 "use client";
 
 import {
-	Archive,
-	ArchiveRestore,
+	Check,
 	Clock,
 	Globe,
 	Mail,
 	MessageCircle,
 	Monitor,
+	RotateCcw,
 	Star,
 	Trash2,
 	TriangleAlert,
 	User,
 } from "lucide-react";
+import { useState } from "react";
 
 import {
 	AlertDialog,
-	AlertDialogAction,
 	AlertDialogCancel,
 	AlertDialogContent,
 	AlertDialogDescription,
 	AlertDialogFooter,
 	AlertDialogHeader,
 	AlertDialogTitle,
-	AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
-import { Button } from "@/components/ui/button";
-import { buttonVariants } from "@/components/ui/button";
+import { Button } from "@/components/ds";
 import { cn } from "@/lib/utils";
 
 import { formatFullDate, initials, parseDevice } from "./format";
@@ -40,8 +38,8 @@ function Section({
 	children: React.ReactNode;
 }) {
 	return (
-		<div className="flex flex-col gap-3 border-t px-4 py-4 first:border-t-0">
-			<h3 className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+		<div className="flex flex-col gap-3 border-t border-ck-border px-4 py-4 first:border-t-0">
+			<h3 className="text-[11px] font-semibold uppercase tracking-wider text-ck-faint">
 				{title}
 			</h3>
 			{children}
@@ -62,12 +60,12 @@ function Field({
 }) {
 	return (
 		<div className="flex items-start gap-3">
-			<span className="mt-0.5 text-muted-foreground">{icon}</span>
+			<span className="mt-0.5 text-ck-faint [&_svg]:size-4">{icon}</span>
 			<div className="min-w-0">
-				<p className="text-xs font-medium text-muted-foreground">{label}</p>
+				<p className="text-xs font-medium text-ck-faint">{label}</p>
 				<p
 					className={cn(
-						"break-words text-sm text-foreground",
+						"break-words text-sm text-ck-text",
 						mono && "font-mono text-xs",
 					)}
 				>
@@ -78,34 +76,49 @@ function Field({
 	);
 }
 
+/** Visitor-context fields the widget does NOT capture yet. Shown as an honest
+ * empty block — designed, not wired — never with a guessed value. */
+const ROADMAP_FIELDS = [
+	"Location",
+	"Local time",
+	"First seen",
+	"Current page",
+	"Referrer",
+	"Pages viewed",
+	"Channel",
+] as const;
+
 export function DetailPanel({
 	conversation,
-	onArchive,
+	onResolve,
 	onDelete,
-	archiving,
+	resolving,
 	deleting,
 }: {
 	conversation: Conversation;
-	onArchive: () => void;
+	/** Toggle resolved (over PATCH {archived}); optimistic + reversible. */
+	onResolve: () => void;
+	/** Permanently delete — fired from the confirm dialog (non-optimistic). */
 	onDelete: () => void;
-	archiving: boolean;
+	resolving: boolean;
 	deleting: boolean;
 }) {
-	const archived = Boolean(conversation.archivedAt);
+	const resolved = Boolean(conversation.archivedAt);
 	const device = parseDevice(conversation.userAgent);
+	const [confirmOpen, setConfirmOpen] = useState(false);
 
 	return (
-		<div className="flex min-h-0 flex-col">
-			<div className="flex flex-col items-center gap-3 border-b px-6 py-6">
-				<span className="flex size-16 items-center justify-center rounded-full bg-primary/10 text-lg font-semibold text-primary">
+		<div className="flex min-h-0 flex-col bg-ck-sidebar">
+			<div className="flex flex-col items-center gap-3 border-b border-ck-border px-6 py-6">
+				<span className="flex size-16 items-center justify-center rounded-2xl bg-ck-accent text-lg font-bold text-white">
 					{initials(conversation.name)}
 				</span>
 				<div className="text-center">
-					<p className="text-sm font-semibold">
+					<p className="text-sm font-bold text-ck-text">
 						{conversation.name ?? "Anonymous"}
 					</p>
 					{conversation.email && (
-						<p className="mt-0.5 break-all text-xs text-muted-foreground">
+						<p className="mt-0.5 break-all text-xs text-ck-faint">
 							{conversation.email}
 						</p>
 					)}
@@ -114,62 +127,58 @@ export function DetailPanel({
 
 			<div className="min-h-0 flex-1 overflow-y-auto">
 				{conversation.escalatedAt && (
-					<div className="m-4 rounded-lg bg-amber-500/10 p-3">
+					<div className="m-4 rounded-[10px] bg-ck-warn/12 p-3">
 						<div className="flex items-center gap-2">
-							<TriangleAlert className="size-4 text-amber-600 dark:text-amber-400" />
-							<span className="text-xs font-semibold text-amber-700 dark:text-amber-400">
+							<TriangleAlert className="size-4 text-ck-warn" />
+							<span className="text-xs font-semibold text-ck-warn">
 								Escalated to a human
 							</span>
 						</div>
-						<p className="mt-1 text-xs text-amber-700/80 dark:text-amber-500">
+						<p className="mt-1 text-xs text-ck-warn/80">
 							{formatFullDate(conversation.escalatedAt)}
 						</p>
 					</div>
 				)}
 
-				<Section title="Contact details">
+				{/* LIVE — real captured fields only. */}
+				<Section title="Contact">
 					<Field
-						icon={<User className="size-4" />}
+						icon={<User />}
 						label="Name"
 						value={conversation.name ?? "Not provided"}
 					/>
 					<Field
-						icon={<Mail className="size-4" />}
+						icon={<Mail />}
 						label="Email"
 						value={conversation.email ?? "Not provided"}
 					/>
 				</Section>
 
-				<Section title="Session info">
+				<Section title="Session">
 					<Field
-						icon={<Clock className="size-4" />}
+						icon={<Clock />}
 						label="Started"
 						value={formatFullDate(conversation.createdAt)}
 					/>
 					<Field
-						icon={<MessageCircle className="size-4" />}
+						icon={<MessageCircle />}
 						label="Messages"
 						value={conversation.messageCount}
 					/>
-				</Section>
-
-				<Section title="Visitor device">
 					<Field
-						icon={<Monitor className="size-4" />}
+						icon={<Monitor />}
 						label="Device"
 						value={device ?? "Unknown"}
 					/>
 					<Field
-						icon={<Globe className="size-4" />}
+						icon={<Globe />}
 						label="IP address"
 						value={conversation.ipAddress ?? "Unknown"}
 						mono
 					/>
 				</Section>
 
-				<Section title="Rating">
-					{/* Conversation-level CSAT (1–5), prompted on widget close — distinct
-					    from the per-message thumbs shown in the thread. */}
+				<Section title="CSAT rating">
 					{conversation.csatRating != null ? (
 						<div className="flex items-center gap-2">
 							<div className="flex items-center gap-0.5">
@@ -179,8 +188,8 @@ export function DetailPanel({
 										className={cn(
 											"size-4",
 											n <= conversation.csatRating!
-												? "text-amber-500"
-												: "text-muted-foreground/30",
+												? "text-ck-warn"
+												: "text-ck-disabled",
 										)}
 										fill={
 											n <= conversation.csatRating! ? "currentColor" : "none"
@@ -188,50 +197,77 @@ export function DetailPanel({
 									/>
 								))}
 							</div>
-							<span className="text-sm font-medium text-foreground">
+							<span className="text-sm font-medium text-ck-text">
 								{conversation.csatRating} / 5
 							</span>
 						</div>
 					) : (
-						<p className="text-sm text-muted-foreground">Not rated</p>
+						<p className="text-sm text-ck-faint">Not rated</p>
 					)}
 				</Section>
+
+				{/* ROADMAP — honest empty. The widget doesn't capture these yet; show
+				    the intended fields with em-dashes, never a fabricated value. */}
+				<div className="m-4 rounded-[14px] border border-dashed border-ck-border p-4">
+					<h3 className="text-[11px] font-semibold uppercase tracking-wider text-ck-faint">
+						Visitor context
+					</h3>
+					<p className="mt-1 text-[11px] leading-relaxed text-ck-faint">
+						Not captured yet — never show a guessed value.
+					</p>
+					<div className="mt-3 flex flex-col gap-2">
+						{ROADMAP_FIELDS.map((label) => (
+							<div
+								key={label}
+								className="flex items-center justify-between gap-3"
+							>
+								<span className="text-xs text-ck-faint">{label}</span>
+								<span className="text-sm font-medium text-ck-disabled">—</span>
+							</div>
+						))}
+					</div>
+				</div>
 			</div>
 
-			<div className="flex flex-col gap-2 border-t p-4">
+			<div className="flex flex-col gap-2 border-t border-ck-border p-4">
 				<Button
-					type="button"
 					variant="outline"
 					size="sm"
 					className="w-full"
-					disabled={archiving}
-					onClick={onArchive}
+					disabled={resolving}
+					onClick={onResolve}
 				>
-					{archived ? (
+					{resolved ? (
 						<>
-							<ArchiveRestore />
-							Unarchive
+							<RotateCcw className="size-4" />
+							Reopen
 						</>
 					) : (
 						<>
-							<Archive />
-							Archive
+							<Check className="size-4" />
+							Resolve
 						</>
 					)}
 				</Button>
 
-				<AlertDialog>
-					<AlertDialogTrigger asChild>
-						<Button
-							type="button"
-							variant="ghost"
-							size="sm"
-							className="w-full text-destructive hover:bg-destructive/10 hover:text-destructive"
-						>
-							<Trash2 />
-							Delete conversation
-						</Button>
-					</AlertDialogTrigger>
+				<Button
+					variant="ghost"
+					size="sm"
+					className="w-full text-ck-warn hover:bg-ck-warn/10 hover:text-ck-warn"
+					onClick={() => setConfirmOpen(true)}
+				>
+					<Trash2 className="size-4" />
+					Delete conversation
+				</Button>
+
+				{/*
+				 * Controlled AlertDialog + a plain submit Button — NOT AlertDialogAction,
+				 * which auto-closes on click and (under React 18) unmounts before the
+				 * handler fires (the dead-button bug). Delete is non-optimistic: the
+				 * dialog stays open showing "Deleting…" until the server confirms, so a
+				 * failed delete surfaces instead of reading as success.
+				 */}
+				<AlertDialog open={confirmOpen} onOpenChange={setConfirmOpen}>
 					<AlertDialogContent>
 						<AlertDialogHeader>
 							<AlertDialogTitle>Delete conversation?</AlertDialogTitle>
@@ -241,14 +277,15 @@ export function DetailPanel({
 							</AlertDialogDescription>
 						</AlertDialogHeader>
 						<AlertDialogFooter>
-							<AlertDialogCancel>Cancel</AlertDialogCancel>
-							<AlertDialogAction
-								className={cn(buttonVariants({ variant: "destructive" }))}
+							<AlertDialogCancel type="button">Cancel</AlertDialogCancel>
+							<Button
+								variant="primary"
+								className="bg-ck-warn hover:bg-ck-warn/90"
 								disabled={deleting}
 								onClick={onDelete}
 							>
 								{deleting ? "Deleting…" : "Delete"}
-							</AlertDialogAction>
+							</Button>
 						</AlertDialogFooter>
 					</AlertDialogContent>
 				</AlertDialog>

--- a/apps/dashboard/src/app/inbox/_components/InboxPanes.tsx
+++ b/apps/dashboard/src/app/inbox/_components/InboxPanes.tsx
@@ -69,7 +69,7 @@ export function InboxPanes({
 			<div
 				data-pane="list"
 				className={cn(
-					"min-h-0 flex-col border-r md:w-80 md:shrink-0",
+					"min-h-0 flex-col border-r border-ck-border md:w-80 md:shrink-0",
 					hasSelection ? "hidden md:flex" : "flex w-full",
 				)}
 			>
@@ -86,7 +86,7 @@ export function InboxPanes({
 			>
 				{hasSelection ? (
 					<>
-						<div className="flex items-center gap-2 border-b px-4 py-3 sm:px-6">
+						<div className="flex items-center gap-2 border-b border-ck-border px-4 py-3 sm:px-6">
 							<Button
 								type="button"
 								variant="ghost"
@@ -124,7 +124,7 @@ export function InboxPanes({
 			{/* Right — details aside (desktop only) */}
 			<aside
 				data-pane="details"
-				className="hidden w-72 shrink-0 border-l lg:flex lg:flex-col"
+				className="hidden w-72 shrink-0 border-l border-ck-border lg:flex lg:flex-col"
 			>
 				{details ?? detailsEmptyState}
 			</aside>

--- a/apps/dashboard/src/app/inbox/_components/InboxStats.tsx
+++ b/apps/dashboard/src/app/inbox/_components/InboxStats.tsx
@@ -18,17 +18,17 @@ function StatCard({
 	tone?: "amber";
 }) {
 	return (
-		<div className="min-w-[5rem] rounded-lg border bg-card px-4 py-2 text-center">
+		<div className="min-w-[5rem] rounded-[10px] border border-ck-border bg-ck-card px-4 py-2 text-center">
 			<div
 				className={cn(
 					"flex items-center justify-center gap-1 text-xl font-semibold leading-none tabular-nums",
-					tone === "amber" ? "text-amber-500" : "text-foreground",
+					tone === "amber" ? "text-ck-warn" : "text-ck-text",
 				)}
 			>
 				{icon}
 				{value}
 			</div>
-			<div className="mt-1 text-[11px] text-muted-foreground">{label}</div>
+			<div className="mt-1 text-[11px] text-ck-faint">{label}</div>
 		</div>
 	);
 }
@@ -58,7 +58,7 @@ export function InboxStats({ stats }: { stats?: ConversationStats }) {
 				label="Avg rating"
 				icon={
 					<Star
-						className="size-4 text-amber-500"
+						className="size-4 text-ck-warn"
 						fill={avgRating != null ? "currentColor" : "none"}
 					/>
 				}

--- a/apps/dashboard/src/app/inbox/_components/InboxToolbar.test.tsx
+++ b/apps/dashboard/src/app/inbox/_components/InboxToolbar.test.tsx
@@ -5,28 +5,27 @@ import { beforeAll, describe, expect, it, vi } from "vitest";
 import { InboxToolbar } from "./InboxToolbar";
 
 beforeAll(() => {
-	// Radix Select uses pointer-capture + scrollIntoView, unimplemented in jsdom.
 	Element.prototype.scrollIntoView = vi.fn();
 	Element.prototype.hasPointerCapture ??= () => false;
 });
 
 function setup(props: Partial<React.ComponentProps<typeof InboxToolbar>> = {}) {
 	const onSearch = vi.fn();
-	const onShowArchivedChange = vi.fn();
+	const onStatusChange = vi.fn();
 	const onTagIdsChange = vi.fn();
 	const { unmount } = render(
 		<InboxToolbar
 			search=""
 			onSearch={onSearch}
-			showArchived={false}
-			onShowArchivedChange={onShowArchivedChange}
+			status="open"
+			onStatusChange={onStatusChange}
 			tags={[]}
 			tagIds={[]}
 			onTagIdsChange={onTagIdsChange}
 			{...props}
 		/>,
 	);
-	return { onSearch, onShowArchivedChange, onTagIdsChange, unmount };
+	return { onSearch, onStatusChange, onTagIdsChange, unmount };
 }
 
 describe("InboxToolbar", () => {
@@ -37,30 +36,22 @@ describe("InboxToolbar", () => {
 		expect(onSearch).toHaveBeenCalledWith("x");
 	});
 
-	it("reflects the active status in the filter control", () => {
-		const base = {
-			search: "",
-			onSearch: vi.fn(),
-			onShowArchivedChange: vi.fn(),
-			tags: [],
-			tagIds: [],
-			onTagIdsChange: vi.fn(),
-		};
-		const { rerender } = render(
-			<InboxToolbar {...base} showArchived={false} />,
+	it("offers the four derived status views and marks the active one", () => {
+		setup({ status: "escalated" });
+		for (const label of ["Open", "Resolved", "Escalated", "All"]) {
+			expect(screen.getByRole("radio", { name: label })).toBeInTheDocument();
+		}
+		expect(screen.getByRole("radio", { name: "Escalated" })).toHaveAttribute(
+			"aria-checked",
+			"true",
 		);
-		expect(screen.getByText("All conversations")).toBeInTheDocument();
-
-		rerender(<InboxToolbar {...base} showArchived />);
-		expect(screen.getByText("Archived")).toBeInTheDocument();
 	});
 
-	it("switches to the archived view from the filter dropdown", async () => {
+	it("reports the chosen status upward", async () => {
 		const user = userEvent.setup();
-		const { onShowArchivedChange } = setup();
-		await user.click(screen.getByRole("combobox", { name: /filter/i }));
-		await user.click(screen.getByRole("option", { name: "Archived" }));
-		expect(onShowArchivedChange).toHaveBeenCalledWith(true);
+		const { onStatusChange } = setup();
+		await user.click(screen.getByRole("radio", { name: "Resolved" }));
+		expect(onStatusChange).toHaveBeenCalledWith("resolved");
 	});
 
 	it("disables the Tags filter when the workspace has no tags", () => {
@@ -84,7 +75,6 @@ describe("InboxToolbar", () => {
 		const user = userEvent.setup();
 		const tags = [{ id: "t1", name: "Billing", color: "#6366f1", count: 3 }];
 
-		// No onManageTags (agent): the link is absent from the filter popover.
 		const { unmount } = setup({ tags });
 		await user.click(screen.getByRole("button", { name: /tags/i }));
 		expect(
@@ -92,7 +82,6 @@ describe("InboxToolbar", () => {
 		).not.toBeInTheDocument();
 		unmount();
 
-		// With onManageTags (admin/owner): the link shows and fires.
 		const onManageTags = vi.fn();
 		setup({ tags, onManageTags });
 		await user.click(screen.getByRole("button", { name: /tags/i }));

--- a/apps/dashboard/src/app/inbox/_components/InboxToolbar.tsx
+++ b/apps/dashboard/src/app/inbox/_components/InboxToolbar.tsx
@@ -2,24 +2,18 @@
 
 import { Search } from "lucide-react";
 
-import { Input } from "@/components/ui/input";
-import {
-	Select,
-	SelectContent,
-	SelectItem,
-	SelectTrigger,
-	SelectValue,
-} from "@/components/ui/select";
+import { Segmented } from "@/components/ds";
 
+import { STATUS_FILTERS, type StatusFilter } from "./status";
 import { TagFilter } from "./TagFilter";
 import type { Tag } from "./types";
 
 export interface InboxToolbarProps {
 	search: string;
 	onSearch: (value: string) => void;
-	/** Active vs archived view — the only real conversation filter we have. */
-	showArchived: boolean;
-	onShowArchivedChange: (archived: boolean) => void;
+	/** Derived status view: Open / Resolved / Escalated / All. */
+	status: StatusFilter;
+	onStatusChange: (status: StatusFilter) => void;
 	/** Workspace tags for the toolbar tag filter. */
 	tags: Tag[];
 	/** Selected tag ids (OR filter). */
@@ -30,47 +24,37 @@ export interface InboxToolbarProps {
 }
 
 /**
- * Top toolbar spanning the inbox panes: status filter + search + a real tag
- * filter (in the slot the disabled "Filters" placeholder used to occupy). The
- * list is always ordered latest-first, so the "Latest" label is truthful. PR2
- * will unify all of these into one filter surface.
+ * Top toolbar spanning the inbox panes: the derived status filter (Open /
+ * Resolved / Escalated / All), search, and the tag filter. Status is query-only
+ * — Resolved == archived, Escalated == escalatedAt — never a fabricated state.
  */
 export function InboxToolbar({
 	search,
 	onSearch,
-	showArchived,
-	onShowArchivedChange,
+	status,
+	onStatusChange,
 	tags,
 	tagIds,
 	onTagIdsChange,
 	onManageTags,
 }: InboxToolbarProps) {
 	return (
-		<div className="flex items-center gap-2 border-b px-4 py-2.5">
-			<Select
-				value={showArchived ? "archived" : "all"}
-				onValueChange={(v) => onShowArchivedChange(v === "archived")}
-			>
-				<SelectTrigger
-					className="h-9 w-[11rem] shrink-0"
-					aria-label="Filter conversations"
-				>
-					<SelectValue />
-				</SelectTrigger>
-				<SelectContent>
-					<SelectItem value="all">All conversations</SelectItem>
-					<SelectItem value="archived">Archived</SelectItem>
-				</SelectContent>
-			</Select>
+		<div className="flex flex-wrap items-center gap-2 border-b border-ck-border px-4 py-2.5">
+			<Segmented
+				options={STATUS_FILTERS}
+				value={status}
+				onChange={onStatusChange}
+				aria-label="Filter conversations by status"
+			/>
 
 			<div className="relative min-w-0 flex-1">
-				<Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
-				<Input
+				<Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-ck-faint" />
+				<input
 					value={search}
 					onChange={(e) => onSearch(e.target.value)}
 					placeholder="Search conversations…"
 					aria-label="Search conversations"
-					className="h-9 pl-9"
+					className="h-9 w-full rounded-[10px] border border-ck-border bg-ck-card pl-9 pr-3 text-sm text-ck-text outline-none placeholder:text-ck-faint focus-visible:border-ck-accent"
 				/>
 			</div>
 
@@ -80,9 +64,6 @@ export function InboxToolbar({
 				onChange={onTagIdsChange}
 				onManage={onManageTags}
 			/>
-			<span className="hidden shrink-0 px-1 text-sm text-muted-foreground sm:inline">
-				Sort: <span className="font-medium text-foreground">Latest</span>
-			</span>
 		</div>
 	);
 }

--- a/apps/dashboard/src/app/inbox/_components/MessageThread.test.tsx
+++ b/apps/dashboard/src/app/inbox/_components/MessageThread.test.tsx
@@ -59,8 +59,8 @@ describe("MessageThread", () => {
 		expect(sideOf("On it!")).toBe("right");
 		// Role labels are shown for bubbles.
 		expect(screen.getByText("Visitor")).toBeInTheDocument();
-		expect(screen.getByText("Bot")).toBeInTheDocument();
-		expect(screen.getByText("Admin")).toBeInTheDocument();
+		expect(screen.getByText("Agent")).toBeInTheDocument();
+		expect(screen.getByText("You")).toBeInTheDocument();
 	});
 
 	it("shows an empty state when there are no messages", () => {

--- a/apps/dashboard/src/app/inbox/_components/MessageThread.tsx
+++ b/apps/dashboard/src/app/inbox/_components/MessageThread.tsx
@@ -4,7 +4,7 @@ import { useStickToBottom } from "@llmchat/widget/chat";
 import { ArrowDown, Headset, ThumbsDown, ThumbsUp } from "lucide-react";
 import { useEffect, useLayoutEffect, useMemo, useRef } from "react";
 
-import { Button } from "@/components/ui/button";
+import { Bubble, Button } from "@/components/ds";
 import { cn } from "@/lib/utils";
 
 import { formatMessageTime } from "./format";
@@ -54,14 +54,27 @@ function RatingIndicator({ rating }: { rating: Message["rating"] }) {
 	);
 }
 
+// "Agent" (the AI support agent), never "Bot"; "You" for the human teammate's
+// own reply. `tone` maps to the ds Bubble variants.
 const ROLE = {
-	user: { side: "left", label: "Visitor", labelClass: "text-muted-foreground" },
+	user: {
+		side: "left",
+		tone: "visitor",
+		label: "Visitor",
+		labelClass: "text-ck-faint",
+	},
 	assistant: {
 		side: "right",
-		label: "Bot",
-		labelClass: "text-emerald-600 dark:text-emerald-400",
+		tone: "agent",
+		label: "Agent",
+		labelClass: "text-ck-muted",
 	},
-	admin: { side: "right", label: "Admin", labelClass: "text-primary" },
+	admin: {
+		side: "right",
+		tone: "admin",
+		label: "You",
+		labelClass: "text-ck-accent",
+	},
 } as const;
 
 function MessageBubble({
@@ -81,7 +94,7 @@ function MessageBubble({
 	/** Nearest preceding visitor message — the default question for this reply. */
 	knowledgeQuestion: string;
 }) {
-	const { side, label, labelClass } =
+	const { side, tone, label, labelClass } =
 		ROLE[message.role as keyof typeof ROLE] ?? ROLE.user;
 	const right = side === "right";
 	return (
@@ -90,24 +103,13 @@ function MessageBubble({
 			data-search-hit={firstHit ? "true" : undefined}
 			className={cn("flex flex-col gap-1", right ? "items-end" : "items-start")}
 		>
-			<span className={cn("px-1 text-[11px] font-medium", labelClass)}>
+			<span className={cn("px-1 text-[11px] font-semibold", labelClass)}>
 				{label}
 			</span>
-			<div
-				className={cn(
-					"max-w-[75%] rounded-2xl px-3.5 py-2 text-sm leading-relaxed",
-					message.role === "user" && "rounded-bl-sm bg-muted text-foreground",
-					message.role === "assistant" &&
-						"rounded-br-sm bg-secondary text-secondary-foreground",
-					message.role === "admin" &&
-						"rounded-br-sm bg-primary text-primary-foreground",
-				)}
-			>
-				<p className="whitespace-pre-wrap break-words">
-					<Highlighted text={message.content} query={search} />
-				</p>
-			</div>
-			<span className="px-1 text-[11px] text-muted-foreground">
+			<Bubble side={side} tone={tone}>
+				<Highlighted text={message.content} query={search} />
+			</Bubble>
+			<span className="px-1 text-[11px] text-ck-faint">
 				{formatMessageTime(message.createdAt)}
 			</span>
 			{message.role === "assistant" && (
@@ -269,13 +271,13 @@ export function MessageThread({
 					<div
 						key={m.id}
 						data-search-hit={m.id === firstHitId ? "true" : undefined}
-						className="mx-auto my-1 flex max-w-[80%] items-center gap-2 rounded-lg border bg-muted/40 px-3 py-2 text-xs text-muted-foreground"
+						className="mx-auto my-1 flex max-w-[80%] items-center gap-2 rounded-[10px] border border-ck-border bg-ck-chip px-3 py-2 text-xs text-ck-muted"
 					>
-						<Headset className="size-4 shrink-0 text-amber-500" />
+						<Headset className="size-4 shrink-0 text-ck-warn" />
 						<span className="flex-1">
 							<Highlighted text={m.content} query={search} />
 						</span>
-						<span className="shrink-0 tabular-nums text-muted-foreground/70">
+						<span className="shrink-0 tabular-nums text-ck-faint">
 							{formatMessageTime(m.createdAt)}
 						</span>
 					</div>
@@ -291,7 +293,7 @@ export function MessageThread({
 				),
 			)}
 			{messages.length === 0 && (
-				<div className="flex flex-1 items-center justify-center text-sm text-muted-foreground">
+				<div className="flex flex-1 items-center justify-center text-sm text-ck-faint">
 					No messages in this conversation
 				</div>
 			)}
@@ -300,7 +302,7 @@ export function MessageThread({
 					type="button"
 					onClick={scrollToBottom}
 					aria-label="Scroll to latest message"
-					className="sticky bottom-2 ml-auto flex size-8 items-center justify-center rounded-full bg-primary text-primary-foreground shadow-md transition-transform hover:-translate-y-0.5"
+					className="sticky bottom-2 ml-auto flex size-8 items-center justify-center rounded-full bg-ck-accent text-white shadow-md transition-transform hover:-translate-y-0.5"
 				>
 					<ArrowDown className="size-4" />
 				</button>

--- a/apps/dashboard/src/app/inbox/_components/ProjectSwitcher.tsx
+++ b/apps/dashboard/src/app/inbox/_components/ProjectSwitcher.tsx
@@ -1,18 +1,22 @@
 "use client";
 
-import {
-	Select,
-	SelectContent,
-	SelectItem,
-	SelectTrigger,
-	SelectValue,
-} from "@/components/ui/select";
+import { ChevronDown } from "lucide-react";
+
+import { Menu, MenuContent, MenuItem, MenuTrigger } from "@/components/ds";
 
 export interface ProjectOption {
 	id: string;
 	name: string;
 }
 
+/**
+ * The inbox's OWN project filter — workspace-scoped, independent of the top-bar
+ * project switcher (locked decision: it does not read the shell selection). It's
+ * framed as a "Project:" FILTER (not a context switcher) so the two don't read
+ * as duplicates. Per-project today; a true "All projects" option lands with the
+ * workspace-wide inbox (its own endpoint), so it's deliberately absent here
+ * rather than shipped non-functional.
+ */
 export function ProjectSwitcher({
 	projects,
 	value,
@@ -22,20 +26,39 @@ export function ProjectSwitcher({
 	value: string | null;
 	onChange: (id: string) => void;
 }) {
+	const current = projects.find((p) => p.id === value);
 	return (
-		<div className="border-b p-3">
-			<Select value={value ?? undefined} onValueChange={onChange}>
-				<SelectTrigger className="w-full" aria-label="Project">
-					<SelectValue placeholder="Select a project" />
-				</SelectTrigger>
-				<SelectContent>
+		<div className="border-b border-ck-border p-3">
+			<Menu>
+				<MenuTrigger asChild>
+					<button
+						aria-label="Filter by project"
+						className="flex h-9 w-full items-center gap-2 rounded-[10px] border border-ck-border bg-ck-card px-3 text-sm text-ck-text outline-none hover:border-ck-accent focus-visible:border-ck-accent"
+					>
+						<span className="text-[11px] font-semibold uppercase tracking-wide text-ck-faint">
+							Project
+						</span>
+						<span className="min-w-0 flex-1 truncate text-left font-medium">
+							{current?.name ?? "Select a project"}
+						</span>
+						<ChevronDown className="size-4 shrink-0 text-ck-faint" />
+					</button>
+				</MenuTrigger>
+				<MenuContent
+					align="start"
+					className="min-w-[var(--radix-dropdown-menu-trigger-width)]"
+				>
 					{projects.map((p) => (
-						<SelectItem key={p.id} value={p.id}>
-							{p.name}
-						</SelectItem>
+						<MenuItem
+							key={p.id}
+							selected={p.id === value}
+							onSelect={() => onChange(p.id)}
+						>
+							<span className="truncate">{p.name}</span>
+						</MenuItem>
 					))}
-				</SelectContent>
-			</Select>
+				</MenuContent>
+			</Menu>
 		</div>
 	);
 }

--- a/apps/dashboard/src/app/inbox/_components/ReplyComposer.tsx
+++ b/apps/dashboard/src/app/inbox/_components/ReplyComposer.tsx
@@ -2,8 +2,7 @@
 
 import { Send } from "lucide-react";
 
-import { Button } from "@/components/ui/button";
-import { Textarea } from "@/components/ui/textarea";
+import { Button } from "@/components/ds";
 
 export interface ReplyComposerProps {
 	value: string;
@@ -31,22 +30,22 @@ export function ReplyComposer({
 	}
 
 	return (
-		<div className="border-t p-3">
-			<div className="rounded-lg border bg-card focus-within:ring-1 focus-within:ring-ring">
-				<Textarea
+		<div className="border-t border-ck-border bg-ck-topbar p-3">
+			<div className="rounded-[12px] border border-ck-border bg-ck-card focus-within:border-ck-accent">
+				<textarea
 					rows={2}
 					value={value}
 					onChange={(e) => onChange(e.target.value)}
 					onKeyDown={handleKeyDown}
 					placeholder={placeholder}
-					className="resize-none border-0 bg-transparent focus-visible:ring-0 focus-visible:ring-offset-0"
+					className="w-full resize-none border-0 bg-transparent px-3 py-2.5 text-sm text-ck-text outline-none placeholder:text-ck-faint"
 				/>
 				<div className="flex items-center justify-between gap-2 px-3 pb-2">
-					<span className="text-[11px] text-muted-foreground">
+					<span className="text-[11px] text-ck-faint">
 						Enter to send · Shift+Enter for a new line
 					</span>
-					<Button type="button" size="sm" onClick={onSend} disabled={!canSend}>
-						<Send />
+					<Button size="sm" onClick={onSend} disabled={!canSend}>
+						<Send className="size-4" />
 						{pending ? "Sending…" : "Send"}
 					</Button>
 				</div>

--- a/apps/dashboard/src/app/inbox/_components/TagFilter.tsx
+++ b/apps/dashboard/src/app/inbox/_components/TagFilter.tsx
@@ -61,7 +61,7 @@ export function TagFilter({
 					size="sm"
 					className={cn(
 						"h-9 shrink-0 gap-1.5",
-						count > 0 && "border-primary/40 text-foreground",
+						count > 0 && "border-ck-accent/40 text-ck-text",
 					)}
 					// Disabled only when there are no tags to filter by.
 					disabled={tags.length === 0}
@@ -69,7 +69,7 @@ export function TagFilter({
 					<SlidersHorizontal className="size-4" />
 					Tags
 					{count > 0 && (
-						<span className="ml-0.5 grid min-w-4 place-items-center rounded-full bg-primary px-1 text-[10px] font-semibold text-primary-foreground">
+						<span className="ml-0.5 grid min-w-4 place-items-center rounded-full bg-ck-accent px-1 text-[10px] font-semibold text-white">
 							{count}
 						</span>
 					)}
@@ -94,7 +94,7 @@ export function TagFilter({
 									/>
 									<span className="flex-1 truncate">{tag.name}</span>
 									{typeof tag.count === "number" && (
-										<span className="text-[10px] tabular-nums text-muted-foreground/70">
+										<span className="text-[10px] tabular-nums text-ck-faint">
 											{tag.count}
 										</span>
 									)}
@@ -110,13 +110,13 @@ export function TagFilter({
 					</CommandList>
 				</Command>
 				{(count > 0 || onManage) && (
-					<div className="flex items-center justify-between gap-1 border-t p-1">
+					<div className="flex items-center justify-between gap-1 border-t border-ck-border p-1">
 						{onManage ? (
 							<Button
 								type="button"
 								variant="ghost"
 								size="sm"
-								className="gap-1.5 text-xs text-muted-foreground"
+								className="gap-1.5 text-xs text-ck-faint"
 								onClick={() => {
 									setOpen(false);
 									onManage();
@@ -133,7 +133,7 @@ export function TagFilter({
 								type="button"
 								variant="ghost"
 								size="sm"
-								className="text-xs text-muted-foreground"
+								className="text-xs text-ck-faint"
 								onClick={() => onChange([])}
 							>
 								Clear {count}

--- a/apps/dashboard/src/app/inbox/_components/status.test.ts
+++ b/apps/dashboard/src/app/inbox/_components/status.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import { deriveStatus } from "./status";
+
+describe("deriveStatus", () => {
+	it("is Open when neither archived nor escalated", () => {
+		expect(deriveStatus({ archivedAt: null, escalatedAt: null })).toBe("open");
+	});
+
+	it("is Escalated when escalated but not resolved", () => {
+		expect(deriveStatus({ archivedAt: null, escalatedAt: "t" })).toBe(
+			"escalated",
+		);
+	});
+
+	it("is Resolved when archived", () => {
+		expect(deriveStatus({ archivedAt: "t", escalatedAt: null })).toBe(
+			"resolved",
+		);
+	});
+
+	it("prioritizes Resolved over Escalated (archiving is the terminal state)", () => {
+		// A conversation can be both escalated and later resolved — Resolved wins.
+		expect(deriveStatus({ archivedAt: "t", escalatedAt: "t" })).toBe(
+			"resolved",
+		);
+	});
+});

--- a/apps/dashboard/src/app/inbox/_components/status.ts
+++ b/apps/dashboard/src/app/inbox/_components/status.ts
@@ -1,0 +1,52 @@
+import type { Conversation } from "./types";
+
+/** The inbox status filter — a query VIEW, not an exclusive state. Maps 1:1 to
+ * the list endpoint's `status` param (open|resolved|escalated|all). */
+export type StatusFilter = "open" | "resolved" | "escalated" | "all";
+
+export const STATUS_FILTERS: ReadonlyArray<{
+	value: StatusFilter;
+	label: string;
+}> = [
+	{ value: "open", label: "Open" },
+	{ value: "resolved", label: "Resolved" },
+	{ value: "escalated", label: "Escalated" },
+	{ value: "all", label: "All" },
+];
+
+/** The single status shown on a conversation's header pill. */
+export type DerivedStatus = "open" | "resolved" | "escalated";
+
+/**
+ * Derive a conversation's display status from the only two real signals on the
+ * row. Priority: **Resolved (archivedAt) > Escalated (escalatedAt) > Open** —
+ * resolving (archiving) is the terminal/closed state, so it wins even if the
+ * conversation was also escalated along the way. No status enum is invented;
+ * these are derived, query-only views.
+ */
+export function deriveStatus(
+	c: Pick<Conversation, "archivedAt" | "escalatedAt">,
+): DerivedStatus {
+	if (c.archivedAt) return "resolved";
+	if (c.escalatedAt) return "escalated";
+	return "open";
+}
+
+/** ck-token pill styling per derived status (label + classes). */
+export const STATUS_PILL: Record<
+	DerivedStatus,
+	{ label: string; className: string }
+> = {
+	open: {
+		label: "Open",
+		className: "bg-ck-chip text-ck-muted",
+	},
+	escalated: {
+		label: "Escalated",
+		className: "bg-ck-warn/15 text-ck-warn",
+	},
+	resolved: {
+		label: "Resolved",
+		className: "bg-ck-accent/12 text-ck-accent",
+	},
+};

--- a/apps/dashboard/src/app/inbox/page.tsx
+++ b/apps/dashboard/src/app/inbox/page.tsx
@@ -10,7 +10,6 @@ import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 
-import { Badge } from "@/components/ui/badge";
 import { ApiError, api, describeApiError } from "@/lib/api";
 import { resolveOnboardingState } from "@/lib/onboarding";
 import { useOptimisticMutation } from "@/lib/optimistic";
@@ -44,6 +43,11 @@ import { MessageThread } from "./_components/MessageThread";
 import { appendOptimisticReply } from "./_components/optimistic-updaters";
 import { ProjectSwitcher } from "./_components/ProjectSwitcher";
 import { ReplyComposer } from "./_components/ReplyComposer";
+import {
+	deriveStatus,
+	STATUS_PILL,
+	type StatusFilter,
+} from "./_components/status";
 import { TagChip } from "./_components/TagChip";
 import { TagPicker } from "./_components/TagPicker";
 import { useThreadMessages } from "./_components/useThreadMessages";
@@ -65,7 +69,7 @@ export default function InboxPage() {
 	const [selectedId, setSelectedId] = useState<string | null>(null);
 	const [reply, setReply] = useState("");
 	const [search, setSearch] = useState("");
-	const [showArchived, setShowArchived] = useState(false);
+	const [status, setStatus] = useState<StatusFilter>("open");
 	const [tagIds, setTagIds] = useState<string[]>([]);
 	const [manageTagsOpen, setManageTagsOpen] = useState(false);
 	// Contact-details sheet (mobile/tablet); on desktop details are a permanent aside.
@@ -117,12 +121,12 @@ export default function InboxPage() {
 		(cursor?: string) => {
 			const params = new URLSearchParams({ limit: String(PAGE_SIZE) });
 			if (debouncedSearch) params.set("search", debouncedSearch);
-			if (showArchived) params.set("archived", "true");
+			params.set("status", status);
 			if (tagFilterKey) params.set("tagIds", tagFilterKey);
 			if (cursor) params.set("cursor", cursor);
 			return params.toString();
 		},
-		[debouncedSearch, showArchived, tagFilterKey],
+		[debouncedSearch, status, tagFilterKey],
 	);
 
 	// The paginated list: keyset cursor, NO polling (a background refetch of an
@@ -134,7 +138,7 @@ export default function InboxPage() {
 			projectId,
 			"list",
 			debouncedSearch,
-			showArchived,
+			status,
 			tagFilterKey,
 		],
 		enabled: !!projectId && !!workspaceId,
@@ -156,7 +160,7 @@ export default function InboxPage() {
 			projectId,
 			"head",
 			debouncedSearch,
-			showArchived,
+			status,
 			tagFilterKey,
 		],
 		enabled: !!projectId && !!workspaceId,
@@ -448,22 +452,30 @@ export default function InboxPage() {
 			}),
 		onSuccess: (_data, vars) =>
 			toast.success(
-				vars.nextArchived ? "Conversation archived" : "Conversation restored",
+				vars.nextArchived ? "Conversation resolved" : "Conversation reopened",
 			),
 		onError: (e) =>
 			toast.error(describeApiError(e, "Failed to update conversation")),
 	});
 
-	const deleteMut = useOptimisticMutation<string>({
-		queryKey: ["conversations", projectId],
-		invalidateKey: ["conversations", projectId, "head"],
-		apply: (prev, id) => dropConversationFromCache(prev, id),
-		mutationFn: (id) =>
+	// Delete is NON-optimistic + confirm: the conversation row must not vanish
+	// before the server acknowledges a permanent, irreversible delete (unlike
+	// Resolve above, which is reversible so optimism is correct). The confirm
+	// dialog stays open showing "Deleting…" until onSuccess, which then closes the
+	// pane and reconciles the list — so a failed delete surfaces, never reads as
+	// success.
+	const deleteMut = useMutation({
+		mutationFn: (id: string) =>
 			api(`/api/projects/${projectId}/conversations/${id}`, {
 				method: "DELETE",
 				workspaceId: workspaceId!,
 			}),
-		onSuccess: () => toast.success("Conversation deleted"),
+		onSuccess: () => {
+			toast.success("Conversation deleted");
+			setSelectedId(null);
+			setDetailsOpen(false);
+			void qc.invalidateQueries({ queryKey: ["conversations", projectId] });
+		},
 		onError: (e) =>
 			toast.error(describeApiError(e, "Failed to delete conversation")),
 	});
@@ -478,11 +490,12 @@ export default function InboxPage() {
 		});
 	}
 
-	function handleArchive() {
+	function handleResolve() {
 		if (!projectId || !detailConv || !workspaceId) return;
 		const { id } = detailConv;
 		const nextArchived = !detailConv.archivedAt;
-		// Close the pane optimistically alongside the row removal.
+		// Resolve is optimistic + reversible: close the pane alongside the row
+		// removal (Reopen restores it).
 		setSelectedId(null);
 		setDetailsOpen(false);
 		archiveMut.mutate({ id, nextArchived });
@@ -490,10 +503,9 @@ export default function InboxPage() {
 
 	function handleDelete() {
 		if (!projectId || !detailConv || !workspaceId) return;
-		const { id } = detailConv;
-		setSelectedId(null);
-		setDetailsOpen(false);
-		deleteMut.mutate(id);
+		// Non-optimistic: fire and let the confirm dialog show pending; the pane
+		// closes on success (see deleteMut), never before the server confirms.
+		deleteMut.mutate(detailConv.id);
 	}
 
 	// Loading, or redirecting a brand-new account to onboarding.
@@ -519,13 +531,13 @@ export default function InboxPage() {
 			{/* Header band + toolbar are list-scoped: hidden on mobile while a thread
 			    is open (the thread takes the full screen), always shown from md. */}
 			<div className={cn(threadOpen && "hidden md:block")}>
-				<header className="flex flex-wrap items-start justify-between gap-4 border-b px-6 py-4">
+				<header className="flex flex-wrap items-start justify-between gap-4 border-b border-ck-border px-6 py-4">
 					<div>
-						<h1 className="font-display text-2xl font-semibold tracking-tight-display">
+						<h1 className="text-2xl font-extrabold tracking-[-0.02em] text-ck-text">
 							Conversations
 						</h1>
-						<p className="mt-0.5 text-sm text-muted-foreground">
-							All visitor conversations in one inbox.
+						<p className="mt-0.5 text-sm text-ck-muted">
+							Visitor conversations for this project.
 						</p>
 					</div>
 					<InboxStats stats={statsQuery.data} />
@@ -534,9 +546,9 @@ export default function InboxPage() {
 				<InboxToolbar
 					search={search}
 					onSearch={setSearch}
-					showArchived={showArchived}
-					onShowArchivedChange={(archived) => {
-						setShowArchived(archived);
+					status={status}
+					onStatusChange={(next) => {
+						setStatus(next);
 						setSelectedId(null);
 					}}
 					tags={allTags}
@@ -567,7 +579,7 @@ export default function InboxPage() {
 									selectedId={selectedId}
 									onSelect={handleSelect}
 									search={debouncedSearch}
-									showArchived={showArchived}
+									status={status}
 								/>
 								{listQuery.hasNextPage && (
 									<LoadMore
@@ -582,22 +594,25 @@ export default function InboxPage() {
 				threadHeader={
 					detailConv && (
 						<>
-							<span className="flex size-9 shrink-0 items-center justify-center rounded-full bg-muted text-xs font-semibold text-muted-foreground">
+							<span className="flex size-9 shrink-0 items-center justify-center rounded-full bg-ck-accent text-xs font-bold text-white">
 								{initials(detailConv.name)}
 							</span>
 							<div className="min-w-0 flex-1">
-								<p className="truncate text-sm font-semibold">
+								<p className="truncate text-sm font-bold text-ck-text">
 									{detailConv.name ?? "Anonymous"}
 								</p>
-								<p className="truncate text-xs text-muted-foreground">
+								<p className="truncate text-xs text-ck-faint">
 									{threadSubtitle}
 								</p>
 							</div>
-							{detailConv.escalatedAt && (
-								<Badge variant="warning" className="shrink-0">
-									Escalated
-								</Badge>
-							)}
+							<span
+								className={cn(
+									"inline-flex shrink-0 items-center rounded-full px-2 py-0.5 text-[11px] font-semibold",
+									STATUS_PILL[deriveStatus(detailConv)].className,
+								)}
+							>
+								{STATUS_PILL[deriveStatus(detailConv)].label}
+							</span>
 							{selectedId && (
 								<div className="flex flex-wrap items-center justify-end gap-1">
 									{selectedTags.map((t) => (
@@ -624,7 +639,7 @@ export default function InboxPage() {
 				threadBody={
 					detailConv &&
 					(thread.isLoading && thread.messages.length === 0 ? (
-						<div className="flex flex-1 items-center justify-center text-sm text-muted-foreground">
+						<div className="flex flex-1 items-center justify-center text-sm text-ck-faint">
 							Loading…
 						</div>
 					) : (
@@ -657,20 +672,20 @@ export default function InboxPage() {
 					detailConv ? (
 						<DetailPanel
 							conversation={detailConv}
-							onArchive={handleArchive}
+							onResolve={handleResolve}
 							onDelete={handleDelete}
-							archiving={archiveMut.isPending}
+							resolving={archiveMut.isPending}
 							deleting={deleteMut.isPending}
 						/>
 					) : null
 				}
 				emptyState={
-					<div className="flex flex-1 items-center justify-center text-sm text-muted-foreground">
+					<div className="flex flex-1 items-center justify-center text-sm text-ck-faint">
 						Select a conversation
 					</div>
 				}
 				detailsEmptyState={
-					<div className="flex flex-1 flex-col items-center justify-center gap-2 px-6 text-center text-muted-foreground">
+					<div className="flex flex-1 flex-col items-center justify-center gap-2 px-6 text-center text-ck-faint">
 						<p className="text-xs">
 							Select a conversation to see visitor details
 						</p>

--- a/apps/dashboard/src/components/ds/bubble.tsx
+++ b/apps/dashboard/src/components/ds/bubble.tsx
@@ -1,0 +1,39 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+/**
+ * Design-system chat bubble for the Clanker restyle. Generic + token-driven:
+ * a `side` (left/right) and a `tone` for who's speaking. Visitor messages read
+ * as a neutral surface; the support agent + human teammate replies read as
+ * accent/raised. The inbox composes per-message actions (Add-to-knowledge,
+ * thumbs) around it; the bubble is just the speech container.
+ */
+const bubbleVariants = cva(
+	"max-w-[75%] rounded-2xl px-3.5 py-2 text-sm leading-relaxed whitespace-pre-wrap break-words",
+	{
+		variants: {
+			side: { left: "rounded-bl-sm", right: "rounded-br-sm" },
+			tone: {
+				visitor: "bg-ck-chip text-ck-text",
+				agent: "border border-ck-border bg-ck-card text-ck-text",
+				admin: "bg-ck-accent text-white",
+			},
+		},
+		defaultVariants: { side: "left", tone: "visitor" },
+	},
+);
+
+export interface BubbleProps
+	extends
+		React.HTMLAttributes<HTMLDivElement>,
+		VariantProps<typeof bubbleVariants> {}
+
+export function Bubble({ className, side, tone, ...props }: BubbleProps) {
+	return (
+		<div className={cn(bubbleVariants({ side, tone }), className)} {...props} />
+	);
+}
+
+export { bubbleVariants };

--- a/apps/dashboard/src/components/ds/index.ts
+++ b/apps/dashboard/src/components/ds/index.ts
@@ -16,3 +16,9 @@ export {
 	MenuSeparator,
 } from "./menu";
 export { NavItem, type NavItemProps } from "./nav-item";
+export {
+	Segmented,
+	type SegmentedProps,
+	type SegmentedOption,
+} from "./segmented";
+export { Bubble, bubbleVariants, type BubbleProps } from "./bubble";

--- a/apps/dashboard/src/components/ds/segmented.tsx
+++ b/apps/dashboard/src/components/ds/segmented.tsx
@@ -1,0 +1,62 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+export interface SegmentedOption<T extends string> {
+	value: T;
+	label: string;
+}
+
+export interface SegmentedProps<T extends string> {
+	options: ReadonlyArray<SegmentedOption<T>>;
+	value: T;
+	onChange: (value: T) => void;
+	"aria-label"?: string;
+	className?: string;
+}
+
+/**
+ * Design-system segmented control for the Clanker restyle. Generic + token-
+ * driven: a bordered track with the active segment filled in accent. Used for
+ * the inbox status filter (Open / Resolved / Escalated / All); reusable for any
+ * small mutually-exclusive choice. Real `radiogroup` semantics for a11y.
+ */
+export function Segmented<T extends string>({
+	options,
+	value,
+	onChange,
+	className,
+	...props
+}: SegmentedProps<T>) {
+	return (
+		<div
+			role="radiogroup"
+			aria-label={props["aria-label"]}
+			className={cn(
+				"inline-flex items-center gap-0.5 rounded-[10px] border border-ck-border bg-ck-card p-0.5",
+				className,
+			)}
+		>
+			{options.map((opt) => {
+				const active = opt.value === value;
+				return (
+					<button
+						key={opt.value}
+						type="button"
+						role="radio"
+						aria-checked={active}
+						onClick={() => onChange(opt.value)}
+						className={cn(
+							"h-7 rounded-[7px] px-3 text-[12.5px] font-semibold transition-colors",
+							active
+								? "bg-ck-accent text-white"
+								: "text-ck-muted hover:bg-ck-navhover hover:text-ck-text",
+						)}
+					>
+						{opt.label}
+					</button>
+				);
+			})}
+		</div>
+	);
+}


### PR DESCRIPTION
## What & why

Restyle the three-pane inbox onto **ck/ds** with the LIVE promotions + honest roadmap states. Renders inside the shell (#69) — **page content only**, plus **one query-only API filter**. No schema/migration.

## LIVE — restyled + wired to real data

- **Three-pane** (list · thread · details) in ck/ds; full-height preserved.
- **Status filter promotion** (the headline): list endpoint's `archived` param → a **`status` enum** (`open|resolved|escalated|all`) — `open=archivedAt null`, `resolved=archivedAt not null`, `escalated=escalatedAt not null`, `all=no predicate`. These are **filter views, not exclusive states** (an escalated convo can also be resolved) — no status column invented, documented so nobody "fixes" the overlap. Only the inbox calls this endpoint. Driven by a new **ds `Segmented`** control + a **derived thread-header status pill** (priority Resolved > Escalated > Open).
- **Archive → Resolve / Unarchive → Reopen** over the same `PATCH {archived}` — kept **optimistic + reversible** (correct, unlike workspace delete).
- Thread **ds `Bubble`** bubbles (Visitor / **Agent** / **You** — never "Bot"), system escalation marker, Add-to-knowledge, thumbs, CSAT.
- **Contact panel** — **real captured fields only**: Name, Email (or "Not provided"), IP, parsed Device, Started, Messages, CSAT.
- Tags (chips/filter/picker), Reply + Send composer.

## Delete — dead-button + optimism both fixed
The DetailPanel delete was an `AlertDialogAction` (auto-closes → unmounts before the handler under React 18 — the banked bug) **and** optimistic. Now a **plain Button + controlled dialog**, and the mutation is **non-optimistic** — the row stays until the server confirms (dialog shows "Deleting…"), so a failed delete can't read as success. Delete stays distinct from Resolve.

## ROADMAP — omitted, not stubbed
**Assign, Internal-note, Suggest-with-AI, Attach** are **omitted** (actions that don't work get omitted — same principle as ⌘K/notifications/Analytics). Status states **Unassigned / AI-handled** omitted. The only honest-empty is the informational **"Visitor context"** card — verbatim *"Not captured yet — never show a guessed value"* with em-dash rows (Location, Local time, First seen, Current page, Referrer, Pages viewed, Channel) — never a fabricated value.

## Locked decisions honored
- **Archive ≡ Resolve** — single control over `archivedAt`, no enum invented; Delete separate.
- **Dual project control** — the inbox keeps its **own** project filter (workspace-scoped, does **not** read the top-bar switcher), restyled as a distinct **"Project:" filter**. "All projects" is **deferred** to the workspace-wide unified inbox (**#105**, tracked — it needs a real cross-project endpoint, out of a restyle's scope). The **subtitle is softened** to *"Visitor conversations for this project."* so it doesn't overpromise; the full "all visitor conversations in one inbox" claim returns with #105.
- LIVE/ROADMAP pills don't ship; "support agent", never "chatbot".

## ds primitives (generic, shared)
New **`Segmented`** + **`Bubble`**.

## Tests
- `deriveStatus` priority mapping; API status filter (`resolved`/`open`/`escalated`/`all` predicates, escalated over `escalatedAt`, composes with search); **Resolve fires `PATCH {archived}`**; **Delete via a plain Button** request-fires + "Deleting…" while pending (never AlertDialogAction); contact panel **real fields only**, roadmap fields show "Not captured yet" / em-dash, **never a value**; status Segmented changes; "Agent"/"You" labels not "Bot".
- Full suites green: **dashboard 358, api 292**. lint/format/typecheck clean.

## Height-chain re-verified on the running app (your gate)
Headless chromium, real session + a seeded conversation: the 3-pane renders **full-height with no double scrollbar** (`docOverflow: 0`, the details panel scrolls internally), in **Light and Dark**. The restyle only swapped tokens/content — the height structure (h-full root from #69, InboxPanes) is unchanged, and the metrics confirm no regression.

## Out of scope
The remaining surfaces (projects/sources/settings) are #91–#93; the workspace-wide inbox is #105.

🤖 Generated with [Claude Code](https://claude.com/claude-code)