### PR TITLE
refactor(dashboard): unify content width with a shared PageContainer

### DIFF
--- a/apps/dashboard/src/app/settings/account/page.tsx
+++ b/apps/dashboard/src/app/settings/account/page.tsx
@@ -7,6 +7,7 @@ import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { toast } from "sonner";
 
+import { PageContainer } from "@/components/page-container";
 import { Button } from "@/components/ui/button";
 import {
 	Card,
@@ -113,7 +114,7 @@ export default function AccountSettingsPage() {
 	);
 
 	return (
-		<div className="mx-auto w-full max-w-[800px] space-y-6 p-6">
+		<PageContainer className="space-y-6">
 			<header>
 				<h1 className="font-display text-2xl font-semibold tracking-tight-display">
 					Account
@@ -257,6 +258,6 @@ export default function AccountSettingsPage() {
 					onConfirm={(body) => remove.mutate(body)}
 				/>
 			)}
-		</div>
+		</PageContainer>
 	);
 }

--- a/apps/dashboard/src/app/settings/billing/_components/BillingSkeleton.tsx
+++ b/apps/dashboard/src/app/settings/billing/_components/BillingSkeleton.tsx
@@ -1,13 +1,16 @@
+import { PageContainer } from "@/components/page-container";
 import { Skeleton } from "@/components/ui/skeleton";
 
 export function BillingSkeleton() {
+	// Same container as the resolved billing page so there's no width jump when
+	// the usage query lands (it doubles as the Suspense fallback).
 	return (
-		<div className="mx-auto w-full max-w-2xl space-y-6 p-6">
+		<PageContainer className="space-y-6">
 			<div className="space-y-2">
 				<Skeleton className="h-7 w-32" />
 				<Skeleton className="h-4 w-64" />
 			</div>
 			<Skeleton className="h-48 w-full rounded-xl" />
-		</div>
+		</PageContainer>
 	);
 }

--- a/apps/dashboard/src/app/settings/billing/page.tsx
+++ b/apps/dashboard/src/app/settings/billing/page.tsx
@@ -5,6 +5,7 @@ import { CreditCard } from "lucide-react";
 import { useSearchParams } from "next/navigation";
 import { Suspense, useEffect, useState } from "react";
 
+import { PageContainer } from "@/components/page-container";
 import {
 	fetchUsage,
 	isBillingNotConfigured,
@@ -83,7 +84,7 @@ function BillingContent() {
 	const selecting = checkout.isPending ? (checkout.variables ?? null) : null;
 
 	return (
-		<div className="mx-auto w-full max-w-[1040px] space-y-6 p-6">
+		<PageContainer className="space-y-6">
 			<header className="space-y-1">
 				<h1 className="text-2xl font-extrabold tracking-[-0.02em] text-ck-text">
 					Billing &amp; usage
@@ -153,7 +154,7 @@ function BillingContent() {
 					</div>
 				</>
 			)}
-		</div>
+		</PageContainer>
 	);
 }
 

--- a/apps/dashboard/src/app/settings/projects/[id]/page.tsx
+++ b/apps/dashboard/src/app/settings/projects/[id]/page.tsx
@@ -5,6 +5,7 @@ import { useParams } from "next/navigation";
 import { useEffect, useState } from "react";
 
 import { Button } from "@/components/ds";
+import { PageContainer } from "@/components/page-container";
 import { Skeleton } from "@/components/ui/skeleton";
 import { ACCOUNT_KEY, fetchAccount } from "@/lib/account";
 import { api } from "@/lib/api";
@@ -91,13 +92,13 @@ export default function ProjectSettingsPage() {
 
 	if (!project || !draft) {
 		return (
-			<div className="mx-auto max-w-[1000px] px-6 py-8">
+			<PageContainer>
 				<Skeleton className="h-8 w-64" />
 				<div className="mt-6 flex gap-6">
 					<Skeleton className="h-40 w-44 shrink-0 rounded-2xl" />
 					<Skeleton className="h-80 flex-1 rounded-2xl" />
 				</div>
-			</div>
+			</PageContainer>
 		);
 	}
 
@@ -121,7 +122,7 @@ export default function ProjectSettingsPage() {
 	}
 
 	return (
-		<div className="mx-auto max-w-[1000px] px-6 py-8">
+		<PageContainer>
 			<header className="mb-6">
 				<h1 className="truncate text-2xl font-extrabold tracking-[-0.02em] text-ck-text">
 					{project.name}
@@ -171,7 +172,8 @@ export default function ProjectSettingsPage() {
 			{/* One save bar for all tabs — saves only the dirty fields (PATCH partial). */}
 			{dirty && (
 				<div className="fixed inset-x-0 bottom-0 z-20 border-t border-ck-border bg-ck-topbar/95 backdrop-blur md:left-60">
-					<div className="mx-auto flex max-w-[1000px] items-center justify-between gap-3 px-6 py-3">
+					{/* Inner width matches PageContainer so the bar lines up with content. */}
+					<div className="mx-auto flex max-w-[1600px] items-center justify-between gap-3 px-6 py-3 sm:px-8">
 						<span className="text-[12.5px] text-ck-muted">Unsaved changes</span>
 						<div className="flex items-center gap-2">
 							<Button
@@ -196,6 +198,6 @@ export default function ProjectSettingsPage() {
 				onConfirm={() => remove.mutate()}
 				pending={remove.isPending}
 			/>
-		</div>
+		</PageContainer>
 	);
 }

--- a/apps/dashboard/src/app/settings/projects/[id]/sources/page.tsx
+++ b/apps/dashboard/src/app/settings/projects/[id]/sources/page.tsx
@@ -5,6 +5,7 @@ import { Plus } from "lucide-react";
 import { useParams } from "next/navigation";
 
 import { Button } from "@/components/ds";
+import { PageContainer } from "@/components/page-container";
 import { api } from "@/lib/api";
 import { useWorkspace } from "@/lib/workspace";
 
@@ -47,7 +48,7 @@ export default function SourcesPage() {
 		useSourceMutations(id, workspaceId);
 
 	return (
-		<div className="mx-auto max-w-3xl px-6 py-8">
+		<PageContainer>
 			<header className="mb-6 flex items-start justify-between gap-4">
 				<div>
 					<div className="flex items-center gap-2.5">
@@ -92,6 +93,6 @@ export default function SourcesPage() {
 				addQaPending={addQa.isPending}
 				refreshingId={refreshSource.isPending ? refreshSource.variables : null}
 			/>
-		</div>
+		</PageContainer>
 	);
 }

--- a/apps/dashboard/src/app/settings/projects/page.tsx
+++ b/apps/dashboard/src/app/settings/projects/page.tsx
@@ -6,6 +6,7 @@ import { useMemo, useState } from "react";
 import { toast } from "sonner";
 
 import { Button } from "@/components/ds";
+import { PageContainer } from "@/components/page-container";
 import {
 	Empty,
 	EmptyContent,
@@ -139,7 +140,7 @@ export default function ProjectsPage() {
 	const { pinned, rest } = partitionPinned(filtered);
 
 	return (
-		<div className="mx-auto max-w-5xl px-6 py-10">
+		<PageContainer>
 			<div className="mb-8 flex items-center justify-between">
 				<div>
 					<h1 className="text-2xl font-extrabold tracking-[-0.02em] text-ck-text">
@@ -282,7 +283,7 @@ export default function ProjectsPage() {
 					)}
 				</div>
 			)}
-		</div>
+		</PageContainer>
 	);
 }
 

--- a/apps/dashboard/src/app/settings/workspaces/page.tsx
+++ b/apps/dashboard/src/app/settings/workspaces/page.tsx
@@ -6,6 +6,7 @@ import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { toast } from "sonner";
 
+import { PageContainer } from "@/components/page-container";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -79,7 +80,7 @@ export default function WorkspacesSettingsPage() {
 				: null;
 
 	return (
-		<div className="mx-auto w-full max-w-[800px] space-y-6 p-6">
+		<PageContainer className="space-y-6">
 			<header className="flex items-start justify-between gap-4">
 				<div>
 					<h1 className="font-display text-2xl font-semibold tracking-tight-display">
@@ -181,6 +182,6 @@ export default function WorkspacesSettingsPage() {
 					onConfirm={() => remove.mutate(deleting.id)}
 				/>
 			)}
-		</div>
+		</PageContainer>
 	);
 }

--- a/apps/dashboard/src/components/page-container.test.tsx
+++ b/apps/dashboard/src/components/page-container.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { PageContainer } from "./page-container";
+
+describe("PageContainer", () => {
+	it("wraps children in the shared full-width content container", () => {
+		render(
+			<PageContainer>
+				<p>content</p>
+			</PageContainer>,
+		);
+		const container = screen.getByText("content").parentElement;
+		// Fills the width (w-full), caps + centers only on ultra-wide (mx-auto +
+		// max-w-[1600px]) — not a narrow centered column.
+		expect(container?.className).toContain("w-full");
+		expect(container?.className).toContain("mx-auto");
+		expect(container?.className).toContain("max-w-[1600px]");
+		expect(container?.className).toContain("px-6");
+		expect(container?.className).toContain("py-8");
+	});
+
+	it("merges a caller className (e.g. space-y-6) onto the container", () => {
+		render(
+			<PageContainer className="space-y-6">
+				<p>spaced</p>
+			</PageContainer>,
+		);
+		const container = screen.getByText("spaced").parentElement;
+		expect(container?.className).toContain("space-y-6");
+		expect(container?.className).toContain("max-w-[1600px]");
+	});
+});

--- a/apps/dashboard/src/components/page-container.tsx
+++ b/apps/dashboard/src/components/page-container.tsx
@@ -1,0 +1,37 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+/**
+ * The single content container for dashboard content pages — Projects, Sources,
+ * Settings, Billing, Account, Workspaces. Fills the width available after the
+ * sidebar with consistent horizontal padding, capping + centering only on
+ * ultra-wide monitors. Replaces the per-page narrow `mx-auto max-w-*` columns
+ * (768–1040px) that left large left/right gaps, so every page lines up the same.
+ *
+ * NOT used by the inbox: that surface is a full-width three-pane with the
+ * bounded full-height layout the shell owns (h-full inside main), so it debars
+ * the padded/max-width container by design.
+ *
+ * `max-w-[1600px]` fills typical laptop/desktop widths edge-to-edge after the
+ * sidebar and only caps on genuinely wide displays; `px-6 sm:px-8` is the shared
+ * gutter, `py-8` the shared vertical rhythm.
+ */
+export function PageContainer({
+	className,
+	children,
+}: {
+	className?: string;
+	children: React.ReactNode;
+}) {
+	return (
+		<div
+			className={cn(
+				"mx-auto w-full max-w-[1600px] px-6 py-8 sm:px-8",
+				className,
+			)}
+		>
+			{children}
+		</div>
+	);
+}


### PR DESCRIPTION
## What

Dashboard-wide **layout/width consistency** pass. Pure layout — no features, data, backend, or component redesigns.

## The problem (map)

Every content page rolled its **own** width container, all narrow + centered, leaving large left/right gaps:

| Page | Before |
|---|---|
| Sources | `mx-auto max-w-3xl` (768px) |
| Account / Workspaces | `mx-auto w-full max-w-[800px] … p-6` |
| Settings (`[id]`) | `mx-auto max-w-[1000px]` (×2 + save bar) |
| Billing | `mx-auto w-full max-w-[1040px]` (skeleton: `max-w-2xl` 672px) |
| Projects grid | `mx-auto max-w-5xl` (1024px) |

No shared container existed — each page diverged.

## The fix

One container — **`components/page-container.tsx`**:

```
mx-auto w-full max-w-[1600px] px-6 py-8 sm:px-8
```

Fills the width available after the sidebar with a consistent gutter, and only caps + centers on genuinely ultra-wide displays. Applied to **Projects, Sources, Settings, Billing, Account, Workspaces** — they now line up identically. The Settings save bar inner width and `BillingSkeleton` were aligned to the same container (the latter removes a load-time width jump).

## Special layouts (left intact)

- **Inbox / Conversations** — full-width three-pane with the shell-owned bounded full-height layout (`h-full` inside `main`). It deliberately does **not** take the container; verified no height/scroll regression.
- **Onboarding, sign-in/up** — untouched (deliberate centered flows).

## Verification

- **Gates:** dashboard `tsc --noEmit` clean, **390 tests** (incl. new PageContainer test), lint + prettier clean.
- **Adversarial multi-agent review** (4 lenses × verify): caught one real issue — `BillingSkeleton` was still a narrow `max-w-2xl` column rendered outside the container (load-time width jump). **Fixed.** No other findings.
- **CDP screenshots at 1680px wide, Light + Dark, all six pages:** every content page fills the width with no wasted left/right gaps; **zero horizontal overflow** on any page (measured `scrollWidth === clientWidth`); main scrolls correctly; the inbox three-pane still works in both themes.
  - *Before* (e.g. Settings/Sources): content floated in a ~1000px/768px centered column with ~220px gaps each side.
  - *After*: content runs from just after the sidebar to near the right edge.

*(Screenshots captured locally via CDP and reviewed in the working session — before/after for Settings, Sources, Billing, Account, Projects, plus the unchanged inbox.)*

## Note

Billing's usage-summary card keeps its intentional inner `max-w-xl` (a single compact card; the plan **tiers** below fill the width). That's a component-level width, not the page container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
