### PR TITLE
feat(sources): typed sources — manual Text + Q&A creation, typed add UI, per-type rollups

### DIFF
--- a/apps/api/src/routes/chat.test.ts
+++ b/apps/api/src/routes/chat.test.ts
@@ -42,7 +42,10 @@ const project = {
 
 /** db whose project is configurable; all writes resolve. resolveAccess is mocked
  * separately, so the workspace row here is unused. */
-function mockDb({ hasProject = true }: { hasProject?: boolean } = {}) {
+function mockDb({
+	hasProject = true,
+	sources = [],
+}: { hasProject?: boolean; sources?: unknown[] } = {}) {
 	const valuesResult = () =>
 		Object.assign(Promise.resolve([]), {
 			returning: async () => [{ id: "ue1" }],
@@ -51,7 +54,7 @@ function mockDb({ hasProject = true }: { hasProject?: boolean } = {}) {
 		query: {
 			project: { findFirst: async () => (hasProject ? project : undefined) },
 			conversation: { findFirst: async () => ({ id: "c1", messageCount: 0 }) },
-			source: { findMany: async () => [] },
+			source: { findMany: async () => sources },
 			systemPrompt: { findFirst: async () => undefined },
 		},
 		insert: () => ({ values: valuesResult }),
@@ -198,5 +201,78 @@ describe("POST /v1/chat — overage metering", () => {
 		await send(validBody, ctx);
 		await settle();
 		expect(reportMeterEvent).not.toHaveBeenCalled();
+	});
+});
+
+describe("POST /v1/chat — retrieval reaches the model input (Text + Q&A)", () => {
+	// Source rows exactly as the DB returns them for the new manual types:
+	// url-less (url:null), active, content set. The failure mode this guards is
+	// silent — a kind/url filter in the load query would drop these and the agent
+	// would never see them despite the UI saving them.
+	const textRow = {
+		id: "s_text",
+		projectId: "p1",
+		kind: "text",
+		url: null,
+		title: "Restock cadence",
+		content: "We restock weekly on Mondays.",
+		question: null,
+		answer: null,
+		sourceMessageId: null,
+		active: true,
+	};
+	const qaRow = {
+		id: "s_qa",
+		projectId: "p1",
+		kind: "qa",
+		url: null,
+		title: "Do you ship internationally?",
+		content:
+			"Q: Do you ship internationally?\nA: Yes — we ship to 40 countries.",
+		question: "Do you ship internationally?",
+		answer: "Yes — we ship to 40 countries.",
+		sourceMessageId: null,
+		active: true,
+	};
+
+	it("loads url-less Text + Q&A sources and renders their content into the system prompt", async () => {
+		mockDb({ sources: [textRow, qaRow] });
+		setAccess({ plan: "starter" });
+		streamOk();
+		const { ctx, settle } = makeCtx();
+		const res = await send(validBody, ctx);
+		expect(res.status).toBe(200);
+		expect(streamChat).toHaveBeenCalledTimes(1);
+
+		// What chat.ts actually handed the model layer: both url-less sources,
+		// content intact, url normalised to "" (never dropped by a filter).
+		const input = vi.mocked(streamChat).mock.calls[0]![1];
+		expect(input.sources).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					url: "",
+					content: expect.stringContaining("We restock weekly on Mondays"),
+				}),
+				expect.objectContaining({
+					url: "",
+					content: expect.stringContaining("Yes — we ship to 40 countries"),
+				}),
+			]),
+		);
+
+		// Run the REAL buildSystem over those args → the literal `system` string the
+		// gateway receives. This is the model input; assert the source content is in
+		// it, so retrieval is proven repeatably (not just "the rows were loaded").
+		const { buildSystem } =
+			await vi.importActual<typeof import("@/lib/llm")>("@/lib/llm");
+		const system = buildSystem(
+			input.systemPrompt,
+			input.knowledgeText,
+			input.sources,
+		);
+		expect(system).toContain("# Reference sources");
+		expect(system).toContain("We restock weekly on Mondays.");
+		expect(system).toContain("Yes — we ship to 40 countries.");
+		await settle();
 	});
 });

--- a/apps/api/src/routes/sources.test.ts
+++ b/apps/api/src/routes/sources.test.ts
@@ -103,6 +103,29 @@ function promote(body: unknown, headers: Record<string, string> = {}) {
 	);
 }
 
+// Generic authed POST for the manual-source routes (text/qa), mirroring
+// `promote` but path-agnostic. Admin role + selected workspace by default.
+function post(
+	path: string,
+	body: unknown,
+	headers: Record<string, string> = {},
+) {
+	return sources.request(
+		path,
+		{
+			method: "POST",
+			headers: {
+				"x-test-user": "u1",
+				"x-workspace-id": "ws_1",
+				"content-type": "application/json",
+				...headers,
+			},
+			body: JSON.stringify(body),
+		},
+		ENV,
+	);
+}
+
 // A conversation that belongs to project p1 (the happy-path tenant chain).
 const okState: State = {
 	role: "agent",
@@ -299,5 +322,209 @@ describe("POST /sources/promote — dedupe", () => {
 		expect(json.source.id).toBe("src_old");
 		expect(json.deduped).toBe(true);
 		expect(insertSpy).not.toHaveBeenCalled();
+	});
+});
+
+// Admin-only manual authoring of url-less sources. Project ∈ workspace; no
+// tenant chain to a message (these aren't promoted), so the state is minimal.
+const authoringState: State = {
+	role: "admin",
+	project: { id: "p1", workspaceId: "ws_1" },
+};
+
+describe("POST /sources/text — manual text snippet", () => {
+	it("creates a text source (kind=text, url=null, content trimmed, title derived)", async () => {
+		mockDb(authoringState);
+		const res = await post("/projects/p1/sources/text", {
+			content: "  We restock on Mondays.  ",
+		});
+		expect(res.status).toBe(200);
+		const json = (await res.json()) as { source: Record<string, unknown> };
+		expect(json.source).toMatchObject({ kind: "text", url: null });
+		expect(lastInsert).toMatchObject({
+			projectId: "p1",
+			kind: "text",
+			url: null,
+			content: "We restock on Mondays.",
+			active: true,
+		});
+		// Title derives from the snippet body when no override is sent.
+		expect(lastInsert?.title).toBe("We restock on Mondays.");
+	});
+
+	it("honors a title override", async () => {
+		mockDb(authoringState);
+		await post("/projects/p1/sources/text", {
+			title: "Restock cadence",
+			content: "Mondays.",
+		});
+		expect(lastInsert?.title).toBe("Restock cadence");
+	});
+
+	it("400s empty content (schema min); never inserts", async () => {
+		mockDb(authoringState);
+		const res = await post("/projects/p1/sources/text", { content: "" });
+		expect(res.status).toBe(400);
+		expect(insertSpy).not.toHaveBeenCalled();
+	});
+
+	it("400s whitespace-only content (trim guard); never inserts", async () => {
+		mockDb(authoringState);
+		const res = await post("/projects/p1/sources/text", { content: "   " });
+		expect(res.status).toBe(400);
+		expect(insertSpy).not.toHaveBeenCalled();
+	});
+
+	it("403s an agent (admin-only authoring); never inserts", async () => {
+		mockDb({ ...authoringState, role: "agent" });
+		const res = await post("/projects/p1/sources/text", { content: "x" });
+		expect(res.status).toBe(403);
+		expect(insertSpy).not.toHaveBeenCalled();
+	});
+
+	it("404s when the project isn't in the caller's workspace; never inserts", async () => {
+		mockDb({ ...authoringState, project: undefined });
+		const res = await post("/projects/p1/sources/text", { content: "x" });
+		expect(res.status).toBe(404);
+		expect(insertSpy).not.toHaveBeenCalled();
+	});
+});
+
+describe("POST /sources/qa — manual Q&A pair", () => {
+	it("creates a qa source with no provenance (sourceMessageId=null), trimmed", async () => {
+		mockDb(authoringState);
+		const res = await post("/projects/p1/sources/qa", {
+			question: "  Do you ship internationally?  ",
+			answer: "  Yes, to 40 countries.  ",
+		});
+		expect(res.status).toBe(200);
+		expect(lastInsert).toMatchObject({
+			projectId: "p1",
+			kind: "qa",
+			url: null,
+			question: "Do you ship internationally?",
+			answer: "Yes, to 40 countries.",
+			content: "Q: Do you ship internationally?\nA: Yes, to 40 countries.",
+			sourceMessageId: null,
+			active: true,
+		});
+		expect(lastInsert?.title).toBe("Do you ship internationally?");
+	});
+
+	it("400s a missing answer (schema required); never inserts", async () => {
+		mockDb(authoringState);
+		const res = await post("/projects/p1/sources/qa", { question: "Q?" });
+		expect(res.status).toBe(400);
+		expect(insertSpy).not.toHaveBeenCalled();
+	});
+
+	it("400s a whitespace-only question (trim guard); never inserts", async () => {
+		mockDb(authoringState);
+		const res = await post("/projects/p1/sources/qa", {
+			question: "   ",
+			answer: "A",
+		});
+		expect(res.status).toBe(400);
+		expect(insertSpy).not.toHaveBeenCalled();
+	});
+
+	it("403s an agent (admin-only); never inserts", async () => {
+		mockDb({ ...authoringState, role: "agent" });
+		const res = await post("/projects/p1/sources/qa", {
+			question: "Q?",
+			answer: "A",
+		});
+		expect(res.status).toBe(403);
+		expect(insertSpy).not.toHaveBeenCalled();
+	});
+});
+
+// Caps, title truncation, and RBAC/workspace edges for the manual routes —
+// mirrors of the guards the promote suite already pins, so a future schema
+// divergence (widened caps, dropped trim guard) can't slip through untested.
+describe("POST /sources/text + /qa — caps, truncation & RBAC edges", () => {
+	it("text: 400s content over the 50k cap; never inserts", async () => {
+		mockDb(authoringState);
+		const res = await post("/projects/p1/sources/text", {
+			content: "x".repeat(50_001),
+		});
+		expect(res.status).toBe(400);
+		expect(insertSpy).not.toHaveBeenCalled();
+	});
+
+	it("qa: 400s an over-length question (2k cap); never inserts", async () => {
+		mockDb(authoringState);
+		const res = await post("/projects/p1/sources/qa", {
+			question: "x".repeat(2_001),
+			answer: "A",
+		});
+		expect(res.status).toBe(400);
+		expect(insertSpy).not.toHaveBeenCalled();
+	});
+
+	it("qa: 400s an over-length answer (8k cap); never inserts", async () => {
+		mockDb(authoringState);
+		const res = await post("/projects/p1/sources/qa", {
+			question: "Q?",
+			answer: "x".repeat(8_001),
+		});
+		expect(res.status).toBe(400);
+		expect(insertSpy).not.toHaveBeenCalled();
+	});
+
+	it("qa: 400s a whitespace-only answer (trim guard mirrors the question case); never inserts", async () => {
+		mockDb(authoringState);
+		const res = await post("/projects/p1/sources/qa", {
+			question: "Q?",
+			answer: "   ",
+		});
+		expect(res.status).toBe(400);
+		expect(insertSpy).not.toHaveBeenCalled();
+	});
+
+	it("text: derives the title from content but truncates it to 60 chars (full content kept)", async () => {
+		mockDb(authoringState);
+		await post("/projects/p1/sources/text", { content: "a".repeat(70) });
+		expect((lastInsert!.title as string).length).toBe(60);
+		expect((lastInsert!.content as string).length).toBe(70);
+	});
+
+	it("text: accepts a long title override (≤200) but stores it truncated to 60", async () => {
+		mockDb(authoringState);
+		await post("/projects/p1/sources/text", {
+			title: "T".repeat(100),
+			content: "body",
+		});
+		expect((lastInsert!.title as string).length).toBe(60);
+	});
+
+	it("qa: title is the question sliced to 60, but the full question is stored", async () => {
+		mockDb(authoringState);
+		const q = "Q".repeat(80);
+		await post("/projects/p1/sources/qa", { question: q, answer: "A" });
+		expect((lastInsert!.title as string).length).toBe(60);
+		expect(lastInsert?.question).toBe(q);
+		expect(lastInsert?.content).toBe(`Q: ${q}\nA: A`);
+	});
+
+	it("text: an owner passes the admin gate (role hierarchy)", async () => {
+		mockDb({ ...authoringState, role: "owner" });
+		const res = await post("/projects/p1/sources/text", { content: "hi" });
+		expect(res.status).toBe(200);
+		expect(insertSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it("qa: 400s when no workspace is selected", async () => {
+		mockDb(authoringState);
+		const res = await sources.request(
+			"/projects/p1/sources/qa",
+			{
+				method: "POST",
+				headers: { "x-test-user": "u1", "content-type": "application/json" },
+				body: JSON.stringify({ question: "Q?", answer: "A" }),
+			},
+			ENV,
+		);
+		expect(res.status).toBe(400);
 	});
 });

--- a/apps/api/src/routes/sources.ts
+++ b/apps/api/src/routes/sources.ts
@@ -34,6 +34,23 @@ const QUESTION_MAX = 2_000;
 const ANSWER_MAX = 8_000;
 const TITLE_LEN = 60;
 
+// Manual non-URL source inputs (admin authoring, siblings of the URL create).
+// A text snippet gets a generous body; a hand-written Q&A reuses the promote
+// caps so the two Q&A creation paths can't diverge. Titles cap at the
+// URL-source title limit.
+const SNIPPET_MAX = 50_000;
+const INPUT_TITLE_MAX = 200;
+
+const textInput = z.object({
+	title: z.string().max(INPUT_TITLE_MAX).optional(),
+	content: z.string().min(1).max(SNIPPET_MAX),
+});
+
+const qaInput = z.object({
+	question: z.string().min(1).max(QUESTION_MAX),
+	answer: z.string().min(1).max(ANSWER_MAX),
+});
+
 // Promote-a-reply input. A purpose-built CREATE schema with the required key
 // (`messageId`) — NOT a `.partial()` of some other schema, and with NO
 // `.default()` anywhere (the Zod-v4 footgun where a default fires on an absent
@@ -194,6 +211,71 @@ export const sources = new Hono<AppContext>()
 					active: data.active ?? true,
 					lastFetchedAt: new Date(),
 					lastError: fetched.error,
+				})
+				.returning();
+			return c.json({ source: created });
+		},
+	)
+	// Manual non-URL sources — admin authoring siblings of the URL create.
+	// "text" is a free-text snippet; "qa" is a hand-written Q&A pair (the same
+	// content shape promote produces, but with no message provenance). Both have
+	// no url and flow straight into retrieval (chat.ts loads every active source).
+	.post(
+		"/projects/:projectId/sources/text",
+		requireRole("admin"),
+		zValidator("json", textInput),
+		async (c) => {
+			const { projectId } = c.req.param();
+			const workspaceId = c.get("workspaceId");
+			const proj = await ensureProject(c.env, projectId, workspaceId);
+			if (!proj) return c.json({ error: "not found" }, 404);
+			const { title, content } = c.req.valid("json");
+			const finalContent = content.trim();
+			if (!finalContent) return c.json({ error: "content required" }, 400);
+			// Title: the override, else the first chars of the snippet — never blank.
+			const finalTitle = (title?.trim() || finalContent).slice(0, TITLE_LEN);
+			const [created] = await db(c.env)
+				.insert(source)
+				.values({
+					projectId,
+					kind: "text",
+					url: null,
+					title: finalTitle,
+					content: finalContent,
+					active: true,
+				})
+				.returning();
+			return c.json({ source: created });
+		},
+	)
+	.post(
+		"/projects/:projectId/sources/qa",
+		requireRole("admin"),
+		zValidator("json", qaInput),
+		async (c) => {
+			const { projectId } = c.req.param();
+			const workspaceId = c.get("workspaceId");
+			const proj = await ensureProject(c.env, projectId, workspaceId);
+			if (!proj) return c.json({ error: "not found" }, 404);
+			const question = c.req.valid("json").question.trim();
+			const answer = c.req.valid("json").answer.trim();
+			if (!question || !answer) {
+				return c.json({ error: "question and answer required" }, 400);
+			}
+			const content = `Q: ${question}\nA: ${answer}`;
+			const title = question.slice(0, TITLE_LEN);
+			const [created] = await db(c.env)
+				.insert(source)
+				.values({
+					projectId,
+					kind: "qa",
+					url: null,
+					title,
+					content,
+					question,
+					answer,
+					sourceMessageId: null,
+					active: true,
 				})
 				.returning();
 			return c.json({ source: created });

--- a/apps/dashboard/src/app/settings/projects/[id]/sources/SourcesPanel.test.tsx
+++ b/apps/dashboard/src/app/settings/projects/[id]/sources/SourcesPanel.test.tsx
@@ -26,62 +26,130 @@ function src(o: Partial<Source>): Source {
 }
 
 function setup(props: Partial<React.ComponentProps<typeof SourcesPanel>> = {}) {
-	const onAdd = vi.fn();
+	const onAddUrl = vi.fn();
+	const onAddText = vi.fn();
+	const onAddQa = vi.fn();
 	const onRefresh = vi.fn();
 	const onDelete = vi.fn();
 	render(
 		<SourcesPanel
 			sources={[]}
 			isLoading={false}
-			onAdd={onAdd}
+			onAddUrl={onAddUrl}
+			onAddText={onAddText}
+			onAddQa={onAddQa}
 			onRefresh={onRefresh}
 			onDelete={onDelete}
-			addPending={false}
+			addUrlPending={false}
+			addTextPending={false}
+			addQaPending={false}
 			refreshingId={null}
 			{...props}
 		/>,
 	);
-	return { onAdd, onRefresh, onDelete };
+	return { onAddUrl, onAddText, onAddQa, onRefresh, onDelete };
 }
 
 beforeEach(() => vi.clearAllMocks());
 
-describe("SourcesPanel", () => {
-	it("adds a valid URL source", async () => {
-		const { onAdd } = setup();
+describe("SourcesPanel — typed add", () => {
+	it("adds a Website source (the default type)", async () => {
+		const { onAddUrl } = setup();
 		const user = userEvent.setup();
 		await user.type(screen.getByLabelText("Source URL"), "https://example.com");
-		await user.click(screen.getByRole("button", { name: /add source/i }));
-		expect(onAdd).toHaveBeenCalledWith("https://example.com");
+		await user.click(screen.getByRole("button", { name: /add website/i }));
+		expect(onAddUrl).toHaveBeenCalledWith("https://example.com");
 	});
 
-	it("renders the real Type + derived Status for a URL source", () => {
+	it("adds a Text snippet (optional title + content)", async () => {
+		const { onAddText } = setup();
+		const user = userEvent.setup();
+		await user.click(screen.getByRole("button", { name: /text snippet/i }));
+		await user.type(screen.getByLabelText("Title"), "Restock cadence");
+		await user.type(screen.getByLabelText("Text"), "We restock on Mondays.");
+		await user.click(screen.getByRole("button", { name: /add text/i }));
+		expect(onAddText).toHaveBeenCalledWith({
+			title: "Restock cadence",
+			content: "We restock on Mondays.",
+		});
+	});
+
+	it("adds a Q&A pair (question + answer)", async () => {
+		const { onAddQa } = setup();
+		const user = userEvent.setup();
+		await user.click(screen.getByRole("button", { name: /q&a pair/i }));
+		await user.type(screen.getByLabelText("Question"), "Do you ship abroad?");
+		await user.type(screen.getByLabelText("Answer"), "Yes, to 40 countries.");
+		await user.click(screen.getByRole("button", { name: /add q&a/i }));
+		expect(onAddQa).toHaveBeenCalledWith({
+			question: "Do you ship abroad?",
+			answer: "Yes, to 40 countries.",
+		});
+	});
+
+	it("renders File upload as a disabled roadmap chip (no fake add)", () => {
+		setup();
+		const file = screen.getByRole("button", { name: /file upload/i });
+		expect(file).toBeDisabled();
+		// No file-input control fakes an upload.
+		expect(screen.queryByLabelText(/upload|choose file/i)).toBeNull();
+	});
+});
+
+describe("SourcesPanel — table + rollups", () => {
+	it("renders the real Type, derived Status, and truthful Items for a URL source", () => {
 		setup({ sources: [src({})] });
 		expect(screen.getByText("https://acme.com/docs")).toBeInTheDocument();
 		expect(screen.getByText("URL")).toBeInTheDocument();
 		expect(screen.getByText("Ready")).toBeInTheDocument();
+		expect(screen.getByText("1 page")).toBeInTheDocument();
 	});
 
-	it("shows 'Promoted from a reply' + Q&A type for a qa source", () => {
+	it("shows 'Promoted from a reply' only for a qa source WITH provenance", () => {
 		setup({
 			sources: [
-				src({ id: "q", kind: "qa", url: null, title: "Refund policy" }),
+				src({
+					id: "q",
+					kind: "qa",
+					url: null,
+					title: "Refund policy",
+					sourceMessageId: "m1",
+				}),
 			],
 		});
 		expect(screen.getByText(/promoted from a reply/i)).toBeInTheDocument();
 		expect(screen.getByText("Q&A")).toBeInTheDocument();
-		expect(screen.getByText("Saved")).toBeInTheDocument();
+		expect(screen.getByText("1 pair")).toBeInTheDocument();
 	});
 
-	it("surfaces the roadmap types as an honest dimmed note (no fake add buttons)", () => {
-		setup();
-		expect(
-			screen.getByText(/more source types — files, q&a import — coming/i),
-		).toBeInTheDocument();
-		// The only add control is the URL one — no PDF/File/Q&A add buttons.
-		expect(
-			screen.queryByRole("button", { name: /add (pdf|file|text)/i }),
-		).toBeNull();
+	it("does NOT label a hand-written qa source as promoted", () => {
+		setup({
+			sources: [
+				src({
+					id: "q",
+					kind: "qa",
+					url: null,
+					title: "Shipping FAQ",
+					sourceMessageId: null,
+				}),
+			],
+		});
+		expect(screen.queryByText(/promoted from a reply/i)).toBeNull();
+		expect(screen.getByText("Shipping FAQ")).toBeInTheDocument();
+	});
+
+	it("renders real per-type rollup counts + a dimmed Files card", () => {
+		setup({
+			sources: [
+				src({ id: "a", kind: "url", url: "https://a.com" }),
+				src({ id: "b", kind: "url", url: "https://b.com" }),
+				src({ id: "c", kind: "qa", url: null, sourceMessageId: "m1" }),
+				src({ id: "d", kind: "text", url: null }),
+			],
+		});
+		expect(screen.getByText("Websites · sources")).toBeInTheDocument();
+		expect(screen.getByText("2")).toBeInTheDocument(); // two websites
+		expect(screen.getByText("Coming soon")).toBeInTheDocument(); // Files roadmap
 	});
 
 	it("recrawls + deletes from the row actions", async () => {

--- a/apps/dashboard/src/app/settings/projects/[id]/sources/SourcesPanel.tsx
+++ b/apps/dashboard/src/app/settings/projects/[id]/sources/SourcesPanel.tsx
@@ -2,6 +2,7 @@
 
 import {
 	FileText,
+	FileUp,
 	Globe,
 	MessagesSquare,
 	Plus,
@@ -11,7 +12,7 @@ import {
 import { useState } from "react";
 import { toast } from "sonner";
 
-import { Badge, Button, Card } from "@/components/ds";
+import { Badge, Button, Card, dsInputClass, Field } from "@/components/ds";
 import {
 	formatRelativeTime,
 	SOURCE_URL_ERRORS,
@@ -21,6 +22,8 @@ import { cn } from "@/lib/utils";
 
 import type { Source } from "../types";
 import {
+	countByType,
+	sourceItemLabel,
 	STATUS_STYLE,
 	sourceStatus,
 	sourceType,
@@ -32,6 +35,262 @@ const TYPE_ICON: Record<SourceType, typeof Globe> = {
 	"Q&A": MessagesSquare,
 	Text: FileText,
 };
+
+// The "Add a source" type picker. Website/Q&A/Text are LIVE; File upload is an
+// honest roadmap affordance (needs storage + parsing under workerd) — rendered
+// dimmed + non-interactive, never a fake working control.
+type AddKind = "url" | "qa" | "text" | "file";
+const ADD_TYPES: ReadonlyArray<{
+	kind: AddKind;
+	label: string;
+	icon: typeof Globe;
+	roadmap?: boolean;
+}> = [
+	{ kind: "url", label: "Website", icon: Globe },
+	{ kind: "qa", label: "Q&A pair", icon: MessagesSquare },
+	{ kind: "text", label: "Text snippet", icon: FileText },
+	{ kind: "file", label: "File upload", icon: FileUp, roadmap: true },
+];
+
+function AddSource({
+	onAddUrl,
+	onAddText,
+	onAddQa,
+	urlPending,
+	textPending,
+	qaPending,
+}: {
+	onAddUrl: (url: string) => void;
+	onAddText: (input: { title?: string; content: string }) => void;
+	onAddQa: (input: { question: string; answer: string }) => void;
+	urlPending: boolean;
+	textPending: boolean;
+	qaPending: boolean;
+}) {
+	const [kind, setKind] = useState<AddKind>("url");
+	const [url, setUrl] = useState("");
+	const [question, setQuestion] = useState("");
+	const [answer, setAnswer] = useState("");
+	const [title, setTitle] = useState("");
+	const [text, setText] = useState("");
+
+	function submitUrl() {
+		const value = url.trim();
+		const error = validateSourceUrl(value);
+		if (error === "empty") return;
+		if (error) {
+			toast.error(SOURCE_URL_ERRORS[error]);
+			return;
+		}
+		onAddUrl(value);
+		setUrl("");
+	}
+
+	function submitQa() {
+		const q = question.trim();
+		const a = answer.trim();
+		if (!q || !a) return;
+		onAddQa({ question: q, answer: a });
+		setQuestion("");
+		setAnswer("");
+	}
+
+	function submitText() {
+		const body = text.trim();
+		if (!body) return;
+		const t = title.trim();
+		onAddText(t ? { title: t, content: body } : { content: body });
+		setTitle("");
+		setText("");
+	}
+
+	return (
+		<Card id="sources-add" className="flex flex-col gap-4 p-4">
+			<div>
+				<h2 className="text-sm font-semibold text-ck-text">Add a source</h2>
+				<p className="mt-0.5 text-xs text-ck-faint">
+					Anything you add here becomes content the agent can answer from.
+				</p>
+			</div>
+
+			{/* Typed picker — File upload is a dimmed roadmap chip, not a fake add. */}
+			<div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+				{ADD_TYPES.map(({ kind: k, label, icon: Icon, roadmap }) => {
+					const active = !roadmap && k === kind;
+					return (
+						<button
+							key={k}
+							type="button"
+							disabled={roadmap}
+							aria-pressed={active}
+							onClick={() => !roadmap && setKind(k)}
+							className={cn(
+								"flex items-center gap-2 rounded-[10px] border px-3 py-2.5 text-[13px] font-semibold transition-colors",
+								roadmap
+									? "cursor-not-allowed border-dashed border-ck-border text-ck-disabled"
+									: active
+										? "border-ck-accent bg-ck-accent/10 text-ck-accent"
+										: "border-ck-border text-ck-muted hover:border-ck-accent/40 hover:text-ck-text",
+							)}
+						>
+							<Icon className="size-4 shrink-0" />
+							<span className="min-w-0 flex-1 truncate text-left">{label}</span>
+							{roadmap && (
+								<span className="text-[10px] font-bold uppercase tracking-wide text-ck-faint">
+									Soon
+								</span>
+							)}
+						</button>
+					);
+				})}
+			</div>
+
+			{/* Active form for the selected type. */}
+			{kind === "url" && (
+				<div className="flex flex-col gap-2 sm:flex-row">
+					<input
+						value={url}
+						onChange={(e) => setUrl(e.target.value)}
+						onKeyDown={(e) => {
+							if (e.key === "Enter") {
+								e.preventDefault();
+								submitUrl();
+							}
+						}}
+						placeholder="https://example.com"
+						aria-label="Source URL"
+						className="h-10 flex-1 rounded-[10px] border border-ck-border bg-ck-card px-3 font-mono text-[13px] text-ck-text outline-none placeholder:text-ck-faint focus-visible:border-ck-accent"
+					/>
+					<Button
+						onClick={submitUrl}
+						disabled={urlPending || !url.trim()}
+						className="shrink-0"
+					>
+						<Plus className="size-4" />
+						{urlPending ? "Adding…" : "Add website"}
+					</Button>
+				</div>
+			)}
+
+			{kind === "qa" && (
+				<div className="flex flex-col gap-3">
+					<Field label="Question">
+						{(id) => (
+							<input
+								id={id}
+								value={question}
+								onChange={(e) => setQuestion(e.target.value)}
+								placeholder="Do you ship internationally?"
+								className={dsInputClass}
+							/>
+						)}
+					</Field>
+					<Field label="Answer">
+						{(id) => (
+							<textarea
+								id={id}
+								value={answer}
+								onChange={(e) => setAnswer(e.target.value)}
+								rows={3}
+								placeholder="Yes — we ship to 40 countries. Rates are shown at checkout."
+								className={dsInputClass}
+							/>
+						)}
+					</Field>
+					<div className="flex justify-end">
+						<Button
+							onClick={submitQa}
+							disabled={qaPending || !question.trim() || !answer.trim()}
+						>
+							<Plus className="size-4" />
+							{qaPending ? "Adding…" : "Add Q&A"}
+						</Button>
+					</div>
+				</div>
+			)}
+
+			{kind === "text" && (
+				<div className="flex flex-col gap-3">
+					<Field
+						label="Title"
+						hint="Optional — defaults to the start of the text."
+					>
+						{(id) => (
+							<input
+								id={id}
+								value={title}
+								onChange={(e) => setTitle(e.target.value)}
+								placeholder="Restock cadence"
+								className={dsInputClass}
+							/>
+						)}
+					</Field>
+					<Field label="Text">
+						{(id) => (
+							<textarea
+								id={id}
+								value={text}
+								onChange={(e) => setText(e.target.value)}
+								rows={4}
+								placeholder="We restock weekly on Mondays. Sold-out sizes usually return within two weeks."
+								className={dsInputClass}
+							/>
+						)}
+					</Field>
+					<div className="flex justify-end">
+						<Button onClick={submitText} disabled={textPending || !text.trim()}>
+							<Plus className="size-4" />
+							{textPending ? "Adding…" : "Add text"}
+						</Button>
+					</div>
+				</div>
+			)}
+		</Card>
+	);
+}
+
+// Per-type rollup cards. Counts are real (sources grouped by kind); Files is a
+// dimmed roadmap card since there's no upload path yet. The deep per-item depth
+// the design hints at (pages crawled, documents parsed) is the roadmap moat —
+// we don't claim it, so no fabricated page totals here.
+function TypeRollup({ sources }: { sources: Source[] }) {
+	const counts = countByType(sources);
+	const live: ReadonlyArray<{
+		label: string;
+		icon: typeof Globe;
+		n: number;
+	}> = [
+		{ label: "Websites", icon: Globe, n: counts.URL },
+		{ label: "Q&A", icon: MessagesSquare, n: counts["Q&A"] },
+		{ label: "Text", icon: FileText, n: counts.Text },
+	];
+	return (
+		<div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+			{live.map(({ label, icon: Icon, n }) => (
+				<Card key={label} className="flex items-center gap-3 p-3">
+					<span className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-ck-chip text-ck-muted">
+						<Icon className="size-4" />
+					</span>
+					<div className="min-w-0">
+						<p className="text-lg font-bold tabular-nums text-ck-text">{n}</p>
+						<p className="truncate text-[11px] text-ck-faint">
+							{label} · {n === 1 ? "source" : "sources"}
+						</p>
+					</div>
+				</Card>
+			))}
+			<Card className="flex items-center gap-3 p-3 opacity-60">
+				<span className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-ck-chip text-ck-disabled">
+					<FileUp className="size-4" />
+				</span>
+				<div className="min-w-0">
+					<p className="text-[13px] font-semibold text-ck-disabled">Files</p>
+					<p className="truncate text-[11px] text-ck-faint">Coming soon</p>
+				</div>
+			</Card>
+		</div>
+	);
+}
 
 function SourceRow({
 	source,
@@ -47,7 +306,9 @@ function SourceRow({
 	const type = sourceType(source);
 	const status = STATUS_STYLE[sourceStatus(source)];
 	const Icon = TYPE_ICON[type];
-	const promoted = source.kind === "qa";
+	// Only a qa source with real message provenance is "promoted from a reply";
+	// a hand-written Q&A (no sourceMessageId) is not.
+	const promoted = source.kind === "qa" && !!source.sourceMessageId;
 	return (
 		<div className="flex items-center gap-3 border-t border-ck-border px-4 py-3 first:border-t-0">
 			<span className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-ck-chip text-ck-muted">
@@ -74,6 +335,9 @@ function SourceRow({
 			>
 				{type}
 			</Badge>
+			<span className="hidden w-16 text-right text-[11px] text-ck-faint md:inline">
+				{sourceItemLabel(source)}
+			</span>
 			<span
 				className={cn(
 					"hidden w-[88px] justify-center rounded-full px-2 py-1 text-[11px] font-semibold sm:inline-flex",
@@ -82,7 +346,7 @@ function SourceRow({
 			>
 				{status.label}
 			</span>
-			<span className="hidden w-20 text-right text-[11px] text-ck-faint md:inline">
+			<span className="hidden w-16 text-right text-[11px] text-ck-faint lg:inline">
 				{formatRelativeTime(source.createdAt)}
 			</span>
 			<div className="flex shrink-0 items-center gap-1">
@@ -115,67 +379,40 @@ function SourceRow({
 export function SourcesPanel({
 	sources,
 	isLoading,
-	onAdd,
+	onAddUrl,
+	onAddText,
+	onAddQa,
 	onRefresh,
 	onDelete,
-	addPending,
+	addUrlPending,
+	addTextPending,
+	addQaPending,
 	refreshingId,
 }: {
 	sources: Source[];
 	isLoading: boolean;
-	onAdd: (url: string) => void;
+	onAddUrl: (url: string) => void;
+	onAddText: (input: { title?: string; content: string }) => void;
+	onAddQa: (input: { question: string; answer: string }) => void;
 	onRefresh: (id: string) => void;
 	onDelete: (id: string) => void;
-	addPending: boolean;
+	addUrlPending: boolean;
+	addTextPending: boolean;
+	addQaPending: boolean;
 	refreshingId: string | null;
 }) {
-	const [url, setUrl] = useState("");
-
-	function submit() {
-		const value = url.trim();
-		const error = validateSourceUrl(value);
-		if (error === "empty") return;
-		if (error) {
-			toast.error(SOURCE_URL_ERRORS[error]);
-			return;
-		}
-		onAdd(value);
-		setUrl("");
-	}
-
 	return (
-		<div className="flex flex-col gap-4">
-			{/* Add a source — URL is LIVE; other types are honest roadmap. */}
-			<div className="flex flex-col gap-2">
-				<div className="flex flex-col gap-2 sm:flex-row">
-					<input
-						value={url}
-						onChange={(e) => setUrl(e.target.value)}
-						onKeyDown={(e) => {
-							if (e.key === "Enter") {
-								e.preventDefault();
-								submit();
-							}
-						}}
-						placeholder="https://example.com"
-						aria-label="Source URL"
-						className="h-10 flex-1 rounded-[10px] border border-ck-border bg-ck-card px-3 font-mono text-[13px] text-ck-text outline-none placeholder:text-ck-faint focus-visible:border-ck-accent"
-					/>
-					<Button
-						onClick={submit}
-						disabled={addPending || !url.trim()}
-						className="shrink-0"
-					>
-						<Plus className="size-4" />
-						{addPending ? "Adding…" : "Add source"}
-					</Button>
-				</div>
-				{/* Roadmap — dimmed, not a working fake. No empty rollup cards. */}
-				<p className="text-[11.5px] text-ck-faint">
-					More source types — files, Q&amp;A import — coming. Q&amp;A sources
-					are added today by promoting an inbox reply.
-				</p>
-			</div>
+		<div className="flex flex-col gap-5">
+			<AddSource
+				onAddUrl={onAddUrl}
+				onAddText={onAddText}
+				onAddQa={onAddQa}
+				urlPending={addUrlPending}
+				textPending={addTextPending}
+				qaPending={addQaPending}
+			/>
+
+			{sources.length > 0 && <TypeRollup sources={sources} />}
 
 			{isLoading ? (
 				<Card className="p-4">
@@ -188,18 +425,20 @@ export function SourcesPanel({
 					</span>
 					<p className="text-sm font-semibold text-ck-text">No sources yet</p>
 					<p className="text-xs text-ck-faint">
-						Add a URL so your agent can answer from your content.
+						Add a website, Q&amp;A pair, or text snippet so your agent can
+						answer from your content.
 					</p>
 				</Card>
 			) : (
 				<Card>
-					{/* Column header (sm+). */}
+					{/* Column header (sm+). Items + Added narrow in at md/lg. */}
 					<div className="hidden items-center gap-3 border-b border-ck-border px-4 py-2 text-[10px] font-bold uppercase tracking-wide text-ck-faint sm:flex">
 						<span className="size-8 shrink-0" />
 						<span className="flex-1">Source</span>
 						<span className="w-16 text-center">Type</span>
+						<span className="hidden w-16 text-right md:inline">Items</span>
 						<span className="w-[88px] text-center">Status</span>
-						<span className="hidden w-20 text-right md:inline">Added</span>
+						<span className="hidden w-16 text-right lg:inline">Added</span>
 						<span className="w-[72px]" />
 					</div>
 					{sources.map((s) => (

--- a/apps/dashboard/src/app/settings/projects/[id]/sources/page.tsx
+++ b/apps/dashboard/src/app/settings/projects/[id]/sources/page.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import { useQuery } from "@tanstack/react-query";
+import { Plus } from "lucide-react";
 import { useParams } from "next/navigation";
 
+import { Button } from "@/components/ds";
 import { api } from "@/lib/api";
 import { useWorkspace } from "@/lib/workspace";
 
@@ -41,37 +43,53 @@ export default function SourcesPage() {
 	});
 	const projectName = projectsQ.data?.projects.find((p) => p.id === id)?.name;
 
-	const { addSource, refreshSource, deleteSource } = useSourceMutations(
-		id,
-		workspaceId,
-	);
+	const { addSource, addText, addQa, refreshSource, deleteSource } =
+		useSourceMutations(id, workspaceId);
 
 	return (
 		<div className="mx-auto max-w-3xl px-6 py-8">
-			<header className="mb-6">
-				<div className="flex items-center gap-2.5">
-					<h1 className="text-2xl font-extrabold tracking-[-0.02em] text-ck-text">
-						Sources
-					</h1>
-					{!sourcesQ.isLoading && sources.length > 0 && (
-						<span className="rounded-full bg-ck-chip px-2 py-0.5 font-mono text-xs font-semibold text-ck-muted">
-							{sources.length}
-						</span>
-					)}
+			<header className="mb-6 flex items-start justify-between gap-4">
+				<div>
+					<div className="flex items-center gap-2.5">
+						<h1 className="text-2xl font-extrabold tracking-[-0.02em] text-ck-text">
+							Sources
+						</h1>
+						{!sourcesQ.isLoading && sources.length > 0 && (
+							<span className="rounded-full bg-ck-chip px-2 py-0.5 font-mono text-xs font-semibold text-ck-muted">
+								{sources.length}
+							</span>
+						)}
+					</div>
+					<p className="mt-1 text-sm text-ck-muted">
+						Content {projectName ? `${projectName}'s` : "this project's"}{" "}
+						support agent retrieves answers from.
+					</p>
 				</div>
-				<p className="mt-1 text-sm text-ck-muted">
-					Content {projectName ? `${projectName}'s` : "this project's"} support
-					agent retrieves answers from.
-				</p>
+				{/* Jumps to the always-visible add panel — real affordance, no fake. */}
+				<Button
+					className="shrink-0"
+					onClick={() =>
+						document
+							.getElementById("sources-add")
+							?.scrollIntoView({ behavior: "smooth", block: "start" })
+					}
+				>
+					<Plus className="size-4" />
+					Add source
+				</Button>
 			</header>
 
 			<SourcesPanel
 				sources={sources}
 				isLoading={sourcesQ.isLoading}
-				onAdd={(url) => addSource.mutate(url)}
+				onAddUrl={(url) => addSource.mutate(url)}
+				onAddText={(input) => addText.mutate(input)}
+				onAddQa={(input) => addQa.mutate(input)}
 				onRefresh={(sid) => refreshSource.mutate(sid)}
 				onDelete={(sid) => deleteSource.mutate(sid)}
-				addPending={addSource.isPending}
+				addUrlPending={addSource.isPending}
+				addTextPending={addText.isPending}
+				addQaPending={addQa.isPending}
 				refreshingId={refreshSource.isPending ? refreshSource.variables : null}
 			/>
 		</div>

--- a/apps/dashboard/src/app/settings/projects/[id]/sources/source-status.test.ts
+++ b/apps/dashboard/src/app/settings/projects/[id]/sources/source-status.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from "vitest";
 
 import type { Source } from "../types";
-import { sourceStatus, sourceType } from "./source-status";
+import {
+	countByType,
+	sourceItemLabel,
+	sourceStatus,
+	sourceType,
+} from "./source-status";
 
 function src(o: Partial<Source>): Source {
 	return {
@@ -51,5 +56,29 @@ describe("sourceStatus (derived from real columns, never fabricated)", () => {
 		expect(
 			sourceStatus(src({ kind: "text", url: null, lastFetchedAt: null })),
 		).toBe("saved");
+	});
+});
+
+describe("countByType (real per-type rollup counts)", () => {
+	it("groups sources by their Type label", () => {
+		expect(
+			countByType([
+				{ kind: "url" },
+				{ kind: "url" },
+				{ kind: "qa" },
+				{ kind: "text" },
+			]),
+		).toEqual({ URL: 2, "Q&A": 1, Text: 1 });
+	});
+	it("returns zeroes for an empty list", () => {
+		expect(countByType([])).toEqual({ URL: 0, "Q&A": 0, Text: 0 });
+	});
+});
+
+describe("sourceItemLabel (truthful one-item-per-source counts)", () => {
+	it("labels each type with its single item, never a fabricated total", () => {
+		expect(sourceItemLabel({ kind: "url" })).toBe("1 page");
+		expect(sourceItemLabel({ kind: "qa" })).toBe("1 pair");
+		expect(sourceItemLabel({ kind: "text" })).toBe("1 snippet");
 	});
 });

--- a/apps/dashboard/src/app/settings/projects/[id]/sources/source-status.ts
+++ b/apps/dashboard/src/app/settings/projects/[id]/sources/source-status.ts
@@ -29,6 +29,27 @@ export function sourceStatus(
 	return "ready";
 }
 
+/** Per-type source counts for the typed-source rollup cards — real data only. */
+export function countByType(
+	sources: Pick<Source, "kind">[],
+): Record<SourceType, number> {
+	const counts: Record<SourceType, number> = { URL: 0, "Q&A": 0, Text: 0 };
+	for (const s of sources) counts[sourceType(s)] += 1;
+	return counts;
+}
+
+/**
+ * Truthful per-source item count for the Items column. Every source holds
+ * exactly one item today — we fetch one page per URL, store one pair, one
+ * snippet — so this reads "1 page" / "1 pair" / "1 snippet". It's the honest
+ * base for the deep-crawl depth that will later let one URL source span many
+ * pages; no fabricated "142 pages".
+ */
+export function sourceItemLabel(s: Pick<Source, "kind">): string {
+	const t = sourceType(s);
+	return t === "URL" ? "1 page" : t === "Q&A" ? "1 pair" : "1 snippet";
+}
+
 /** ck-token chip styling per status (label + classes). */
 export const STATUS_STYLE: Record<
 	SourceStatus,

--- a/apps/dashboard/src/app/settings/projects/[id]/sources/useSourceMutations.ts
+++ b/apps/dashboard/src/app/settings/projects/[id]/sources/useSourceMutations.ts
@@ -33,6 +33,37 @@ export function useSourceMutations(id: string, workspaceId: string | null) {
 		onError: (e) => toast.error(describeApiError(e, "Could not add source")),
 	});
 
+	// Manual text snippet — hits the dedicated /sources/text create route.
+	const addText = useMutation({
+		mutationFn: (input: { title?: string; content: string }) =>
+			api<{ source: Source }>(`/api/projects/${id}/sources/text`, {
+				method: "POST",
+				body: input,
+				workspaceId: workspaceId!,
+			}),
+		onSuccess: () => {
+			qc.invalidateQueries({ queryKey: ["sources", id] });
+			toast.success("Source added");
+		},
+		onError: (e) => toast.error(describeApiError(e, "Could not add source")),
+	});
+
+	// Hand-written Q&A pair — /sources/qa (sibling of promote-a-reply, no
+	// message provenance).
+	const addQa = useMutation({
+		mutationFn: (input: { question: string; answer: string }) =>
+			api<{ source: Source }>(`/api/projects/${id}/sources/qa`, {
+				method: "POST",
+				body: input,
+				workspaceId: workspaceId!,
+			}),
+		onSuccess: () => {
+			qc.invalidateQueries({ queryKey: ["sources", id] });
+			toast.success("Source added");
+		},
+		onError: (e) => toast.error(describeApiError(e, "Could not add source")),
+	});
+
 	const refreshSource = useMutation({
 		mutationFn: (sourceId: string) =>
 			api(`/api/projects/${id}/sources/${sourceId}/refresh`, {
@@ -59,5 +90,5 @@ export function useSourceMutations(id: string, workspaceId: string | null) {
 		onError: (e) => toast.error(describeApiError(e, "Could not remove source")),
 	});
 
-	return { addSource, refreshSource, deleteSource };
+	return { addSource, addText, addQa, refreshSource, deleteSource };
 }


### PR DESCRIPTION
## What

Brings the Sources tab to the target design's **LIVE scope**: three working source types behind a typed add UI, per-type rollups, an Items column, and a provenance fix — keeping not-yet-built features as honest dimmed/"coming" affordances (no fabricated UI, no shipped LIVE/ROADMAP pills).

Top of the queue (#106, typed-sources half). "RAG depth" / multi-page crawl remain roadmap (#100).

## Changes

**Backend** (`apps/api/src/routes/sources.ts`)
- `POST /projects/:id/sources/text` and `/sources/qa` — admin-only, url-less. Q&A reuses promote's `Q:/A:` content shape but with **`sourceMessageId: null`** (no fake provenance). Zod caps, trim guards, `ensureProject` tenant isolation.
- Both create `active:true` rows that flow into retrieval via the **existing** active-source load — no chat-path change.

**Dashboard** (`[id]/sources/`)
- Typed "Add a source" picker: Website / Q&A / Text each with their own form; **File upload** is a disabled, dashed "SOON" chip (inert — no hidden file input).
- Per-type **rollup cards** with real counts + a dimmed "Coming soon" Files card.
- **Items** column with truthful `1 page / 1 pair / 1 snippet` (no fabricated multi-page totals).
- **Provenance fix**: only `qa` sources *with* `sourceMessageId` read "Promoted from a reply" — hand-written Q&A is no longer mislabeled.
- Header "+ Add source" affordance.

## Verification

**Gates:** 314 api + 388 dashboard tests; `tsc --noEmit` (api + dashboard); prettier + oxlint clean.

**Adversarial multi-agent review** (5 lenses × verify): zero code defects; findings were test-hardening, added (over-length caps, whitespace-answer, title truncation, owner-allowed, no-workspace).

**Retrieval — proven end-to-end (the key risk: a `kind`/`url` filter silently dropping url-less rows):**
- Path audit: `chat.ts` loads sources filtering **only** `projectId + active=true` (no `kind`/`url IS NOT NULL`); the map normalises `url → ""`; `buildSystem` (`llm.ts`) filters only on non-empty content and renders url-less sources (just omitting the URL line). No exclusion anywhere.
- **Integration test** (`chat.test.ts`): a project with url-less Text + Q&A rows → asserts both `content` strings appear in the literal `system` prompt produced by the **real** `buildSystem`. Repeatable proof, not one manual chat.
- **Live chat** (dev agent made live via the documented owner-exemption `INTERNAL_ACCOUNT_EMAILS`, reverted after; real LLM gateway):
  - *"When do you restock?"* → **"We restock weekly on Mondays. Sold-out sizes usually come back within two weeks."** (Text source)
  - *"Do you ship internationally?"* → **"Yes — we ship internationally to 40 countries… Source: "Do you ship internationally?""** (Q&A source — even cites the source title)

**Persistence + UI:** created Text + Q&A via the new endpoints through the real authenticated stack → fresh GET confirmed they persist (active, url null, `sourceMessageId` null) → deleted to restore the seed's clean state. Local screenshots confirm the page matches the target design: typed picker, rollup cards, Items column, File upload "SOON" dimmed.

**Note:** the Items "1 page" for a website is the real single-fetch count (we fetch one page per URL today); multi-page crawl is #100, not a placeholder.

## Scope (deliberately roadmap)
File upload (storage + PDF parsing under workerd), deep RAG / multi-page crawl, plan-limit enforcement (#107).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
