### PR TITLE
feat(dashboard): projects grid restyle (restyle PR3)

### DIFF
--- a/apps/api/src/routes/projects.test.ts
+++ b/apps/api/src/routes/projects.test.ts
@@ -32,6 +32,8 @@ interface State {
 	plan?: string;
 	/** Existing project count for the project-cap check. Defaults to 0. */
 	projectCount?: number;
+	/** Rows the /projects/usage aggregate (select→from→where→groupBy) returns. */
+	usageRows?: { projectId: string; n: number }[];
 }
 
 let insertSpy: ReturnType<typeof vi.fn>;
@@ -68,9 +70,17 @@ function mockDb(state: State) {
 				findFirst: async () => ({ plan: state.plan ?? "scale" }),
 			},
 		},
-		// Count queries (projectCount): db.select({n}).from(...).where(...) → [{n}]
+		// Two select shapes:
+		//  - projectCount: db.select({n}).from(...).where(...) — awaited directly.
+		//  - usage:        db.select(...).from(...).where(...).groupBy(...).
+		// So where() is both a thenable (count) and exposes groupBy (usage).
 		select: () => ({
-			from: () => ({ where: async () => [{ n: state.projectCount ?? 0 }] }),
+			from: () => ({
+				where: () =>
+					Object.assign(Promise.resolve([{ n: state.projectCount ?? 0 }]), {
+						groupBy: async () => state.usageRows ?? [],
+					}),
+			}),
 		}),
 		insert: insertSpy,
 		delete: deleteSpy,
@@ -87,6 +97,31 @@ function req(path: string, init: RequestInit = {}) {
 const json = { "content-type": "application/json" };
 
 beforeEach(() => vi.clearAllMocks());
+
+describe("GET /projects/usage — 30-day per-project counts", () => {
+	it("returns a { projectId: count } map for the workspace", async () => {
+		mockDb({
+			role: "agent",
+			usageRows: [
+				{ projectId: "p1", n: 12 },
+				{ projectId: "p2", n: 3 },
+			],
+		});
+		const res = await req("/projects/usage", {
+			headers: { "x-test-user": "u1", "x-workspace-id": "ws_1" },
+		});
+		expect(res.status).toBe(200);
+		expect(await res.json()).toEqual({ usage: { p1: 12, p2: 3 } });
+	});
+
+	it("is role-gated — a non-member gets 403, no aggregate", async () => {
+		mockDb({}); // not a member
+		const res = await req("/projects/usage", {
+			headers: { "x-test-user": "u1", "x-workspace-id": "ws_1" },
+		});
+		expect(res.status).toBe(403);
+	});
+});
 
 describe("RBAC — POST /projects (create)", () => {
 	it("403s an agent (insufficient_role) and never inserts", async () => {

--- a/apps/api/src/routes/projects.ts
+++ b/apps/api/src/routes/projects.ts
@@ -14,7 +14,7 @@ import {
 	requireWorkspace,
 } from "@/middleware/session";
 
-import { eq, project } from "@llmchat/db";
+import { and, count, eq, gte, project, usageEvent } from "@llmchat/db";
 import {
 	DEFAULT_MODEL,
 	isModelAllowed,
@@ -83,6 +83,29 @@ export const projects = new Hono<AppContext>()
 			where: (pt, { eq: e }) => e(pt.workspaceId, workspaceId),
 		});
 		return c.json({ projects: rows });
+	})
+	// Per-project response counts for the last 30 days — the projects grid's
+	// "responses · 30d" badge. DELIBERATELY a separate endpoint, not folded into
+	// GET /projects: that list is on the hot path (inbox, shell switcher,
+	// onboarding, workspaces), so it stays lean while the grid lazy-loads these
+	// counts. One bounded, indexed (workspace_id, created_at) aggregate grouped by
+	// project — no pagination, output is at most the project cap.
+	.get("/projects/usage", async (c) => {
+		const workspaceId = c.get("workspaceId");
+		const since = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+		const rows = await db(c.env)
+			.select({ projectId: usageEvent.projectId, n: count() })
+			.from(usageEvent)
+			.where(
+				and(
+					eq(usageEvent.workspaceId, workspaceId),
+					gte(usageEvent.createdAt, since),
+				),
+			)
+			.groupBy(usageEvent.projectId);
+		const usage: Record<string, number> = {};
+		for (const r of rows) usage[r.projectId] = Number(r.n);
+		return c.json({ usage });
 	})
 	.post(
 		"/projects",

--- a/apps/dashboard/src/app/settings/projects/_components/DeleteProjectDialog.test.tsx
+++ b/apps/dashboard/src/app/settings/projects/_components/DeleteProjectDialog.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { DeleteProjectDialog } from "./DeleteProjectDialog";
+
+describe("DeleteProjectDialog", () => {
+	// Plain Button (not AlertDialogAction): the confirm fires the handler, and the
+	// parent's mutation is non-optimistic so the dialog stays open until success.
+	it("fires onConfirm from the plain Delete button", async () => {
+		const onConfirm = vi.fn();
+		render(
+			<DeleteProjectDialog
+				open
+				onOpenChange={vi.fn()}
+				onConfirm={onConfirm}
+				pending={false}
+			/>,
+		);
+		await userEvent
+			.setup()
+			.click(screen.getByRole("button", { name: /^delete$/i }));
+		expect(onConfirm).toHaveBeenCalledTimes(1);
+	});
+
+	it("shows 'Deleting…' and disables confirm while pending (dialog stays open)", () => {
+		render(
+			<DeleteProjectDialog
+				open
+				onOpenChange={vi.fn()}
+				onConfirm={vi.fn()}
+				pending
+			/>,
+		);
+		const btn = screen.getByRole("button", { name: /deleting/i });
+		expect(btn).toBeInTheDocument();
+		expect(btn).toBeDisabled();
+	});
+});

--- a/apps/dashboard/src/app/settings/projects/_components/DeleteProjectDialog.tsx
+++ b/apps/dashboard/src/app/settings/projects/_components/DeleteProjectDialog.tsx
@@ -2,7 +2,6 @@
 
 import {
 	AlertDialog,
-	AlertDialogAction,
 	AlertDialogCancel,
 	AlertDialogContent,
 	AlertDialogDescription,
@@ -10,6 +9,7 @@ import {
 	AlertDialogHeader,
 	AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ds";
 
 export interface DeleteProjectDialogProps {
 	open: boolean;
@@ -18,6 +18,13 @@ export interface DeleteProjectDialogProps {
 	pending: boolean;
 }
 
+/**
+ * Project-delete confirm. A plain submit Button — NOT AlertDialogAction (which
+ * auto-closes on click and, under React 18, can fire before the handler) — and
+ * the parent's mutation is non-optimistic: the dialog stays open showing
+ * "Deleting…" until the server confirms, so a failed delete surfaces instead of
+ * reading as success. Consistent with the workspace + conversation deletes.
+ */
 export function DeleteProjectDialog({
 	open,
 	onOpenChange,
@@ -35,17 +42,15 @@ export function DeleteProjectDialog({
 					</AlertDialogDescription>
 				</AlertDialogHeader>
 				<AlertDialogFooter>
-					<AlertDialogCancel>Cancel</AlertDialogCancel>
-					<AlertDialogAction
-						className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-						onClick={(e) => {
-							e.preventDefault();
-							onConfirm();
-						}}
+					<AlertDialogCancel type="button">Cancel</AlertDialogCancel>
+					<Button
+						variant="primary"
+						className="bg-ck-warn hover:bg-ck-warn/90"
 						disabled={pending}
+						onClick={onConfirm}
 					>
 						{pending ? "Deleting…" : "Delete"}
-					</AlertDialogAction>
+					</Button>
 				</AlertDialogFooter>
 			</AlertDialogContent>
 		</AlertDialog>

--- a/apps/dashboard/src/app/settings/projects/_components/ProjectCard.test.tsx
+++ b/apps/dashboard/src/app/settings/projects/_components/ProjectCard.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ProjectCard } from "./ProjectCard";
+
+import type { ProjectListItem } from "./types";
+
+function project(overrides: Partial<ProjectListItem> = {}): ProjectListItem {
+	return {
+		id: "p1",
+		name: "Acme Tools",
+		publicKey: "pk_local-dev-key",
+		model: "gpt-5.4-mini",
+		brandColor: "#4f46e5",
+		favorite: false,
+		pinned: false,
+		createdAt: "2026-06-16T05:00:00.000Z",
+		...overrides,
+	};
+}
+
+function setup(props: Partial<React.ComponentProps<typeof ProjectCard>> = {}) {
+	Object.defineProperty(navigator, "clipboard", {
+		configurable: true,
+		value: { writeText: vi.fn().mockResolvedValue(undefined) },
+	});
+	render(
+		<ProjectCard
+			project={project()}
+			onToggleFavorite={vi.fn()}
+			onTogglePin={vi.fn()}
+			onDelete={vi.fn()}
+			{...props}
+		/>,
+	);
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("ProjectCard", () => {
+	it("shows an honest '—' for the 30d count until it loads (never a fabricated 0)", () => {
+		setup({ responses30d: undefined });
+		expect(screen.getByText("—")).toBeInTheDocument();
+		expect(screen.getByText(/responses · 30d/i)).toBeInTheDocument();
+	});
+
+	it("shows the real 30d count once loaded", () => {
+		setup({ responses30d: 1234 });
+		expect(screen.getByText("1,234")).toBeInTheDocument();
+		expect(screen.queryByText("—")).not.toBeInTheDocument();
+	});
+
+	it("renders the real model badge + the public key with a copy affordance", () => {
+		setup();
+		expect(screen.getByText("gpt-5.4-mini")).toBeInTheDocument();
+		expect(screen.getByText("pk_local-dev-key")).toBeInTheDocument();
+		expect(
+			screen.getByRole("button", { name: /copy public key/i }),
+		).toBeInTheDocument();
+	});
+
+	it("never fabricates a domain (no domain row exists)", () => {
+		setup();
+		expect(screen.queryByText(/\.com|\.io|lordapparel/i)).toBeNull();
+	});
+});

--- a/apps/dashboard/src/app/settings/projects/_components/ProjectCard.tsx
+++ b/apps/dashboard/src/app/settings/projects/_components/ProjectCard.tsx
@@ -3,87 +3,112 @@
 import { Pin, Settings, Star, Trash2 } from "lucide-react";
 import Link from "next/link";
 
-import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
-import { Card } from "@/components/ui/card";
+import { Badge, Button, Card, CopyButton } from "@/components/ds";
 import { cn } from "@/lib/utils";
+
 import type { ProjectListItem } from "./types";
 
 export interface ProjectCardProps {
 	project: ProjectListItem;
+	/** Responses in the last 30 days (lazy-loaded). `undefined` → still loading,
+	 * render an honest "—", never a fabricated 0. */
+	responses30d?: number;
 	onToggleFavorite: (id: string, next: boolean) => void;
 	onTogglePin: (id: string, next: boolean) => void;
 	onDelete: (id: string) => void;
 }
 
+const initial = (name: string) => name.trim().charAt(0).toUpperCase() || "?";
+
 export function ProjectCard({
 	project,
+	responses30d,
 	onToggleFavorite,
 	onTogglePin,
 	onDelete,
 }: ProjectCardProps) {
+	const brand = project.brandColor || "#6366f1";
 	return (
-		<Card className="group relative flex flex-col p-5 transition-all hover:border-foreground/15 hover:shadow-md">
-			<div className="mb-4 flex items-start justify-between">
-				<div
-					className="h-2 w-10 rounded-full"
-					style={{ backgroundColor: project.brandColor || "#000" }}
-				/>
-				<div className="flex items-center gap-1">
+		<Card className="flex flex-col p-5 transition-colors hover:border-ck-accent/50">
+			<div className="flex items-start gap-3">
+				<span
+					className="flex size-9 shrink-0 items-center justify-center rounded-[10px] text-sm font-bold text-white"
+					style={{ backgroundColor: brand }}
+				>
+					{initial(project.name)}
+				</span>
+				<h3 className="min-w-0 flex-1 truncate pt-1.5 text-[15px] font-bold text-ck-text">
+					{project.name}
+				</h3>
+				<div className="flex shrink-0 items-center">
 					<Button
-						type="button"
 						variant="ghost"
 						size="icon"
-						className={cn(
-							"size-8",
-							project.favorite
-								? "text-warning hover:text-warning"
-								: "text-muted-foreground/50",
-						)}
+						className={cn(project.favorite ? "text-ck-warn" : "text-ck-faint")}
 						onClick={() => onToggleFavorite(project.id, !project.favorite)}
-						title={project.favorite ? "Unfavorite" : "Favorite"}
+						aria-label={project.favorite ? "Unfavorite" : "Favorite"}
 					>
-						<Star className={cn(project.favorite && "fill-warning")} />
+						<Star
+							className={cn("size-4", project.favorite && "fill-current")}
+						/>
 					</Button>
 					<Button
-						type="button"
 						variant="ghost"
 						size="icon"
-						className={cn(
-							"size-8",
-							project.pinned ? "text-foreground" : "text-muted-foreground/50",
-						)}
+						className={cn(project.pinned ? "text-ck-text" : "text-ck-faint")}
 						onClick={() => onTogglePin(project.id, !project.pinned)}
-						title={project.pinned ? "Unpin" : "Pin"}
+						aria-label={project.pinned ? "Unpin" : "Pin"}
 					>
-						<Pin className={cn(project.pinned && "fill-current")} />
+						<Pin className={cn("size-4", project.pinned && "fill-current")} />
 					</Button>
 				</div>
 			</div>
-			<h3 className="text-base font-semibold">{project.name}</h3>
-			<p className="mt-1 font-mono text-xs text-muted-foreground">
-				{project.publicKey.slice(0, 20)}…
-			</p>
-			<div className="mt-3 flex items-center gap-2">
-				<Badge variant="secondary">{project.model}</Badge>
+
+			{/* Public key — public + safe to expose; with a real copy affordance. */}
+			<div className="mt-3 flex items-center gap-2 rounded-[10px] border border-ck-border bg-ck-app px-2.5 py-1.5">
+				<span className="text-[10px] font-bold uppercase tracking-wide text-ck-faint">
+					Key
+				</span>
+				<span className="min-w-0 flex-1 truncate font-mono text-xs text-ck-muted">
+					{project.publicKey}
+				</span>
+				<CopyButton
+					value={project.publicKey}
+					aria-label="Copy public key"
+					className="size-7 shrink-0 text-ck-faint hover:text-ck-text"
+				/>
 			</div>
-			<div className="mt-auto flex items-center gap-2 pt-5">
-				<Button asChild variant="outline" className="flex-1">
-					<Link href={`/settings/projects/${project.id}`}>
-						<Settings />
-						Configure
-					</Link>
-				</Button>
-				<Button
-					type="button"
-					variant="outline"
-					size="icon"
-					onClick={() => onDelete(project.id)}
-					className="border-destructive/20 text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
-					title="Delete project"
-				>
-					<Trash2 />
-				</Button>
+
+			<div className="my-3.5 h-px bg-ck-border" />
+
+			<div className="flex items-center justify-between gap-2">
+				<div>
+					<div className="font-mono text-[15px] font-extrabold text-ck-text tabular-nums">
+						{responses30d === undefined
+							? "—"
+							: responses30d.toLocaleString("en-US")}
+					</div>
+					<div className="text-[10.5px] text-ck-faint">responses · 30d</div>
+				</div>
+				<div className="flex items-center gap-2">
+					<Badge tone="neutral" className="font-mono">
+						{project.model}
+					</Badge>
+					<Button asChild variant="outline" size="icon" aria-label="Configure">
+						<Link href={`/settings/projects/${project.id}`}>
+							<Settings className="size-4" />
+						</Link>
+					</Button>
+					<Button
+						variant="ghost"
+						size="icon"
+						className="text-ck-faint hover:bg-ck-warn/10 hover:text-ck-warn"
+						onClick={() => onDelete(project.id)}
+						aria-label="Delete project"
+					>
+						<Trash2 className="size-4" />
+					</Button>
+				</div>
 			</div>
 		</Card>
 	);

--- a/apps/dashboard/src/app/settings/projects/_components/ProjectFilters.tsx
+++ b/apps/dashboard/src/app/settings/projects/_components/ProjectFilters.tsx
@@ -36,7 +36,7 @@ export function ProjectFilters({
 	return (
 		<div className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-center">
 			<div className="relative flex-1">
-				<Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+				<Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-ck-faint" />
 				<Input
 					value={search}
 					onChange={(e) => onSearchChange(e.target.value)}

--- a/apps/dashboard/src/app/settings/projects/page.tsx
+++ b/apps/dashboard/src/app/settings/projects/page.tsx
@@ -5,7 +5,7 @@ import { FolderOpen, FolderPlus, Pin, Plus } from "lucide-react";
 import { useMemo, useState } from "react";
 import { toast } from "sonner";
 
-import { Button } from "@/components/ui/button";
+import { Button } from "@/components/ds";
 import {
 	Empty,
 	EmptyContent,
@@ -15,7 +15,7 @@ import {
 	EmptyTitle,
 } from "@/components/ui/empty";
 import { api, describeApiError } from "@/lib/api";
-import { dropById, mapById, useOptimisticMutation } from "@/lib/optimistic";
+import { mapById, useOptimisticMutation } from "@/lib/optimistic";
 import { useWorkspace } from "@/lib/workspace";
 import { track, ANALYTICS_EVENTS } from "@/lib/analytics";
 import { RoleGate } from "@/components/role-gate";
@@ -51,6 +51,19 @@ export default function ProjectsPage() {
 			}),
 	});
 
+	// Per-project 30-day response counts — a SEPARATE, lazy query (never folded
+	// into the hot ["projects"] query). The grid renders from `projects` first;
+	// cards show an honest "—" until this resolves, then the real count.
+	const usage = useQuery({
+		queryKey: ["projects-usage", workspaceId],
+		enabled: !!workspaceId,
+		queryFn: () =>
+			api<{ usage: Record<string, number> }>("/api/projects/usage", {
+				workspaceId: workspaceId!,
+			}),
+	});
+	const usageMap = usage.data?.usage;
+
 	const create = useMutation({
 		mutationFn: (input: { name: string }) =>
 			api<{ project: ProjectListItem }>("/api/projects", {
@@ -72,12 +85,14 @@ export default function ProjectsPage() {
 			toast.error(describeApiError(e, "Failed to create project")),
 	});
 
-	// Optimistic delete: the card leaves the grid immediately; a failure rolls it
-	// back and toasts. The confirm dialog closes at the call site (handler below).
-	const remove = useOptimisticMutation<string>({
-		queryKey: ["projects", workspaceId],
-		apply: (prev, id) => dropById(prev, "projects", id),
-		mutationFn: (id) =>
+	// Delete is NON-optimistic + confirm: a permanent, irreversible delete must
+	// not pull the card before the server acknowledges it (the bug fixed in
+	// #68/#70). The confirm dialog stays open showing "Deleting…" until onSuccess,
+	// which then closes it and reconciles the grid — so a failed delete surfaces,
+	// never reads as success. (Favorite/pin toggles below stay optimistic: those
+	// are reversible and non-destructive.)
+	const remove = useMutation({
+		mutationFn: (id: string) =>
 			api(`/api/projects/${id}`, {
 				method: "DELETE",
 				workspaceId: workspaceId!,
@@ -85,6 +100,9 @@ export default function ProjectsPage() {
 		onSuccess: (_res, id) => {
 			track(ANALYTICS_EVENTS.projectDeleted, { project_id: id });
 			toast.success("Project deleted");
+			setDeleteId(null);
+			void qc.invalidateQueries({ queryKey: ["projects", workspaceId] });
+			void qc.invalidateQueries({ queryKey: ["projects-usage", workspaceId] });
 		},
 		onError: (e) =>
 			toast.error(describeApiError(e, "Failed to delete project")),
@@ -124,9 +142,11 @@ export default function ProjectsPage() {
 		<div className="mx-auto max-w-5xl px-6 py-10">
 			<div className="mb-8 flex items-center justify-between">
 				<div>
-					<h1 className="text-2xl font-bold tracking-tight">Projects</h1>
-					<p className="mt-1 text-sm text-muted-foreground">
-						Manage your chat projects and their configurations.
+					<h1 className="text-2xl font-extrabold tracking-[-0.02em] text-ck-text">
+						Projects
+					</h1>
+					<p className="mt-1 text-sm text-ck-muted">
+						Your support agents and their configuration.
 					</p>
 				</div>
 				<RoleGate>
@@ -164,11 +184,9 @@ export default function ProjectsPage() {
 				open={deleteId !== null}
 				onOpenChange={(open) => !open && setDeleteId(null)}
 				onConfirm={() => {
-					if (!deleteId) return;
-					const id = deleteId;
-					// Close the dialog as the card optimistically leaves the grid.
-					setDeleteId(null);
-					remove.mutate(id);
+					// Non-optimistic: fire and let the dialog show pending; it closes on
+					// success (see `remove`), never before the server confirms.
+					if (deleteId) remove.mutate(deleteId);
 				}}
 				pending={remove.isPending}
 			/>
@@ -225,12 +243,13 @@ export default function ProjectsPage() {
 				<div className="flex flex-col gap-8">
 					{pinned.length > 0 && (
 						<section>
-							<div className="mb-3 flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+							<div className="mb-3 flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wide text-ck-faint">
 								<Pin className="size-3" />
 								Pinned
 							</div>
 							<ProjectGrid
 								projects={pinned}
+								usage={usageMap}
 								onToggleFavorite={(id, favorite) =>
 									toggle.mutate({ id, favorite })
 								}
@@ -244,12 +263,13 @@ export default function ProjectsPage() {
 					{rest.length > 0 && (
 						<section>
 							{pinned.length > 0 && (
-								<div className="mb-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+								<div className="mb-3 text-xs font-semibold uppercase tracking-wide text-ck-faint">
 									All projects
 								</div>
 							)}
 							<ProjectGrid
 								projects={rest}
+								usage={usageMap}
 								onToggleFavorite={(id, favorite) =>
 									toggle.mutate({ id, favorite })
 								}
@@ -268,11 +288,14 @@ export default function ProjectsPage() {
 
 function ProjectGrid({
 	projects,
+	usage,
 	onToggleFavorite,
 	onTogglePin,
 	onDelete,
 }: {
 	projects: ProjectListItem[];
+	/** 30-day response counts by project id; undefined entries render "—". */
+	usage?: Record<string, number>;
 	onToggleFavorite: (id: string, next: boolean) => void;
 	onTogglePin: (id: string, next: boolean) => void;
 	onDelete: (id: string) => void;
@@ -283,6 +306,7 @@ function ProjectGrid({
 				<ProjectCard
 					key={project.id}
 					project={project}
+					responses30d={usage?.[project.id]}
 					onToggleFavorite={onToggleFavorite}
 					onTogglePin={onTogglePin}
 					onDelete={onDelete}

--- a/apps/dashboard/src/components/ds/copy-button.test.tsx
+++ b/apps/dashboard/src/components/ds/copy-button.test.tsx
@@ -1,0 +1,38 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { CopyButton } from "./copy-button";
+
+const writeText = vi.fn().mockResolvedValue(undefined);
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	// Set the stub directly (not via userEvent, which installs its own clipboard).
+	Object.defineProperty(navigator, "clipboard", {
+		configurable: true,
+		value: { writeText },
+	});
+});
+
+describe("CopyButton", () => {
+	it("writes the value to the clipboard on click", async () => {
+		render(
+			<CopyButton value="pk_local-dev-key" aria-label="Copy public key" />,
+		);
+		fireEvent.click(screen.getByRole("button", { name: /copy public key/i }));
+		await waitFor(() =>
+			expect(writeText).toHaveBeenCalledWith("pk_local-dev-key"),
+		);
+	});
+
+	it("does not throw when the clipboard API is unavailable", async () => {
+		Object.defineProperty(navigator, "clipboard", {
+			configurable: true,
+			value: undefined,
+		});
+		render(<CopyButton value="x" />);
+		// Clicking must be a no-op, never an unhandled rejection.
+		fireEvent.click(screen.getByRole("button"));
+		await waitFor(() => expect(screen.getByRole("button")).toBeEnabled());
+	});
+});

--- a/apps/dashboard/src/components/ds/copy-button.tsx
+++ b/apps/dashboard/src/components/ds/copy-button.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import * as React from "react";
+import { Check, Copy } from "lucide-react";
+
+import { Button, type ButtonProps } from "./button";
+
+export interface CopyButtonProps extends Omit<
+	ButtonProps,
+	"onClick" | "children"
+> {
+	/** The text written to the clipboard. */
+	value: string;
+	/** Optional visible label; icon-only when omitted. */
+	label?: string;
+	/** Accessible label (defaults to "Copy"). */
+	"aria-label"?: string;
+}
+
+/**
+ * Design-system copy-to-clipboard button. Generic + shared — the projects grid's
+ * public-key copy, the install snippet, and future Settings/Widget copies all use
+ * it. Shows a transient check on success; falls back silently if the clipboard
+ * API is unavailable (never throws at the user).
+ */
+export function CopyButton({
+	value,
+	label,
+	variant = "ghost",
+	size = label ? "sm" : "icon",
+	"aria-label": ariaLabel = "Copy",
+	...props
+}: CopyButtonProps) {
+	const [copied, setCopied] = React.useState(false);
+	const timer = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+
+	React.useEffect(
+		() => () => {
+			if (timer.current) clearTimeout(timer.current);
+		},
+		[],
+	);
+
+	async function copy() {
+		try {
+			await navigator.clipboard.writeText(value);
+			setCopied(true);
+			if (timer.current) clearTimeout(timer.current);
+			timer.current = setTimeout(() => setCopied(false), 1500);
+		} catch {
+			// Clipboard blocked (insecure context / denied) — no-op, no error UI.
+		}
+	}
+
+	return (
+		<Button
+			variant={variant}
+			size={size}
+			aria-label={ariaLabel}
+			onClick={copy}
+			{...props}
+		>
+			{copied ? (
+				<Check className="size-3.5 text-ck-accent" />
+			) : (
+				<Copy className="size-3.5" />
+			)}
+			{label}
+		</Button>
+	);
+}

--- a/apps/dashboard/src/components/ds/index.ts
+++ b/apps/dashboard/src/components/ds/index.ts
@@ -22,3 +22,4 @@ export {
 	type SegmentedOption,
 } from "./segmented";
 export { Bubble, bubbleVariants, type BubbleProps } from "./bubble";
+export { CopyButton, type CopyButtonProps } from "./copy-button";


### PR DESCRIPTION
## What & why

Restyle the Projects grid (agent cards) onto **ck/ds**. Renders inside the shell (#69) — page content + **one bounded read-only aggregate endpoint**. No schema/migration.

## The two promotion candidates (the reason for the plan-first round)

**① Status pill → OMITTED.** "Live" is only derivable from the **workspace** plan, which is **uniform across every project** and already stated by the launch banner; stamping it per-card would imply a per-project granularity that doesn't exist. The real per-project **Live/Paused/Draft** (needs a status column) stays roadmap (#101). No fabricated/uniform decoration.

**② "Responses · 30d" → PROMOTED (LIVE).** Real per-card information (projects differ), and the backend is trivial: a **new separate `GET /api/projects/usage`** — one bounded, indexed `(workspace_id, created_at)` aggregate grouped by project, no pagination. **Deliberately NOT folded into `GET /api/projects`** (that query is hot — inbox, shell switcher, onboarding, workspaces, `useSelectedProject`). **Lazy-loaded** by the grid; cards show an honest **"—" until it resolves**, never a fabricated number.

## LIVE — restyled + wired
- Cards (ck/ds): brand-initial, name, favorite/pin, **public-key + a real CopyButton**, **model badge** (real `project.model`, gateway snapshot — no hardcoded names), **Configure** → `/settings/projects/[id]` (interim, repoints at #92/#93).
- Search · favorites · sort · Pinned/All sections; **New project** → first-run setup.

## ROADMAP — omitted, never fabricated
- **Domain line** — no domain column → **omitted** (no fake `lordapparel.com`; an always-empty row is noise).
- **Manual Paused/Draft** status enum → roadmap (#101).

## Delete fixed (latent bug closed)
`DeleteProjectDialog` was `AlertDialogAction` **and** optimistic — a failed delete would read as success (card gone, server errored). Now a **plain Button + controlled dialog + non-optimistic** mutation: the card stays until the server confirms; the dialog shows "Deleting…" and surfaces failures. Consistent with the workspace (#68) + conversation (#70) deletes. (Favorite/pin toggles stay optimistic — reversible, non-destructive.)

## ds primitives
New generic **`CopyButton`** (shared — reusable by the install snippet + future Settings/Widget). Copy is "support agents", never "chatbot"/"bot".

## Tests
- API `GET /projects/usage`: returns a `{ projectId: count }` map; role-gated.
- ProjectCard: honest **"—" until loaded**, real count once loaded, model badge + public-key + copy, **never fabricates a domain**.
- CopyButton writes to clipboard; no-throw when clipboard unavailable.
- DeleteProjectDialog: plain Button fires onConfirm; "Deleting…" + disabled while pending (stays open).
- Full suites: **dashboard 366, api 294**. lint/format/typecheck clean.

## Height/scroll re-verified on the running app
Headless chromium, real session + seeded `usage_events`, both **Light/Dark**: grid renders, the **30d count shows the real value (not "—")** once the lazy query resolves, no fabricated domain/status, and the page **scrolls within `main`** (`docOverflow: 0`).

## Out of scope
Sources (#92), Settings (#93); workspace-wide inbox (#105).

🤖 Generated with [Claude Code](https://claude.com/claude-code)