### PR TITLE
feat(db): add conversation summary columns (phase 1 of #94)

### DIFF
--- a/apps/api/migrations/0014_conversation_summary.sql
+++ b/apps/api/migrations/0014_conversation_summary.sql
@@ -1,0 +1,19 @@
+-- One-line AI triage summary per conversation, shown in the inbox list/detail
+-- for at-a-glance scanning ("refund request for order #1234" instead of the raw
+-- last-message snippet). Generated lazily on-view by a cheap model and CACHED
+-- here; `summary_message_count` records the conversation.message_count the
+-- summary reflects (the staleness marker — regenerate when message_count
+-- advances). Both nullable: NULL `summary` = not generated yet (the UI falls
+-- back to the existing snippet, never a placeholder); NULL `summary_message_count`
+-- = never summarized. Additive ADD COLUMN matching the 0010 pattern; Ploy's
+-- ledger applies each file once, in filename order.
+--
+-- PHASE 1 of 2 (deliberate migrate-before-serve split). Ploy's deploy ordering
+-- between "apply migrations" and "new Worker serves traffic" is undocumented, so
+-- this PR ships ONLY the columns — schema.ts is intentionally NOT changed, so the
+-- live Worker never references a column that might not exist yet (the inbox is
+-- the hottest path; no read can 500 on a missing column under any ordering). The
+-- reading + generating code lands in a follow-up PR once these columns are live
+-- in prod.
+ALTER TABLE `conversation` ADD COLUMN `summary` text;
+ALTER TABLE `conversation` ADD COLUMN `summary_message_count` integer;

--- a/apps/api/src/seed.test.ts
+++ b/apps/api/src/seed.test.ts
@@ -44,6 +44,30 @@ describe("production migrations", () => {
 		db.close();
 	});
 
+	it("add the nullable conversation.summary + summary_message_count columns (0014)", () => {
+		// Phase 1 of the conversation-summary feature: the columns must exist in a
+		// freshly-migrated DB, both nullable (NULL = not summarized → snippet
+		// fallback). schema.ts deliberately doesn't declare them yet, so this is the
+		// ground-truth check that the migration applies cleanly.
+		const db = migratedDb();
+		const cols = db.prepare("PRAGMA table_info('conversation')").all() as {
+			name: string;
+			type: string;
+			notnull: number;
+		}[];
+		const byName = Object.fromEntries(cols.map((c) => [c.name, c]));
+		expect(byName.summary, "summary column").toBeTruthy();
+		expect(byName.summary.type.toUpperCase()).toContain("TEXT");
+		expect(byName.summary.notnull, "summary nullable").toBe(0);
+		expect(
+			byName.summary_message_count,
+			"summary_message_count column",
+		).toBeTruthy();
+		expect(byName.summary_message_count.type.toUpperCase()).toContain("INT");
+		expect(byName.summary_message_count.notnull, "marker nullable").toBe(0);
+		db.close();
+	});
+
 	it("contain no seed file (the dev seed lives outside migrations/)", () => {
 		const offending = readdirSync(MIGRATIONS_DIR)
 			.filter((f) => f.endsWith(".sql"))


### PR DESCRIPTION
## Phase 1 of 2 — migrate prod first (conversation summary, #94)

The approved design caches a one-line AI summary on the `conversation` row. Adding a column the inbox reads has a deploy-ordering hazard: **Ploy's ordering between applying migrations and the new Worker serving traffic is undocumented** (repo says only "applied on deploy, once, in filename order"; the Ploy docs have no zero-downtime/release-phase section). The inbox is the hottest path in the app, so we don't gamble on a brief "no such column" 500.

**So this is split two-phase** (the safe habit to lock in before customers):
- **This PR (phase 1):** add the columns to prod — and **nothing reads them**. `schema.ts` is intentionally unchanged, so the deployed Worker never references `summary`; the column just sits in the DB, unused. Safe under *any* deploy ordering, and it doesn't even break preview.
- **Phase 2 (follow-up, after this is live in prod):** `schema.ts` declaration + the summarize helper + the lazy on-view trigger + the inbox UI. By then the columns exist, so the reading code can't gap.

## Changes
- `migrations/0014_conversation_summary.sql` — `ALTER TABLE conversation ADD COLUMN summary text` + `ADD COLUMN summary_message_count integer`, both nullable (NULL `summary` → inbox snippet fallback; NULL marker → never summarized). Hand-authored, matching the 0010 CSAT precedent (the team hand-authors migrations; Ploy's ledger applies each once in filename order).
- `seed.test.ts` — asserts a freshly-migrated DB has both columns, both nullable.

## Verification
- 315 api tests pass (the migration runs in every e2e `:memory:` DB; the new test checks the columns via `PRAGMA table_info`), `tsc` clean, lint + prettier clean.
- No runtime behavior change: Drizzle selects only schema-declared columns, and `schema.ts` doesn't declare these yet, so an extra DB column is inert.

## Merge note
Merge this, let Ploy deploy it (columns live in prod), **then** I open phase 2. Sequencing the deploys is the whole point — phase 2 must not serve before these columns exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
