### PR TITLE
feat(auth): email-verification flow — close account squatting (security PR2b)

### DIFF
--- a/apps/api/src/auth.emailverification.e2e.test.ts
+++ b/apps/api/src/auth.emailverification.e2e.test.ts
@@ -1,0 +1,202 @@
+// End-to-end proof of the email-verification gate (PR2b) against the REAL Better
+// Auth handler + a real sqlite DB. Only @/lib/db (proxy) and @/lib/email's
+// sendEmail (to capture the link/token) are mocked. Asserts: credential sign-up
+// issues NO session and leaves the user unverified; clicking the link verifies +
+// creates a session (autoSignInAfterVerification); unverified sign-in is blocked
+// 403; the link is built with the fixed dashboard callbackURL. OAuth's
+// pass-through is proven separately in auth.linking.e2e.test.ts.
+
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+
+import { drizzle } from "drizzle-orm/sqlite-proxy";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { schema } from "@llmchat/db";
+
+import type { Env } from "@/env";
+
+vi.mock("@/lib/db", () => ({ db: vi.fn() }));
+// Keep buildVerificationEmail real; capture sendEmail to read the link + token.
+vi.mock("@/lib/email", async (orig) => ({
+	...(await orig<typeof import("@/lib/email")>()),
+	sendEmail: vi.fn(async () => ({ id: "email_1" })),
+}));
+import { db } from "@/lib/db";
+import { sendEmail } from "@/lib/email";
+import { createAuth } from "@/auth";
+
+function applyMigrations(sqlite: DatabaseSync) {
+	sqlite.exec("PRAGMA foreign_keys=OFF;");
+	const dir = join(process.cwd(), "migrations");
+	for (const f of readdirSync(dir)
+		.filter((x) => x.endsWith(".sql"))
+		.sort()) {
+		sqlite.exec(
+			readFileSync(join(dir, f), "utf8")
+				.split("--> statement-breakpoint")
+				.join("\n"),
+		);
+	}
+}
+
+function makeProxy(sqlite: DatabaseSync) {
+	const exec = async (sql: string, params: unknown[], method: string) => {
+		const stmt = sqlite.prepare(sql);
+		if (method === "run") {
+			stmt.run(...(params as never[]));
+			return { rows: [] };
+		}
+		const rows = stmt
+			.all(...(params as never[]))
+			.map((r) => Object.values(r as object));
+		return { rows: method === "get" ? (rows[0] as never) : rows };
+	};
+	const batch = async (
+		queries: { sql: string; params: unknown[]; method: string }[],
+	) =>
+		queries.map((q) => {
+			const stmt = sqlite.prepare(q.sql);
+			if (q.method === "run") {
+				stmt.run(...(q.params as never[]));
+				return { rows: [] };
+			}
+			const rows = stmt
+				.all(...(q.params as never[]))
+				.map((o) => Object.values(o as object));
+			return { rows: q.method === "get" ? (rows[0] as never) : rows };
+		});
+	return drizzle(exec, batch, { schema, casing: "snake_case" });
+}
+
+function makeEnv(): Env {
+	const store = new Map<string, string>();
+	return {
+		vars: {
+			BETTER_AUTH_SECRET: "x".repeat(32),
+			BETTER_AUTH_URL: "http://localhost:8787",
+			DASHBOARD_URL: "http://localhost:3001",
+			MARKETING_URL: "http://localhost:3002",
+			SHOWCASE_URL: "http://localhost:3003",
+			TRUSTED_CLIENT_IP_HEADER: "cf-connecting-ip",
+		},
+		DB: {},
+		STATE: {
+			get: vi.fn(async (k: string) => store.get(k) ?? null),
+			set: vi.fn(async (k: string, v: string) => {
+				store.set(k, v);
+			}),
+		},
+	} as unknown as Env;
+}
+
+const PASSWORD = "verify-me-12345";
+
+function signUpRequest(email: string, ip = "203.0.113.30") {
+	return new Request("http://localhost:8787/api/auth/sign-up/email", {
+		method: "POST",
+		headers: {
+			"content-type": "application/json",
+			"cf-connecting-ip": ip,
+			origin: "http://localhost:3001",
+		},
+		body: JSON.stringify({ email, password: PASSWORD, name: "Tester" }),
+	});
+}
+
+describe("email verification — credential path", () => {
+	let sqlite: DatabaseSync;
+	beforeEach(() => {
+		sqlite = new DatabaseSync(":memory:");
+		applyMigrations(sqlite);
+		vi.mocked(db).mockReturnValue(makeProxy(sqlite) as never);
+		vi.mocked(sendEmail).mockClear();
+	});
+
+	function userVerified(email: string) {
+		return (
+			sqlite
+				.prepare("SELECT email_verified FROM user WHERE email = ?")
+				.get(email) as { email_verified: number } | undefined
+		)?.email_verified;
+	}
+	const sessionCount = () =>
+		(sqlite.prepare("SELECT count(*) AS c FROM session").get() as { c: number })
+			.c;
+
+	it("sign-up creates an UNVERIFIED user, issues NO session, and sends a verification email", async () => {
+		const auth = createAuth(makeEnv());
+		const res = await auth.handler(signUpRequest("newuser@example.com"));
+
+		expect(res.status).toBeLessThan(400);
+		expect(userVerified("newuser@example.com")).toBe(0);
+		expect(sessionCount()).toBe(0); // gated: no auto-session
+		expect(sendEmail).toHaveBeenCalledTimes(1);
+		expect(vi.mocked(sendEmail).mock.calls[0]![1].to).toBe(
+			"newuser@example.com",
+		);
+	});
+
+	it("the verification link uses /api/auth/verify-email + the fixed dashboard callbackURL", async () => {
+		const auth = createAuth(makeEnv());
+		await auth.handler(signUpRequest("link@example.com"));
+
+		const text = vi.mocked(sendEmail).mock.calls[0]![1].text!;
+		expect(text).toContain(
+			"http://localhost:8787/api/auth/verify-email?token=",
+		);
+		expect(text).toContain(
+			encodeURIComponent("http://localhost:3001/verify-email"),
+		);
+	});
+
+	it("clicking the link verifies the email AND creates a session (autoSignInAfterVerification)", async () => {
+		const auth = createAuth(makeEnv());
+		await auth.handler(signUpRequest("verify@example.com"));
+
+		const token = /token=([^&]+)/.exec(
+			vi.mocked(sendEmail).mock.calls[0]![1].text!,
+		)![1];
+		const callbackURL = encodeURIComponent(
+			"http://localhost:3001/verify-email",
+		);
+		const res = await auth.handler(
+			new Request(
+				`http://localhost:8787/api/auth/verify-email?token=${token}&callbackURL=${callbackURL}`,
+				{ headers: { origin: "http://localhost:3001" } },
+			),
+		);
+
+		// Success → redirect to the callbackURL with NO error param.
+		expect(res.status).toBe(302);
+		const location = res.headers.get("location") ?? "";
+		expect(location).toContain("localhost:3001/verify-email");
+		expect(location).not.toContain("error=");
+
+		expect(userVerified("verify@example.com")).toBe(1);
+		expect(sessionCount()).toBeGreaterThanOrEqual(1);
+	});
+
+	it("an unverified credential sign-in is blocked with 403", async () => {
+		const auth = createAuth(makeEnv());
+		await auth.handler(signUpRequest("blocked@example.com"));
+
+		const res = await auth.handler(
+			new Request("http://localhost:8787/api/auth/sign-in/email", {
+				method: "POST",
+				headers: {
+					"content-type": "application/json",
+					"cf-connecting-ip": "203.0.113.31",
+					origin: "http://localhost:3001",
+				},
+				body: JSON.stringify({
+					email: "blocked@example.com",
+					password: PASSWORD,
+				}),
+			}),
+		);
+
+		expect(res.status).toBe(403);
+	});
+});

--- a/apps/api/src/auth.linking.e2e.test.ts
+++ b/apps/api/src/auth.linking.e2e.test.ts
@@ -182,6 +182,26 @@ describe("account-takeover fix — implicit OAuth linking", () => {
 		expect((res.data as { user: { id: string } }).user.id).toBe("new-user");
 	});
 
+	it("NON-REGRESSION: OAuth signup is NOT subject to the email-verification gate — a provider-verified user gets a session immediately", async () => {
+		// requireEmailVerification (PR2b) gates ONLY the credential path.
+		// handleOAuthUserInfo never consults it: a fresh Google identity
+		// (emailVerified:true) is created and a session is issued with no
+		// verification step — exactly the live prod behavior we must not regress.
+		const adapter = makeAdapter(null); // no existing user → fresh OAuth signup
+		const c = makeContext(
+			{ enabled: true, disableImplicitLinking: true },
+			adapter,
+			[],
+		);
+
+		const res = await handleOAuthUserInfo(c as never, OPTS as never);
+
+		expect(adapter.createOAuthUser).toHaveBeenCalledTimes(1);
+		expect(adapter.createSession).toHaveBeenCalledWith("new-user");
+		expect(res.error).toBeNull();
+		expect(res.data).not.toBeNull();
+	});
+
 	it("NON-REGRESSION: re-signin with an ALREADY-linked Google account issues a session and does not re-link", async () => {
 		// The everyday flow for an existing OAuth user. disableImplicitLinking must
 		// only block linking into a NON-linked account; it must not interfere here.

--- a/apps/api/src/auth.ratelimit.e2e.test.ts
+++ b/apps/api/src/auth.ratelimit.e2e.test.ts
@@ -182,29 +182,50 @@ describe("durable auth rate limiting (cross-isolate)", () => {
 	});
 
 	it("keeps SESSIONS in D1, never in STATE — the delete-cascade contract", async () => {
-		// customStorage (not secondaryStorage) must mean a sign-up's session lands in
-		// the D1 `session` table and STATE holds ONLY rate-limit buckets. If a future
+		// customStorage (not secondaryStorage) must mean a real session lands in the
+		// D1 `session` table and STATE holds ONLY rate-limit buckets. If a future
 		// change relocated sessions to STATE, the FK-based delete cascade would orphan
-		// them — this guards exactly that.
+		// them — this guards exactly that. (Sign-up no longer auto-sessions under the
+		// PR2b email-verification gate, so verify the user then sign in to mint one.)
 		const { store, STATE } = freshStore();
 		const auth = createAuth(makeEnv(STATE));
+		const email = "fresh@example.com";
+		const password = "whatever123";
+		const headers = {
+			"content-type": "application/json",
+			"cf-connecting-ip": "203.0.113.20",
+			origin: "http://localhost:3001",
+		};
 
-		const res = await auth.handler(
+		const signUp = await auth.handler(
 			new Request("http://localhost:8787/api/auth/sign-up/email", {
 				method: "POST",
-				headers: {
-					"content-type": "application/json",
-					"cf-connecting-ip": "203.0.113.20",
-					origin: "http://localhost:3001",
-				},
-				body: JSON.stringify({
-					email: "fresh@example.com",
-					password: "whatever123",
-					name: "Fresh",
-				}),
+				headers,
+				body: JSON.stringify({ email, password, name: "Fresh" }),
 			}),
 		);
-		expect(res.status).toBeLessThan(400);
+		expect(signUp.status).toBeLessThan(400);
+		// Gated: sign-up issues no session.
+		expect(
+			(
+				sqlite.prepare("SELECT count(*) AS c FROM session").get() as {
+					c: number;
+				}
+			).c,
+		).toBe(0);
+
+		// Mark verified (stand-in for clicking the link) so sign-in can mint a session.
+		sqlite
+			.prepare("UPDATE user SET email_verified = 1 WHERE email = ?")
+			.run(email);
+		const signIn = await auth.handler(
+			new Request("http://localhost:8787/api/auth/sign-in/email", {
+				method: "POST",
+				headers,
+				body: JSON.stringify({ email, password }),
+			}),
+		);
+		expect(signIn.status).toBeLessThan(400);
 
 		const sessions = sqlite
 			.prepare("SELECT count(*) AS c FROM session")

--- a/apps/api/src/auth.test.ts
+++ b/apps/api/src/auth.test.ts
@@ -76,6 +76,16 @@ describe("buildAuthOptions", () => {
 		});
 	});
 
+	it("requires email verification on the credential path and wires the verification email", () => {
+		const opts = buildAuthOptions(env());
+		expect(opts.emailAndPassword.requireEmailVerification).toBe(true);
+		expect(opts.emailVerification.sendOnSignUp).toBe(true);
+		expect(opts.emailVerification.autoSignInAfterVerification).toBe(true);
+		expect(typeof opts.emailVerification.sendVerificationEmail).toBe(
+			"function",
+		);
+	});
+
 	it("enables durable rate limiting backed by a customStorage (not secondaryStorage, so sessions stay in D1)", () => {
 		const rl = buildAuthOptions(env()).rateLimit;
 		expect(rl.enabled).toBe(true);

--- a/apps/api/src/auth.ts
+++ b/apps/api/src/auth.ts
@@ -3,6 +3,7 @@ import { drizzleAdapter } from "better-auth/adapters/drizzle";
 
 import { createAuthRateLimitStorage } from "@/lib/auth-rate-limit-storage";
 import { db } from "@/lib/db";
+import { buildVerificationEmail, sendEmail } from "@/lib/email";
 import { isAllowedOrigin } from "@/lib/origins";
 import { defaultWorkspaceName, provisionWorkspace } from "@/lib/provisioning";
 import { trustedIpHeaders } from "@/lib/request";
@@ -87,8 +88,30 @@ export function buildAuthOptions(env: Env) {
 			// rules. Better Auth hashes with scrypt.
 			minPasswordLength: 8,
 			maxPasswordLength: 128,
-			// Issue a session on sign-up so the user lands straight in onboarding.
+			// autoSignIn is inert while requireEmailVerification is on (sign-up
+			// returns no session until verified), kept for intent.
 			autoSignIn: true,
+			// SECURITY (account squatting): a new email/password user must prove they
+			// own the address before they get a session. Sign-up creates the row but
+			// issues NO session; sign-in is blocked (403 EMAIL_NOT_VERIFIED, BA
+			// auto-resends) until verified. This gates ONLY the credential path —
+			// OAuth (Google/GitHub) arrives emailVerified from the provider and is
+			// untouched (the callback issues a session with no verify step).
+			requireEmailVerification: true,
+		},
+		// Verification email transport. Sends on sign-up; clicking the link verifies
+		// + auto-signs-in. The link is built deterministically here with a fixed
+		// dashboard callbackURL (one trusted landing for both success and the
+		// ?error=... case), rather than relying on the per-trigger callbackURL.
+		emailVerification: {
+			sendOnSignUp: true,
+			autoSignInAfterVerification: true,
+			sendVerificationEmail: async ({ user: u, token }) => {
+				const callbackURL = `${env.vars.DASHBOARD_URL}/verify-email`;
+				const verifyUrl = `${env.vars.BETTER_AUTH_URL}/api/auth/verify-email?token=${token}&callbackURL=${encodeURIComponent(callbackURL)}`;
+				const { subject, html, text } = buildVerificationEmail(verifyUrl);
+				await sendEmail(env, { to: u.email, subject, html, text });
+			},
 		},
 		// Google + GitHub, included only when their env credentials are set (see
 		// buildSocialProviders). A social sign-up inserts a `user` row, which fires

--- a/apps/api/src/lib/email.ts
+++ b/apps/api/src/lib/email.ts
@@ -55,3 +55,26 @@ export function escapeHtml(text: string) {
 	};
 	return text.replace(/[&<>"']/g, (c) => map[c] ?? c);
 }
+
+/** Subject/html/text for the email-verification message. The link is escaped for
+ * the href (the `&` between token & callbackURL must become `&amp;`). Kept brand-
+ * plain — this is the account email, not customer-facing support agent copy. */
+export function buildVerificationEmail(verifyUrl: string): {
+	subject: string;
+	html: string;
+	text: string;
+} {
+	const href = escapeHtml(verifyUrl);
+	return {
+		subject: "Verify your email for Clanker Support",
+		text: `Confirm your email to finish setting up your Clanker Support account:\n\n${verifyUrl}\n\nThis link expires shortly. If you didn't create an account, you can ignore this email.`,
+		html: `<div style="font-family:system-ui,-apple-system,Segoe UI,Roboto,sans-serif;max-width:480px;margin:0 auto;color:#1a1a1a">
+<h1 style="font-size:20px;margin:0 0 12px">Verify your email</h1>
+<p style="margin:0 0 20px;line-height:1.5">Confirm your email to finish setting up your Clanker Support account.</p>
+<p style="margin:0 0 24px"><a href="${href}" style="display:inline-block;background:#4f46e5;color:#fff;text-decoration:none;padding:10px 18px;border-radius:8px;font-weight:600">Verify email</a></p>
+<p style="margin:0 0 8px;font-size:13px;color:#666">Or paste this link into your browser:</p>
+<p style="margin:0 0 24px;font-size:13px;word-break:break-all"><a href="${href}" style="color:#4f46e5">${href}</a></p>
+<p style="margin:0;font-size:12px;color:#999">This link expires shortly. If you didn't create an account, you can ignore this email.</p>
+</div>`,
+	};
+}

--- a/apps/dashboard/src/app/sign-in/page.test.tsx
+++ b/apps/dashboard/src/app/sign-in/page.test.tsx
@@ -1,0 +1,88 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { toast } from "sonner";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { signIn } from "@/lib/auth-client";
+
+import SignInPage from "./page";
+
+vi.mock("@/lib/auth-client", () => ({
+	signIn: { email: vi.fn() },
+	sendVerificationEmail: vi.fn(async () => ({ error: null })),
+}));
+vi.mock("@/lib/analytics", () => ({
+	track: vi.fn(),
+	ANALYTICS_EVENTS: { signedIn: "signed_in" },
+}));
+vi.mock("@/lib/oauth", () => ({
+	fetchOAuthProviders: vi.fn(async () => ({ google: false, github: false })),
+	startSocialSignIn: vi.fn(),
+}));
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+function renderPage() {
+	const client = new QueryClient({
+		defaultOptions: { queries: { retry: false } },
+	});
+	render(
+		<QueryClientProvider client={client}>
+			<SignInPage />
+		</QueryClientProvider>,
+	);
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("SignInPage — unverified email", () => {
+	it("shows the inline verify notice + resend when sign-in returns EMAIL_NOT_VERIFIED (403)", async () => {
+		vi.mocked(signIn.email).mockResolvedValue({
+			data: null,
+			error: {
+				code: "EMAIL_NOT_VERIFIED",
+				status: 403,
+				message: "not verified",
+			},
+		} as never);
+		renderPage();
+
+		await userEvent.type(
+			screen.getByLabelText(/^email$/i),
+			"blocked@example.com",
+		);
+		await userEvent.type(screen.getByLabelText(/^password$/i), "verylongpass");
+		await userEvent.click(screen.getByRole("button", { name: /^sign in$/i }));
+
+		await waitFor(() =>
+			expect(
+				screen.getByText(/verify your email to sign in/i),
+			).toBeInTheDocument(),
+		);
+		expect(screen.getByText("blocked@example.com")).toBeInTheDocument();
+		expect(
+			screen.getByRole("button", { name: /resend link/i }),
+		).toBeInTheDocument();
+	});
+
+	it("does NOT show the verify notice for invalid credentials (401) — falls back to the generic toast", async () => {
+		vi.mocked(signIn.email).mockResolvedValue({
+			data: null,
+			error: {
+				code: "INVALID_EMAIL_OR_PASSWORD",
+				status: 401,
+				message: "Invalid email or password",
+			},
+		} as never);
+		renderPage();
+
+		await userEvent.type(screen.getByLabelText(/^email$/i), "user@example.com");
+		await userEvent.type(screen.getByLabelText(/^password$/i), "wrongpass123");
+		await userEvent.click(screen.getByRole("button", { name: /^sign in$/i }));
+
+		await waitFor(() => expect(toast.error).toHaveBeenCalled());
+		expect(
+			screen.queryByText(/verify your email to sign in/i),
+		).not.toBeInTheDocument();
+	});
+});

--- a/apps/dashboard/src/app/sign-in/page.tsx
+++ b/apps/dashboard/src/app/sign-in/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { ArrowRight, Eye, EyeOff, Lock, Mail } from "lucide-react";
+import { AlertCircle, ArrowRight, Eye, EyeOff, Lock, Mail } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
 
@@ -13,6 +13,7 @@ import { Input } from "@/components/ui/input";
 import { signIn } from "@/lib/auth-client";
 import { track, ANALYTICS_EVENTS } from "@/lib/analytics";
 import { fieldErrors, signInSchema } from "@/lib/auth-schema";
+import { useResendVerification } from "@/lib/use-resend-verification";
 
 export default function SignInPage() {
 	const [email, setEmail] = useState("");
@@ -21,6 +22,8 @@ export default function SignInPage() {
 	const [remember, setRemember] = useState(true);
 	const [errors, setErrors] = useState<Record<string, string>>({});
 	const [loading, setLoading] = useState(false);
+	const [unverifiedEmail, setUnverifiedEmail] = useState<string | null>(null);
+	const { resend, sending, cooldown } = useResendVerification();
 
 	async function handleSubmit(e: React.FormEvent) {
 		e.preventDefault();
@@ -38,6 +41,15 @@ export default function SignInPage() {
 		});
 		if (res.error) {
 			setLoading(false);
+			// Unverified email: Better Auth returns EMAIL_NOT_VERIFIED and has already
+			// auto-resent the link. Match on the stable `code` only — NOT status 403 —
+			// so a future error that also 403s can't be mistaken for "unverified"
+			// (bad credentials are 401). Worst case it degrades to the generic toast.
+			if (res.error.code === "EMAIL_NOT_VERIFIED") {
+				setUnverifiedEmail(parsed.data.email);
+				return;
+			}
+			setUnverifiedEmail(null);
 			toast.error("Sign in failed", {
 				description: res.error.message ?? undefined,
 			});
@@ -58,6 +70,31 @@ export default function SignInPage() {
 			heading={<>Welcome back 👋</>}
 			subheading="Sign in to your Clanker Support dashboard"
 		>
+			{unverifiedEmail && (
+				<div className="mb-4 flex flex-col gap-3 rounded-lg border border-primary/30 bg-primary/10 p-3">
+					<div className="flex items-start gap-3">
+						<AlertCircle className="mt-0.5 size-4 shrink-0 text-primary" />
+						<p className="text-sm">
+							Verify your email to sign in. We re-sent a link to{" "}
+							<span className="font-medium break-all">{unverifiedEmail}</span>.
+						</p>
+					</div>
+					<Button
+						type="button"
+						variant="outline"
+						size="sm"
+						className="self-start"
+						disabled={sending || cooldown > 0}
+						onClick={() => resend(unverifiedEmail)}
+					>
+						{cooldown > 0
+							? `Resend in ${cooldown}s`
+							: sending
+								? "Sending…"
+								: "Resend link"}
+					</Button>
+				</div>
+			)}
 			<form onSubmit={handleSubmit} noValidate className="flex flex-col gap-4">
 				<FormField id="email" label="Email" error={errors.email}>
 					<div className="relative">

--- a/apps/dashboard/src/app/sign-up/page.test.tsx
+++ b/apps/dashboard/src/app/sign-up/page.test.tsx
@@ -1,0 +1,64 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { signUp } from "@/lib/auth-client";
+
+import SignUpPage from "./page";
+
+vi.mock("@/lib/auth-client", () => ({
+	signUp: { email: vi.fn() },
+	sendVerificationEmail: vi.fn(async () => ({ error: null })),
+}));
+vi.mock("@/lib/analytics", () => ({
+	track: vi.fn(),
+	ANALYTICS_EVENTS: { signupCompleted: "signup_completed" },
+}));
+vi.mock("@/lib/oauth", () => ({
+	fetchOAuthProviders: vi.fn(async () => ({ google: false, github: false })),
+	startSocialSignIn: vi.fn(),
+}));
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+function renderPage() {
+	const client = new QueryClient({
+		defaultOptions: { queries: { retry: false } },
+	});
+	render(
+		<QueryClientProvider client={client}>
+			<SignUpPage />
+		</QueryClientProvider>,
+	);
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("SignUpPage — email verification", () => {
+	it("shows the 'check your email' notice (address + resend) after a successful signup, without navigating", async () => {
+		vi.mocked(signUp.email).mockResolvedValue({
+			data: { token: null, user: {} },
+			error: null,
+		} as never);
+		renderPage();
+
+		await userEvent.type(
+			screen.getByLabelText(/^email$/i),
+			"newuser@example.com",
+		);
+		await userEvent.type(screen.getByLabelText(/^password$/i), "verylongpass");
+		await userEvent.click(
+			screen.getByRole("button", { name: /create account/i }),
+		);
+
+		await waitFor(() =>
+			expect(
+				screen.getByText(/we sent a verification link to/i),
+			).toBeInTheDocument(),
+		);
+		expect(screen.getByText("newuser@example.com")).toBeInTheDocument();
+		expect(
+			screen.getByRole("button", { name: /resend link/i }),
+		).toBeInTheDocument();
+	});
+});

--- a/apps/dashboard/src/app/sign-up/page.tsx
+++ b/apps/dashboard/src/app/sign-up/page.tsx
@@ -7,6 +7,7 @@ import { toast } from "sonner";
 
 import { AuthLayout } from "@/components/auth-layout";
 import { OAuthButtons } from "@/components/auth/oauth-buttons";
+import { VerifyEmailNotice } from "@/components/auth/verify-email-notice";
 import { FormField } from "@/components/form-field";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -21,6 +22,7 @@ export default function SignUpPage() {
 	const [showPassword, setShowPassword] = useState(false);
 	const [errors, setErrors] = useState<Record<string, string>>({});
 	const [loading, setLoading] = useState(false);
+	const [submittedEmail, setSubmittedEmail] = useState<string | null>(null);
 
 	async function handleSubmit(e: React.FormEvent) {
 		e.preventDefault();
@@ -51,13 +53,36 @@ export default function SignUpPage() {
 			return;
 		}
 		track(ANALYTICS_EVENTS.signupCompleted, { method: "email" });
-		// New account → straight into onboarding (workspace is provisioned
-		// server-side). Hard navigation, not router.replace: the session cookie
-		// is set on the API origin, so the client session store on this page is
-		// still "logged out" — a soft nav lands on /onboarding with a stale store
-		// and its auth gate bounces back to sign-in. A full load re-initializes
-		// the session with the cookie present.
-		window.location.assign("/onboarding");
+		// Email verification is required: sign-up issues NO session. Instead of
+		// navigating (which would bounce off the auth gate), show the "check your
+		// email" panel. The session arrives only after the user clicks the link
+		// (autoSignInAfterVerification) and lands on /verify-email → /onboarding.
+		setLoading(false);
+		setSubmittedEmail(parsed.data.email);
+	}
+
+	if (submittedEmail) {
+		return (
+			<AuthLayout
+				heading="Check your email"
+				subheading="Verify your email to finish setting up your account"
+			>
+				<VerifyEmailNotice
+					email={submittedEmail}
+					body="We sent a verification link to"
+				/>
+				<p className="mt-6 text-center text-sm text-muted-foreground">
+					Wrong email?{" "}
+					<button
+						type="button"
+						onClick={() => setSubmittedEmail(null)}
+						className="font-medium text-primary"
+					>
+						Go back
+					</button>
+				</p>
+			</AuthLayout>
+		);
 	}
 
 	return (

--- a/apps/dashboard/src/app/verify-email/page.test.tsx
+++ b/apps/dashboard/src/app/verify-email/page.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import VerifyEmailPage from "./page";
+
+// Landing reached via Better Auth's redirect with ?error=CODE on a bad/expired
+// link. useSession is irrelevant on the error path.
+vi.mock("next/navigation", () => ({
+	useSearchParams: () => new URLSearchParams("error=token_expired"),
+}));
+vi.mock("@/lib/auth-client", () => ({
+	useSession: () => ({ data: null, isPending: false }),
+	sendVerificationEmail: vi.fn(async () => ({ error: null })),
+}));
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+describe("VerifyEmailPage — error path", () => {
+	it("shows the expired-link message and a resend form when ?error is present", () => {
+		render(<VerifyEmailPage />);
+		expect(
+			screen.getByText(/this verification link has expired/i),
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole("button", { name: /send a new link/i }),
+		).toBeInTheDocument();
+	});
+});

--- a/apps/dashboard/src/app/verify-email/page.tsx
+++ b/apps/dashboard/src/app/verify-email/page.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import { Suspense, useEffect, useState } from "react";
+import { useSearchParams } from "next/navigation";
+import { AlertCircle, Loader2, Mail } from "lucide-react";
+
+import { AuthLayout } from "@/components/auth-layout";
+import { FormField } from "@/components/form-field";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { useSession } from "@/lib/auth-client";
+import { useResendVerification } from "@/lib/use-resend-verification";
+
+function VerifyEmailInner() {
+	const params = useSearchParams();
+	const error = params.get("error");
+	const { data: session, isPending } = useSession();
+	const { resend, sending, cooldown } = useResendVerification();
+	const [email, setEmail] = useState("");
+	const [stalled, setStalled] = useState(false);
+
+	// Success path: no ?error means Better Auth verified the token and (via
+	// autoSignInAfterVerification) set a session before redirecting here. The
+	// cookie was set on the API origin during the server redirect; this full page
+	// load re-inits the client session store, so a hard nav lands cleanly.
+	useEffect(() => {
+		if (error) return;
+		if (!isPending && session) window.location.assign("/onboarding");
+	}, [error, isPending, session]);
+
+	// Don't hang forever if the session never resolves (autoSignIn edge).
+	useEffect(() => {
+		if (error) return;
+		const t = setTimeout(() => setStalled(true), 4000);
+		return () => clearTimeout(t);
+	}, [error]);
+
+	if (!error) {
+		if (!isPending && !session && stalled) {
+			return (
+				<AuthLayout heading="Email verified" subheading="You can sign in now">
+					<div className="flex flex-col items-center gap-4 py-4 text-center">
+						<p className="text-sm text-muted-foreground">
+							Your email is verified. Please sign in to continue.
+						</p>
+						<Button
+							type="button"
+							className="w-full"
+							onClick={() => window.location.assign("/sign-in")}
+						>
+							Go to sign in
+						</Button>
+					</div>
+				</AuthLayout>
+			);
+		}
+		return (
+			<AuthLayout
+				heading="Email verified"
+				subheading="Taking you to your dashboard…"
+			>
+				<div className="flex flex-col items-center gap-4 py-8 text-center">
+					<Loader2 className="size-6 animate-spin text-primary" />
+					<p className="text-sm text-muted-foreground">
+						You&apos;re verified. Redirecting…
+					</p>
+				</div>
+			</AuthLayout>
+		);
+	}
+
+	return (
+		<AuthLayout
+			heading="That link didn't work"
+			subheading="Request a fresh verification link"
+		>
+			<div className="flex flex-col gap-4">
+				<div className="flex items-start gap-3 rounded-lg border border-destructive/30 bg-destructive/10 p-3 text-left">
+					<AlertCircle className="mt-0.5 size-4 shrink-0 text-destructive" />
+					<p className="text-sm">
+						This verification link has expired or was already used. Enter your
+						email and we&apos;ll send a new one.
+					</p>
+				</div>
+				<form
+					onSubmit={(e) => {
+						e.preventDefault();
+						void resend(email);
+					}}
+					className="flex flex-col gap-3"
+				>
+					<FormField id="email" label="Email">
+						<div className="relative">
+							<Mail className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+							<Input
+								id="email"
+								type="email"
+								autoComplete="email"
+								placeholder="you@company.com"
+								value={email}
+								onChange={(e) => setEmail(e.target.value)}
+								className="pl-9"
+							/>
+						</div>
+					</FormField>
+					<Button
+						type="submit"
+						className="w-full"
+						disabled={sending || cooldown > 0 || !email}
+					>
+						{cooldown > 0
+							? `Resend in ${cooldown}s`
+							: sending
+								? "Sending…"
+								: "Send a new link"}
+					</Button>
+				</form>
+			</div>
+		</AuthLayout>
+	);
+}
+
+export default function VerifyEmailPage() {
+	return (
+		<Suspense fallback={null}>
+			<VerifyEmailInner />
+		</Suspense>
+	);
+}

--- a/apps/dashboard/src/components/auth/verify-email-notice.tsx
+++ b/apps/dashboard/src/components/auth/verify-email-notice.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { MailCheck } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { useResendVerification } from "@/lib/use-resend-verification";
+
+/**
+ * "Check your email" panel shown after sign-up (and reused on the sign-in
+ * unverified path). The visitor must confirm they own the address before they
+ * get a session — Better Auth issues none until the link is clicked.
+ */
+export function VerifyEmailNotice({
+	email,
+	body,
+}: {
+	email: string;
+	body: string;
+}) {
+	const { resend, sending, cooldown } = useResendVerification();
+	return (
+		<div className="flex flex-col items-center gap-5 py-2 text-center">
+			<div className="flex size-12 items-center justify-center rounded-full bg-primary/15">
+				<MailCheck className="size-6 text-primary" />
+			</div>
+			<div className="space-y-1.5">
+				<p className="text-sm text-muted-foreground">{body}</p>
+				<p className="text-sm font-medium break-all">{email}</p>
+			</div>
+			<div className="w-full space-y-2">
+				<Button
+					type="button"
+					variant="outline"
+					className="w-full"
+					disabled={sending || cooldown > 0}
+					onClick={() => resend(email)}
+				>
+					{cooldown > 0
+						? `Resend link in ${cooldown}s`
+						: sending
+							? "Sending…"
+							: "Resend link"}
+				</Button>
+				<p className="text-xs text-muted-foreground">
+					Wrong address or didn&apos;t arrive? Resend, or check your spam
+					folder.
+				</p>
+			</div>
+		</div>
+	);
+}

--- a/apps/dashboard/src/lib/auth-client.ts
+++ b/apps/dashboard/src/lib/auth-client.ts
@@ -6,4 +6,5 @@ export const authClient = createAuthClient({
 	baseURL: apiBaseUrl(),
 });
 
-export const { useSession, signIn, signUp, signOut } = authClient;
+export const { useSession, signIn, signUp, signOut, sendVerificationEmail } =
+	authClient;

--- a/apps/dashboard/src/lib/use-resend-verification.ts
+++ b/apps/dashboard/src/lib/use-resend-verification.ts
@@ -1,0 +1,59 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { toast } from "sonner";
+
+import { sendVerificationEmail } from "./auth-client";
+
+// Better Auth caps /send-verification-email at 3 per 60s per IP. A per-send
+// cooldown keeps a normal user comfortably under that; a 429 is still handled.
+const COOLDOWN_SECONDS = 30;
+
+/**
+ * Resend the email-verification link, with a cooldown so the user can't trip
+ * Better Auth's rate limit. The verification link's landing is fixed server-side
+ * (auth.ts overrides callbackURL), so the callbackURL passed here only satisfies
+ * the endpoint and points at our own (trusted) origin.
+ */
+export function useResendVerification() {
+	const [cooldown, setCooldown] = useState(0);
+	const [sending, setSending] = useState(false);
+
+	useEffect(() => {
+		if (cooldown <= 0) return;
+		const t = setTimeout(() => setCooldown((c) => c - 1), 1000);
+		return () => clearTimeout(t);
+	}, [cooldown]);
+
+	const resend = useCallback(
+		async (email: string) => {
+			if (!email || sending || cooldown > 0) return;
+			setSending(true);
+			const res = await sendVerificationEmail({
+				email,
+				callbackURL: `${window.location.origin}/verify-email`,
+			});
+			setSending(false);
+			if (res.error) {
+				if (res.error.status === 429) {
+					toast.error("Too many requests", {
+						description: "Wait a minute before requesting another link.",
+					});
+					setCooldown(COOLDOWN_SECONDS);
+				} else {
+					toast.error("Couldn't send the link", {
+						description: res.error.message ?? undefined,
+					});
+				}
+				return;
+			}
+			toast.success("Verification link sent", {
+				description: `Check ${email}.`,
+			});
+			setCooldown(COOLDOWN_SECONDS);
+		},
+		[sending, cooldown],
+	);
+
+	return { resend, sending, cooldown };
+}


### PR DESCRIPTION
## Security Hardening — PR 2b (#111): email-verification flow

The identity half of the auth hardening (2a closed the account-takeover; this closes **account squatting**). Email/password sign-up must prove ownership before getting a session. **OAuth (live in prod) is untouched** — the gate is email/password-scoped.

### Two paths
- **Email/password (gated):** sign-up → user row, **no session** → verification email → click link → `emailVerified:true` + session (`autoSignInAfterVerification`) → `/verify-email` → `/onboarding` → paywall. Unverified sign-in → `403 EMAIL_NOT_VERIFIED` (BA auto-resends).
- **OAuth (pass-through, unchanged):** `callback.mjs` has no `requireEmailVerification` check; a provider-verified user gets a session with no verify step. Proven by an explicit `handleOAuthUserInfo` test.

### API
`emailAndPassword.requireEmailVerification: true` + `emailVerification: { sendOnSignUp, autoSignInAfterVerification, sendVerificationEmail }`. `sendVerificationEmail` builds the link deterministically with a fixed `callbackURL=${DASHBOARD_URL}/verify-email` (one trusted landing for success + `?error`), reusing `lib/email.ts` (Resend, workerd-safe). **No new secret.**

### Dashboard (ck/ds, "support agent" never "chatbot")
- **A** — sign-up success → inline "check your email" + resend (replaces the now-broken `/onboarding` nav).
- **B** — public `/verify-email` landing: no `?error` → success → hard-nav `/onboarding` (4s stall fallback to sign-in); `?error=CODE` → friendly "link expired" + resend form.
- **C** — sign-in `EMAIL_NOT_VERIFIED` → inline "we re-sent the link" + resend. Matched on the stable error **`code`**, never status 403 (adversarial-review fix — bad credentials are 401, so 403-matching was fragile).
- `use-resend-verification` hook (30s cooldown, 429-safe); `auth-client` gains the native `sendVerificationEmail`.

### Migration / seed / backfill
No migration (`emailVerified` exists). Dev seed already sets `email_verified=1` for admin. **No prod backfill** (post-reset: OAuth accounts already verified; credential test accounts self-heal via sign-in auto-resend) — the approved hard-gate decision.

### Tests (the deliverable)
- **API e2e** (real sqlite + real BA handler): sign-up → unverified + no session; **link verify round-trip** → verified + session minted; unverified sign-in → 403; **OAuth → session + no gate**; config assertion; verification-link construction.
- **Dashboard**: the three surfaces + the **invalid-credentials (401) negative case** (does NOT show the verify notice). Also fixed PR2a's "sessions stay in D1" test for the new no-auto-session-on-sign-up behavior.
- Gates: api 370 + dashboard 397 pass; oxlint + prettier + tsc clean.

### Process
Plan-first → pre-build design review (OAuth no-regression confirmed 12 ways) → build → adversarial review (OAuth + verify round-trip + regression sweep + frontend) → 1 confirmed finding fixed (the 403 breadth) → PR.

### Deploy note
2b touches the dashboard frontend → its preview runs through the `kind: nextjs` builder that flaked transiently before. If a preview fails with `No executable pnpm found`, it's the known transient Ploy flake — re-trigger once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)