### PR TITLE
feat(inbox): one-line AI conversation summaries for triage (phase 2 of #94)

### DIFF
--- a/apps/api/src/lib/conversation-summary.test.ts
+++ b/apps/api/src/lib/conversation-summary.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+
+import { buildTranscript, summaryIsStale } from "./conversation-summary";
+
+describe("summaryIsStale (the cost-bound trigger)", () => {
+	it("not stale below the min-message threshold → snippet fallback", () => {
+		expect(
+			summaryIsStale({
+				messageCount: 1,
+				summary: null,
+				summaryMessageCount: null,
+			}),
+		).toBe(false);
+	});
+
+	it("stale when never summarized and there's a full exchange", () => {
+		expect(
+			summaryIsStale({
+				messageCount: 2,
+				summary: null,
+				summaryMessageCount: null,
+			}),
+		).toBe(true);
+	});
+
+	it("fresh when the cached marker matches the current count", () => {
+		expect(
+			summaryIsStale({ messageCount: 4, summary: "x", summaryMessageCount: 4 }),
+		).toBe(false);
+	});
+
+	it("NOT stale on a single new message (per-exchange delta, cost-aware)", () => {
+		expect(
+			summaryIsStale({ messageCount: 5, summary: "x", summaryMessageCount: 4 }),
+		).toBe(false);
+	});
+
+	it("stale once a full exchange (delta >= 2) has accrued", () => {
+		expect(
+			summaryIsStale({ messageCount: 6, summary: "x", summaryMessageCount: 4 }),
+		).toBe(true);
+	});
+});
+
+describe("buildTranscript", () => {
+	it("labels roles (visitor/agent/system) and drops empty messages", () => {
+		const t = buildTranscript([
+			{ role: "user", content: "Where is my order?" },
+			{ role: "assistant", content: "Let me check." },
+			{ role: "admin", content: "It ships Monday." },
+			{ role: "system", content: "" },
+		]);
+		expect(t).toContain("Visitor: Where is my order?");
+		expect(t).toContain("Agent: Let me check.");
+		expect(t).toContain("Agent: It ships Monday.");
+		expect(t).not.toContain("System:");
+	});
+
+	it("keeps the opener and truncates the middle when over budget", () => {
+		const lines = Array.from({ length: 500 }, (_, i) => ({
+			role: "user",
+			content: `line ${i} ${"x".repeat(40)}`,
+		}));
+		lines[0] = { role: "user", content: "OPENER the core intent" };
+		const t = buildTranscript(lines);
+		expect(t.startsWith("Visitor: OPENER the core intent")).toBe(true);
+		expect(t).toContain("…");
+		expect(t.length).toBeLessThan(6_500);
+	});
+
+	it("returns empty string when there's no usable content", () => {
+		expect(buildTranscript([{ role: "user", content: "   " }])).toBe("");
+	});
+});

--- a/apps/api/src/lib/conversation-summary.ts
+++ b/apps/api/src/lib/conversation-summary.ts
@@ -1,0 +1,102 @@
+import { conversation, eq } from "@llmchat/db";
+
+import { db } from "@/lib/db";
+import { summarizeConversation } from "@/lib/llm";
+
+import type { Env } from "@/env";
+
+/** One full exchange (visitor + reply) before a conversation is worth a summary;
+ * below this the inbox shows the message snippet. */
+export const SUMMARY_MIN_MESSAGES = 2;
+/** Regenerate only once the conversation has advanced by a full exchange since
+ * the cached summary — cost-aware (per-exchange, never per-message). */
+export const SUMMARY_STALE_DELTA = 2;
+/** Cap generations enqueued per inbox list fetch so the first load can't fan out
+ * a page's worth of gateway calls at once; the rest drain on later loads. */
+export const SUMMARY_PER_REQUEST_CAP = 8;
+/** Per-conversation cooldown (seconds) that also dedupes concurrent list fetches.
+ * The deployed state binding exposes only get/set (no put/TTL), so expiry is
+ * tracked in the stored value, mirroring lib/kv.ts. */
+const SUMMARY_COOLDOWN_SECONDS = 90;
+/** Chars of transcript handed to the model (~1.5k tokens). */
+const TRANSCRIPT_CHAR_BUDGET = 6_000;
+
+/** Is the cached summary missing or stale enough to (re)generate? Pure. */
+export function summaryIsStale(c: {
+	messageCount: number;
+	summary: string | null;
+	summaryMessageCount: number | null;
+}): boolean {
+	if (c.messageCount < SUMMARY_MIN_MESSAGES) return false;
+	if (c.summary === null || c.summaryMessageCount === null) return true;
+	return c.messageCount - c.summaryMessageCount >= SUMMARY_STALE_DELTA;
+}
+
+/** Role-labeled, length-bounded transcript: the opener (intent) is always kept,
+ * the recent tail (current state) fills the rest of the budget. Pure. */
+export function buildTranscript(
+	messages: { role: string; content: string }[],
+): string {
+	const label = (r: string) =>
+		r === "user" ? "Visitor" : r === "system" ? "System" : "Agent";
+	const lines = messages
+		.filter((m) => m.content.trim())
+		.map((m) => `${label(m.role)}: ${m.content.trim().replace(/\s+/g, " ")}`);
+	if (lines.length === 0) return "";
+	const joined = lines.join("\n");
+	if (joined.length <= TRANSCRIPT_CHAR_BUDGET) return joined;
+	// Cap the opener too, so a single huge first message can't blow the budget.
+	const head = lines[0].slice(0, TRANSCRIPT_CHAR_BUDGET);
+	const tailBudget = Math.max(0, TRANSCRIPT_CHAR_BUDGET - head.length - 2);
+	const tail = lines.slice(1).join("\n").slice(-tailBudget);
+	return `${head}\n…\n${tail}`;
+}
+
+/** Generate + persist a summary for one conversation. On generation failure
+ * writes NOTHING (the inbox keeps the snippet). Writes NO usageEvent — internal
+ * triage aid, off the customer's quota and billing. */
+async function generateAndStore(
+	env: Env,
+	conv: { id: string; messageCount: number },
+): Promise<void> {
+	const msgs = await db(env).query.message.findMany({
+		where: (m, { eq: e }) => e(m.conversationId, conv.id),
+		orderBy: (m, { asc }) => [asc(m.sequence)],
+		columns: { role: true, content: true },
+	});
+	const summary = await summarizeConversation(env, buildTranscript(msgs));
+	if (!summary) return;
+	await db(env)
+		.update(conversation)
+		.set({ summary, summaryMessageCount: conv.messageCount })
+		.where(eq(conversation.id, conv.id));
+}
+
+/** Best-effort dedup/cooldown around generation using the state binding (get/set
+ * only). Skips if this conversation was summarized within the cooldown; fails
+ * OPEN (a state outage must not block the summary). Intended for waitUntil. */
+export async function maybeSummarize(
+	env: Env,
+	conv: { id: string; messageCount: number },
+): Promise<void> {
+	const key = `summ:${conv.id}`;
+	const now = Math.floor(Date.now() / 1000);
+	try {
+		const raw = await env.STATE.get(key);
+		if (raw) {
+			const ts = Number(raw);
+			if (ts && now - ts < SUMMARY_COOLDOWN_SECONDS) return;
+		}
+		await env.STATE.set(key, String(now));
+	} catch {
+		// State unavailable — generate anyway rather than skip.
+	}
+	try {
+		await generateAndStore(env, conv);
+	} catch (err) {
+		// Detached (runs in waitUntil): swallow so a transient DB fault never
+		// surfaces as an unhandled rejection — the inbox just keeps the snippet
+		// until a later load retries.
+		console.warn("maybeSummarize: generation failed", err);
+	}
+}

--- a/apps/api/src/lib/llm.ts
+++ b/apps/api/src/lib/llm.ts
@@ -1,5 +1,10 @@
 import { createLLMGateway } from "@llmgateway/ai-sdk-provider";
-import { streamText, convertToModelMessages, type UIMessage } from "ai";
+import {
+	streamText,
+	generateText,
+	convertToModelMessages,
+	type UIMessage,
+} from "ai";
 
 import type { Env } from "@/env";
 
@@ -66,4 +71,45 @@ export async function streamChat(env: Env, input: LlmCallInput) {
 		system: buildSystem(input.systemPrompt, input.knowledgeText, input.sources),
 		messages: await convertToModelMessages(input.messages),
 	});
+}
+
+// Cheapest adequate model for internal one-line triage summaries (gateway
+// pricing ~$0.05/$0.40 per 1M tokens → ~0.009¢/summary). Hardcoded on purpose —
+// NOT routed through effectiveModel()/the web-search guard (that would coerce it
+// to the pricier agent default; summarizing an existing transcript needs no web
+// search). Internal, operator-absorbed cost.
+const SUMMARY_MODEL = "gpt-5-nano";
+
+const SUMMARY_SYSTEM =
+	'You write ONE short line summarizing a customer-support conversation for an agent scanning their inbox. Capture the visitor\'s core intent or issue — e.g. "Refund request for order #1234", "Asking about international shipping". Plain text, no surrounding quotes, no leading label like "Summary:". Max ~12 words.';
+
+/**
+ * One-line triage summary of a conversation transcript. Non-streaming, cheap
+ * model, tight output cap. Returns the trimmed line, or null on ANY failure — so
+ * the caller leaves the cache untouched and the inbox keeps showing the snippet,
+ * never a fabricated or partial summary. Writes nothing itself (no usageEvent).
+ */
+export async function summarizeConversation(
+	env: Env,
+	transcript: string,
+): Promise<string | null> {
+	if (!transcript.trim()) return null;
+	const gateway = createLLMGateway({
+		apiKey: env.vars.LLMGATEWAY_API_KEY,
+		baseURL: env.vars.LLMGATEWAY_BASE_URL,
+	});
+	try {
+		const { text } = await generateText({
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			model: gateway(SUMMARY_MODEL as any),
+			system: SUMMARY_SYSTEM,
+			prompt: transcript,
+			maxOutputTokens: 60,
+		});
+		const line = text.trim().replace(/\s+/g, " ");
+		return line || null;
+	} catch (err) {
+		console.warn("summarizeConversation: generation failed", err);
+		return null;
+	}
 }

--- a/apps/api/src/routes/conversations.ts
+++ b/apps/api/src/routes/conversations.ts
@@ -2,6 +2,11 @@ import { zValidator } from "@hono/zod-validator";
 import { Hono } from "hono";
 import { z } from "zod";
 
+import {
+	maybeSummarize,
+	SUMMARY_PER_REQUEST_CAP,
+	summaryIsStale,
+} from "@/lib/conversation-summary";
 import { decodeCursor, encodeCursor } from "@/lib/cursor";
 import { db } from "@/lib/db";
 import { buildReplyToAddress, escapeHtml, sendEmail } from "@/lib/email";
@@ -71,6 +76,10 @@ export const conversations = new Hono<AppContext>()
 				// Comma-separated tag ids. OR semantics (a conversation matches if it
 				// has ANY of them). Empty/absent ⇒ no tag filtering.
 				tagIds: z.string().optional(),
+				// Lazy-summary trigger. Set ("1") on genuine loads/scrolls, NEVER on
+				// the 5s freshness poll — so summary generation scales with views, not
+				// poll cadence. Absent ⇒ pure read.
+				summarize: z.coerce.boolean().optional(),
 			}),
 		),
 		async (c) => {
@@ -301,6 +310,22 @@ export const conversations = new Hono<AppContext>()
 					const list = tagsByConv.get(t.conversationId) ?? [];
 					list.push({ id: t.id, name: t.name, color: t.color });
 					tagsByConv.set(t.conversationId, list);
+				}
+			}
+
+			// Lazy triage summaries: on a genuine load/scroll (summarize=1, never the
+			// 5s poll), enqueue async generation for stale conversations on this page
+			// — capped + cooldown-deduped, and OFF the customer's quota (writes no
+			// usageEvent). The list returns immediately with whatever summaries are
+			// cached; freshly-generated ones appear on the next load.
+			if (c.req.valid("query").summarize) {
+				const stale = rows
+					.filter((r) => summaryIsStale(r))
+					.slice(0, SUMMARY_PER_REQUEST_CAP);
+				for (const r of stale) {
+					c.executionCtx.waitUntil(
+						maybeSummarize(c.env, { id: r.id, messageCount: r.messageCount }),
+					);
 				}
 			}
 

--- a/apps/dashboard/src/app/inbox/_components/ConversationList.test.tsx
+++ b/apps/dashboard/src/app/inbox/_components/ConversationList.test.tsx
@@ -143,6 +143,51 @@ describe("ConversationList", () => {
 		expect(screen.getByText("ada@example.com")).toBeInTheDocument();
 	});
 
+	it("prefers the AI summary over the first-message snippet in the preview", () => {
+		setup({
+			conversations: [
+				conv({
+					id: "s",
+					summary: "Refund request for order #1234",
+					firstMessage: "How do I reset my device?",
+				}),
+			],
+		});
+		expect(
+			screen.getByText("Refund request for order #1234"),
+		).toBeInTheDocument();
+		// The summary replaces the raw snippet — no double preview line.
+		expect(
+			screen.queryByText("How do I reset my device?"),
+		).not.toBeInTheDocument();
+	});
+
+	it("falls back to the snippet when no summary exists yet (honest, no placeholder)", () => {
+		setup({
+			conversations: [
+				conv({ id: "s", summary: null, firstMessage: "Where is my order?" }),
+			],
+		});
+		expect(screen.getByText("Where is my order?")).toBeInTheDocument();
+	});
+
+	it("lets a search match still win over the summary while searching", () => {
+		setup({
+			search: "refund",
+			conversations: [
+				conv({
+					id: "s",
+					summary: "Asking about shipping times",
+					match: { field: "body", snippet: "our refund policy is 30 days" },
+				}),
+			],
+		});
+		expect(screen.getByText("refund").tagName).toBe("MARK");
+		expect(
+			screen.queryByText("Asking about shipping times"),
+		).not.toBeInTheDocument();
+	});
+
 	it("reports the selected conversation upward", async () => {
 		const user = userEvent.setup();
 		const { onSelect } = setup();

--- a/apps/dashboard/src/app/inbox/_components/ConversationList.tsx
+++ b/apps/dashboard/src/app/inbox/_components/ConversationList.tsx
@@ -101,7 +101,8 @@ function ConversationRow({
 								: "text-ck-muted",
 						)}
 					>
-						{conversation.firstMessage?.trim() ||
+						{conversation.summary?.trim() ||
+							conversation.firstMessage?.trim() ||
 							conversation.email ||
 							"No messages yet"}
 					</p>

--- a/apps/dashboard/src/app/inbox/_components/types.ts
+++ b/apps/dashboard/src/app/inbox/_components/types.ts
@@ -25,6 +25,9 @@ export interface Conversation {
 	csatRating: number | null;
 	/** First visitor message, used as the list preview (added by the list API). */
 	firstMessage?: string | null;
+	/** One-line AI triage summary (added by the list API; null until generated).
+	 * Preferred over firstMessage in the preview; null → snippet fallback. */
+	summary?: string | null;
 	/** True when the current user hasn't seen the latest messages. */
 	unread?: boolean;
 	/** Why this conversation matched the active search: an excerpt + which field

--- a/apps/dashboard/src/app/inbox/page.tsx
+++ b/apps/dashboard/src/app/inbox/page.tsx
@@ -118,12 +118,15 @@ export default function InboxPage() {
 	// Stable joined key for the tag filter so it slots into query keys + params.
 	const tagFilterKey = tagIds.join(",");
 	const listParams = useCallback(
-		(cursor?: string) => {
+		(cursor?: string, summarize?: boolean) => {
 			const params = new URLSearchParams({ limit: String(PAGE_SIZE) });
 			if (debouncedSearch) params.set("search", debouncedSearch);
 			params.set("status", status);
 			if (tagFilterKey) params.set("tagIds", tagFilterKey);
 			if (cursor) params.set("cursor", cursor);
+			// Trigger lazy summary generation only on genuine loads/scrolls — never
+			// on the 5s head poll, which stays a pure read.
+			if (summarize) params.set("summarize", "1");
 			return params.toString();
 		},
 		[debouncedSearch, status, tagFilterKey],
@@ -145,7 +148,7 @@ export default function InboxPage() {
 		initialPageParam: undefined as string | undefined,
 		queryFn: ({ pageParam }) =>
 			api<ConversationPage>(
-				`/api/projects/${projectId}/conversations?${listParams(pageParam)}`,
+				`/api/projects/${projectId}/conversations?${listParams(pageParam, true)}`,
 				{ workspaceId: workspaceId! },
 			),
 		getNextPageParam: (last) => last.nextCursor ?? undefined,
@@ -601,6 +604,11 @@ export default function InboxPage() {
 								<p className="truncate text-sm font-bold text-ck-text">
 									{detailConv.name ?? "Anonymous"}
 								</p>
+								{detailConv.summary && (
+									<p className="truncate text-xs text-ck-muted">
+										{detailConv.summary}
+									</p>
+								)}
 								<p className="truncate text-xs text-ck-faint">
 									{threadSubtitle}
 								</p>

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -182,6 +182,13 @@ export const conversation = sqliteTable(
 		// unrated. Distinct from per-message thumbs (message.rating). Range is
 		// enforced in the /v1/csat route, not by a DB constraint.
 		csatRating: integer(),
+		// One-line AI triage summary for the inbox (cached). Nullable: NULL = not
+		// generated yet → the inbox falls back to the message snippet, never a
+		// placeholder. `summaryMessageCount` is the messageCount the summary
+		// reflects (staleness marker — regenerate once messageCount advances).
+		// Columns were shipped ahead of this code in migration 0014 (phase 1).
+		summary: text(),
+		summaryMessageCount: integer(),
 		createdAt: createdAt(),
 		updatedAt: timestamp()
 			.notNull()


### PR DESCRIPTION
## Phase 2 of 2 — the feature (conversation summary, #94)

Phase 1 (#76) shipped the `conversation.summary` / `summary_message_count` columns to prod, unused. This PR adds the code that reads + generates them. **Merge after #76 has deployed to prod** (it's already merged; columns are live) — that ordering is the whole point of the two-phase split.

A one-line AI summary per conversation, shown in the inbox list + thread header for at-a-glance triage. Built to the approved design.

## Trigger — cost-aware (the lever)
Lazy, cached, staleness-gated. `?summarize=1` is set **only on genuine loads/scrolls** (the infinite list query), **never** the 5s freshness poll — so cost scales with conversations *viewed*, not poll cadence or message volume. The list handler enqueues async generation (`waitUntil`) for stale rows and returns immediately; summaries land on the next load. Staleness = `messageCount >= 2` AND (never summarized OR advanced a full exchange, `delta >= 2`); plus a per-request cap (8) and a 90s per-conversation cooldown (state `get`/`set`). The summary is a **denormalized column read at list time**, never computed per render.

## Model + cost
`gpt-5-nano`, non-streaming, `maxOutputTokens: 60` — **~0.009¢/summary**, hardcoded so it bypasses the agent web-search guard (no web search to summarize a transcript). try/catch → `null` on any failure.

## Metering — absorbed, provably non-metered
The summary path writes **no `usageEvent`** and never calls `reportMeterEvent`. Quota is counted by `usageEvent` rows (`plan.ts`) and overage fires only from `chat.ts` — so summaries are **off the customer's monthly quota and Stripe overage**. The gateway token cost lands on the shared operator key (absorbed; <$10/mo even at 100k calls).

## Honest fallback
List-row preview precedence: **search-match → summary → first-message snippet → email → "No messages yet"**. Thread header shows the summary only when present. A missing/failed summary leaves the cache untouched → the real snippet shows. Never a fabricated or "generating…" placeholder.

## Verification
- **Gates:** 323 api + 393 dashboard tests, both `tsc`, lint + prettier — all green.
- **Adversarial review** (5 lenses × verify): **0 confirmed defects**; 2 low-confidence nits, both applied (guard the `waitUntil` task's rejection for tidy logs; cap an oversized transcript opener).
- **Live round-trip** (dev, real gateway): `?summarize=1` returned in **19ms** (async), then two real conversations got cached summaries — *"Do you ship internationally?"* → **"International shipping availability inquiry"**, *"When do you restock?"* → **"Question about restock schedule."** (`summaryMessageCount=2`). Snippet showed until they landed. Screenshots confirm the summaries in the inbox list rows and the thread header.

## Scope
Additive only — does not touch the agent's retrieval/answer path. No new migration (0014 shipped in phase 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
