### PR TITLE
fix: pre-launch day-one — default notifyEmail on create + guard onboarding bounce on failed fetch

### DIFF
--- a/apps/api/src/routes/chat.test.ts
+++ b/apps/api/src/routes/chat.test.ts
@@ -320,7 +320,10 @@ function sendEscalate(body: unknown, ctx: ReturnType<typeof makeCtx>["ctx"]) {
 }
 
 describe("POST /v1/escalate — operator transcript is server-side", () => {
-	function mockDbForEscalate(storedMessages: unknown[]) {
+	function mockDbForEscalate(
+		storedMessages: unknown[],
+		notifyEmail: string | null = "ops@acme.com",
+	) {
 		const valuesResult = () =>
 			Object.assign(Promise.resolve([]), {
 				returning: async () => [{ id: "ue1" }],
@@ -330,7 +333,7 @@ describe("POST /v1/escalate — operator transcript is server-side", () => {
 				project: {
 					findFirst: async () => ({
 						...project,
-						notifyEmail: "ops@acme.com",
+						notifyEmail,
 						inboundEmailLocal: "acme",
 						slackWebhookUrl: null,
 					}),
@@ -374,6 +377,52 @@ describe("POST /v1/escalate — operator transcript is server-side", () => {
 		expect(html).toContain("stored question");
 		expect(html).toContain("stored answer");
 		expect(html).not.toContain("FORGED-INJECTED-CONTENT");
+		await settle();
+	});
+
+	it("addresses the operator alert to the project's notifyEmail — the create-time default reaches the owner", async () => {
+		mockDbForEscalate(
+			[{ role: "user", content: "help", sequence: 1 }],
+			"owner@acme.com",
+		);
+		const { ctx, settle } = makeCtx();
+
+		const res = await sendEscalate(
+			{
+				projectKey: "pk_live",
+				clientId: "client_1",
+				messages: [{ role: "user", content: "help" }],
+			},
+			ctx,
+		);
+
+		expect(res.status).toBe(200);
+		expect(sendEmail).toHaveBeenCalledTimes(1);
+		// A freshly-created project's notifyEmail (seeded from the owner at creation)
+		// is exactly what the alert is addressed to — so escalation reaches someone.
+		expect(vi.mocked(sendEmail).mock.calls[0]![1].to).toBe("owner@acme.com");
+		await settle();
+	});
+
+	it("sends NO operator email when notifyEmail is null — the day-one gap the create-time default closes", async () => {
+		mockDbForEscalate([{ role: "user", content: "help", sequence: 1 }], null);
+		const { ctx, settle } = makeCtx();
+
+		const res = await sendEscalate(
+			{
+				projectKey: "pk_live",
+				clientId: "client_1",
+				messages: [{ role: "user", content: "help" }],
+			},
+			ctx,
+		);
+
+		// Escalation is still recorded + visible in the inbox (loop intact)…
+		expect(res.status).toBe(200);
+		expect(await res.json()).toMatchObject({ ok: true });
+		// …but with no notifyEmail there is no alert — exactly why creation now
+		// defaults notifyEmail to the owner's email.
+		expect(sendEmail).not.toHaveBeenCalled();
 		await settle();
 	});
 });

--- a/apps/api/src/routes/projects.test.ts
+++ b/apps/api/src/routes/projects.test.ts
@@ -34,6 +34,10 @@ interface State {
 	projectCount?: number;
 	/** Rows the /projects/usage aggregate (select→from→where→groupBy) returns. */
 	usageRows?: { projectId: string; n: number }[];
+	/** Email the creating user's row carries — drives the notifyEmail default on
+	 * create. `undefined` here means "use a default"; pass null to model a user
+	 * with no email on record. */
+	creatorEmail?: string | null;
 }
 
 let insertSpy: ReturnType<typeof vi.fn>;
@@ -42,10 +46,17 @@ let updateSpy: ReturnType<typeof vi.fn>;
 /** The exact object handed to `.update().set(...)` on the last PATCH — lets a
  * test assert ONLY the provided fields are written (no defaulted siblings). */
 let lastSetData: Record<string, unknown> | null;
+/** The exact object handed to `.insert().values(...)` on the last create — lets
+ * a test assert the notifyEmail default (and that explicit values survive). */
+let lastInsertValues: Record<string, unknown> | null;
 
 function mockDb(state: State) {
+	lastInsertValues = null;
 	insertSpy = vi.fn(() => ({
-		values: () => ({ returning: async () => [{ id: "p_new", name: "New" }] }),
+		values: (v: Record<string, unknown>) => {
+			lastInsertValues = v;
+			return { returning: async () => [{ id: "p_new", ...v }] };
+		},
 	}));
 	deleteSpy = vi.fn(() => ({ where: async () => [] }));
 	lastSetData = null;
@@ -68,6 +79,17 @@ function mockDb(state: State) {
 			},
 			workspace: {
 				findFirst: async () => ({ plan: state.plan ?? "scale" }),
+			},
+			// The create handler looks up the caller's own user row to seed the
+			// notifyEmail default. `undefined` creatorEmail ⇒ a sensible default.
+			user: {
+				findFirst: async () => ({
+					id: "u1",
+					email:
+						state.creatorEmail === undefined
+							? "owner@acme.com"
+							: state.creatorEmail,
+				}),
 			},
 		},
 		// Two select shapes:
@@ -232,6 +254,48 @@ describe("Plan caps — POST /projects (create)", () => {
 	});
 });
 
+describe("notifyEmail default — escalation alerts work out of the box", () => {
+	const hdr = { "x-test-user": "u1", "x-workspace-id": "ws_1", ...json };
+
+	function create(body: Record<string, unknown>) {
+		return req("/projects", {
+			method: "POST",
+			headers: hdr,
+			body: JSON.stringify(body),
+		});
+	}
+
+	it("seeds notifyEmail with the creating user's email when omitted (alerts fire on a fresh project)", async () => {
+		mockDb({ role: "owner", creatorEmail: "owner@acme.com" });
+		const res = await create({ name: "Bot" });
+		expect(res.status).toBe(200);
+		// The inserted row carries the owner's address, so /escalate's
+		// `if (project.notifyEmail)` email path is live without any manual config.
+		expect(lastInsertValues).toMatchObject({ notifyEmail: "owner@acme.com" });
+	});
+
+	it("respects an explicit notifyEmail at creation (default only fills an omitted field)", async () => {
+		mockDb({ role: "owner", creatorEmail: "owner@acme.com" });
+		const res = await create({ name: "Bot", notifyEmail: "ops@acme.com" });
+		expect(res.status).toBe(200);
+		expect(lastInsertValues).toMatchObject({ notifyEmail: "ops@acme.com" });
+	});
+
+	it("respects an explicit null (opting out of alerts is honored, not overwritten)", async () => {
+		mockDb({ role: "owner", creatorEmail: "owner@acme.com" });
+		const res = await create({ name: "Bot", notifyEmail: null });
+		expect(res.status).toBe(200);
+		expect(lastInsertValues).toMatchObject({ notifyEmail: null });
+	});
+
+	it("falls back to null when the creating user has no email on record", async () => {
+		mockDb({ role: "owner", creatorEmail: null });
+		const res = await create({ name: "Bot" });
+		expect(res.status).toBe(200);
+		expect(lastInsertValues).toMatchObject({ notifyEmail: null });
+	});
+});
+
 describe("RBAC — read & delete", () => {
 	it("lets an agent LIST projects (read is open to members)", async () => {
 		mockDb({ role: "agent" });
@@ -288,6 +352,8 @@ describe("PATCH /projects/:id — partial update never clobbers siblings", () =>
 		["model", "gpt-5.4-mini"],
 		["escalationThreshold", 5],
 		["name", "Renamed bot"],
+		// notifyEmail stays editable after the create-time default is seeded.
+		["notifyEmail", "newops@acme.com"],
 	])("PATCH { %s } writes only that field to .set()", async (field, value) => {
 		mockDb({ role: "admin", existingProject: { id: "p1" }, plan: "scale" });
 		const res = await patch({ [field]: value });

--- a/apps/api/src/routes/projects.ts
+++ b/apps/api/src/routes/projects.ts
@@ -113,6 +113,7 @@ export const projects = new Hono<AppContext>()
 		zValidator("json", projectCreateInput),
 		async (c) => {
 			const workspaceId = c.get("workspaceId");
+			const userId = c.get("userId");
 			const data = c.req.valid("json");
 			// Paywall (server-side, non-bypassable): a non-exempt workspace with no
 			// active subscription can't build at all — paid-only, hard gate before
@@ -131,10 +132,25 @@ export const projects = new Hono<AppContext>()
 			if (!exempt && !isModelAllowed(plan, data.model)) {
 				return c.json({ error: "model_not_allowed" }, 402);
 			}
+			// Escalation alerts work out of the box: when the caller omits
+			// notifyEmail, seed it with the creating user's own email so the "Talk
+			// to a human" handoff actually reaches someone on day one (still editable
+			// later via PATCH / Settings → Behavior). An explicit value — including
+			// null to opt out — is always respected. Looking up the caller's OWN
+			// session user by id is not a tenant-scoped read, so a bare id match is
+			// correct here.
+			let notifyEmail = data.notifyEmail;
+			if (notifyEmail === undefined) {
+				const creator = await db(c.env).query.user.findFirst({
+					where: (u, { eq: e }) => e(u.id, userId),
+				});
+				notifyEmail = creator?.email ?? null;
+			}
 			const [created] = await db(c.env)
 				.insert(project)
 				.values({
 					...data,
+					notifyEmail,
 					workspaceId,
 					publicKey: generatePublicKey(),
 					inboundEmailLocal: generateInboundLocal(),

--- a/apps/dashboard/src/app/inbox/page.test.tsx
+++ b/apps/dashboard/src/app/inbox/page.test.tsx
@@ -14,8 +14,11 @@ beforeAll(() => {
 	Element.prototype.hasPointerCapture ??= () => false;
 });
 
+// Stable router.replace spy (hoisted with the mock) so the onboarding-redirect
+// guard can be asserted at the real incident call site.
+const routerReplace = vi.hoisted(() => vi.fn());
 vi.mock("next/navigation", () => ({
-	useRouter: () => ({ replace: vi.fn(), push: vi.fn() }),
+	useRouter: () => ({ replace: routerReplace, push: vi.fn() }),
 }));
 
 // Admin in a workspace with a project, so the inbox renders (not onboarding) and
@@ -276,5 +279,44 @@ describe("InboxPage — ⌘K deep link", () => {
 		// deep link round-trips.
 		await waitFor(() => expect(window.location.search).toContain("c=c1"));
 		expect(window.location.search).toContain("project=p1");
+	});
+});
+
+// The named incident path: the inbox wires `projectsLoaded: projects.isSuccess`
+// inline (page.tsx) then redirects to /onboarding only on "needs-onboarding".
+// These render-level tests pin that wiring at the real call site — a wrong VALUE
+// (e.g. a future `projectsLoaded: true`) compiles but would reintroduce the
+// paying-customer bounce / duplicate-workspace bug, and would fail here.
+describe("InboxPage — onboarding redirect guards on the projects fetch outcome", () => {
+	it("does NOT redirect to /onboarding when the projects fetch FAILS (no false bounce)", async () => {
+		vi.mocked(api).mockImplementation(async (path: string, opts = {}) => {
+			calls.push({ path, method: opts.method ?? "GET" });
+			// A failed projects fetch reports zero projects too — must NOT be read as
+			// an empty workspace and bounce the user (where rebuilding dupes a ws).
+			if (path === "/api/projects") throw new Error("projects fetch failed");
+			if (path === "/api/tags") return { tags: tagsState };
+			return {};
+		});
+		renderInbox();
+		// Let the failed query settle (retry:false → straight to error).
+		await waitFor(() =>
+			expect(calls.some((c) => c.path === "/api/projects")).toBe(true),
+		);
+		// Give the redirect effect time to (wrongly) fire, then assert it never did.
+		await new Promise((r) => setTimeout(r, 30));
+		expect(routerReplace).not.toHaveBeenCalledWith("/onboarding");
+	});
+
+	it("DOES redirect a genuinely-empty workspace (successful fetch, zero projects) to /onboarding", async () => {
+		vi.mocked(api).mockImplementation(async (path: string, opts = {}) => {
+			calls.push({ path, method: opts.method ?? "GET" });
+			if (path === "/api/projects") return { projects: [] };
+			if (path === "/api/tags") return { tags: tagsState };
+			return {};
+		});
+		renderInbox();
+		await waitFor(() =>
+			expect(routerReplace).toHaveBeenCalledWith("/onboarding"),
+		);
 	});
 });

--- a/apps/dashboard/src/app/inbox/page.tsx
+++ b/apps/dashboard/src/app/inbox/page.tsx
@@ -459,6 +459,9 @@ export default function InboxPage() {
 	const onboardingState = resolveOnboardingState({
 		loading: workspacesLoading || (!!workspaceId && projects.isLoading),
 		hasWorkspace: workspaces.length > 0,
+		// Guard the bounce on a SUCCESSFUL projects fetch: a failed/pending fetch
+		// reads as zero too, and bouncing on it can provision a duplicate workspace.
+		projectsLoaded: projects.isSuccess,
 		projectCount: projects.data?.projects.length ?? 0,
 	});
 	useEffect(() => {

--- a/apps/dashboard/src/lib/onboarding.test.ts
+++ b/apps/dashboard/src/lib/onboarding.test.ts
@@ -36,23 +36,29 @@ describe("resolveOnboardingState", () => {
 			resolveOnboardingState({
 				loading: true,
 				hasWorkspace: false,
+				projectsLoaded: false,
 				projectCount: 0,
 			}),
 		).toBe("loading");
 	});
 
-	it("needs onboarding with no workspace OR no project", () => {
+	it("needs onboarding with no workspace (brand-new account)", () => {
 		expect(
 			resolveOnboardingState({
 				loading: false,
 				hasWorkspace: false,
+				projectsLoaded: false,
 				projectCount: 0,
 			}),
 		).toBe("needs-onboarding");
+	});
+
+	it("needs onboarding when a SUCCESSFUL projects fetch returns zero", () => {
 		expect(
 			resolveOnboardingState({
 				loading: false,
 				hasWorkspace: true,
+				projectsLoaded: true,
 				projectCount: 0,
 			}),
 		).toBe("needs-onboarding");
@@ -63,6 +69,7 @@ describe("resolveOnboardingState", () => {
 			resolveOnboardingState({
 				loading: false,
 				hasWorkspace: true,
+				projectsLoaded: true,
 				projectCount: 1,
 			}),
 		).toBe("ready");
@@ -74,7 +81,32 @@ describe("resolveOnboardingState", () => {
 			resolveOnboardingState({
 				loading: true,
 				hasWorkspace: true,
+				projectsLoaded: true,
 				projectCount: 3,
+			}),
+		).toBe("loading");
+	});
+
+	it("does NOT conclude needs-onboarding from a failed/unsettled projects fetch", () => {
+		// The sharp bug: a failed `/api/projects` reports projectCount:0 with
+		// loading:false — identical to a genuine empty workspace. Concluding
+		// "needs-onboarding" here bounces a PAYING customer into onboarding, where
+		// rebuilding can provision a duplicate workspace. With projectsLoaded:false
+		// (isSuccess === false → error or pending) we must hold, never bounce.
+		expect(
+			resolveOnboardingState({
+				loading: false,
+				hasWorkspace: true,
+				projectsLoaded: false,
+				projectCount: 0,
+			}),
+		).not.toBe("needs-onboarding");
+		expect(
+			resolveOnboardingState({
+				loading: false,
+				hasWorkspace: true,
+				projectsLoaded: false,
+				projectCount: 0,
 			}),
 		).toBe("loading");
 	});

--- a/apps/dashboard/src/lib/onboarding.ts
+++ b/apps/dashboard/src/lib/onboarding.ts
@@ -26,14 +26,28 @@ export type OnboardingState = "loading" | "needs-onboarding" | "ready";
  * Where an authenticated user belongs: a brand-new account (no workspace or no
  * project) needs onboarding; otherwise the dashboard. Pure so both the
  * onboarding page and the inbox guard derive the same answer.
+ *
+ * `projectsLoaded` MUST be the projects query's `isSuccess` — "empty workspace →
+ * onboarding" is only ever concluded from a SUCCESSFUL fetch that genuinely
+ * returned zero projects. A failed (or not-yet-settled) projects fetch reports
+ * `projectCount: 0` too, and treating that as "no projects" would bounce a
+ * paying customer into onboarding (where rebuilding can provision a duplicate
+ * workspace). This mirrors the `projects.isSuccess` guard in
+ * use-onboarding-redirect.ts so both paths agree.
  */
 export function resolveOnboardingState(input: {
 	loading: boolean;
 	hasWorkspace: boolean;
+	projectsLoaded: boolean;
 	projectCount: number;
 }): OnboardingState {
 	if (input.loading) return "loading";
-	if (!input.hasWorkspace || input.projectCount === 0)
-		return "needs-onboarding";
-	return "ready";
+	// No workspace at all → brand-new account → onboarding. Workspace data has
+	// genuinely settled here because callers fold the workspace query's loading
+	// into `loading`; this is independent of the projects fetch.
+	if (!input.hasWorkspace) return "needs-onboarding";
+	// Hold rather than bounce until the projects fetch has SUCCEEDED — a failed
+	// fetch must never be mistaken for "zero projects".
+	if (!input.projectsLoaded) return "loading";
+	return input.projectCount === 0 ? "needs-onboarding" : "ready";
 }

--- a/apps/dashboard/src/lib/use-onboarding.test.tsx
+++ b/apps/dashboard/src/lib/use-onboarding.test.tsx
@@ -1,0 +1,83 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { api } from "@/lib/api";
+
+import { useOnboardingState } from "./use-onboarding";
+
+// useOnboardingState backs the onboarding page guard AND (via the shared
+// resolveOnboardingState) the inbox redirect. The sharp bug: a FAILED
+// `/api/projects` fetch reports projectCount:0 with loading:false — identical to
+// a genuinely empty workspace — so it would conclude "needs-onboarding" and
+// bounce a paying customer into onboarding (risking a duplicate workspace). The
+// fix threads the query's isSuccess in, so only a SUCCESSFUL empty fetch counts.
+
+let workspaceState: {
+	workspaces: { id: string }[];
+	workspaceId: string | null;
+	isLoading: boolean;
+};
+vi.mock("@/lib/workspace", () => ({ useWorkspace: () => workspaceState }));
+vi.mock("@/lib/api", () => ({ api: vi.fn() }));
+
+function setup() {
+	// retry:false so a rejected fetch settles straight to `error` (no backoff),
+	// and a fresh client per test so query state never leaks between cases.
+	const client = new QueryClient({
+		defaultOptions: { queries: { retry: false } },
+	});
+	const wrapper = ({ children }: { children: ReactNode }) =>
+		createElement(QueryClientProvider, { client }, children);
+	const { result } = renderHook(() => useOnboardingState(), { wrapper });
+	return { client, result };
+}
+
+beforeEach(() => {
+	workspaceState = {
+		workspaces: [{ id: "ws1" }],
+		workspaceId: "ws1",
+		isLoading: false,
+	};
+});
+afterEach(() => vi.clearAllMocks());
+
+describe("useOnboardingState", () => {
+	it("does NOT report needs-onboarding when the projects fetch FAILS (no false bounce)", async () => {
+		vi.mocked(api).mockRejectedValue(new Error("network down"));
+		const { client, result } = setup();
+
+		// Wait until the query has genuinely SETTLED into error — only then is the
+		// distinction meaningful (the buggy code concluded needs-onboarding here).
+		await waitFor(() =>
+			expect(client.getQueryState(["projects", "ws1"])?.status).toBe("error"),
+		);
+
+		expect(result.current.state).not.toBe("needs-onboarding");
+		// Holds in a loading state rather than bouncing — mirrors the redirect
+		// hook's "do nothing on non-success".
+		expect(result.current.state).toBe("loading");
+	});
+
+	it("reports needs-onboarding only from a SUCCESSFUL empty fetch", async () => {
+		vi.mocked(api).mockResolvedValue({ projects: [] });
+		const { result } = setup();
+		await waitFor(() => expect(result.current.state).toBe("needs-onboarding"));
+	});
+
+	it("reports ready when a successful fetch returns projects", async () => {
+		vi.mocked(api).mockResolvedValue({ projects: [{ id: "p1" }] });
+		const { result } = setup();
+		await waitFor(() => expect(result.current.state).toBe("ready"));
+	});
+
+	it("reports needs-onboarding for a brand-new user with no workspace", async () => {
+		workspaceState = { workspaces: [], workspaceId: null, isLoading: false };
+		const { result } = setup();
+		// No workspace at all → onboarding, independent of the projects fetch
+		// (which is disabled without a workspace id).
+		await waitFor(() => expect(result.current.state).toBe("needs-onboarding"));
+		expect(api).not.toHaveBeenCalled();
+	});
+});

--- a/apps/dashboard/src/lib/use-onboarding.ts
+++ b/apps/dashboard/src/lib/use-onboarding.ts
@@ -33,6 +33,9 @@ export function useOnboardingState(): {
 	const state = resolveOnboardingState({
 		loading,
 		hasWorkspace: !!workspaceId,
+		// Only a successful fetch may be read as "zero projects" → onboarding; a
+		// failed fetch must not bounce the user (it would risk a duplicate workspace).
+		projectsLoaded: projects.isSuccess,
 		projectCount: projects.data?.projects.length ?? 0,
 	});
 	return { state, workspaceId };


### PR DESCRIPTION
Two small, contained pre-launch fixes from the launch-readiness audit. Both protect the **day-one** experience; the tests proving the behavior are the deliverable. Branched off `main` — independent of the open PRs #80 / #83 (verified: neither touches any of these files).

## Fix 1 — default `project.notifyEmail` to the creator's email on create
The product's headline promise is human escalation, but it was **dark by default**: new projects had `notifyEmail=null`, onboarding never set it, and `/escalate` only emails inside `if (project.notifyEmail)` (`chat.ts:397`) — so a fresh project's "Talk to a human" handoff landed in the inbox but sent **no operator alert** until manually configured.

- `POST /projects` now seeds `notifyEmail` with the **creating user's own email** when omitted (`db.query.user.findFirst` on the caller's own session `userId` — a primary-key self-read, not a tenant-scoped query).
- An explicit value is always respected — a string is kept, and an explicit `null` (opt out) is **never overwritten**.
- Stays editable later via `PATCH /projects/:id` (untouched). **No migration** — `notify_email` is already nullable.

## Fix 2 — only conclude "needs onboarding" from a *successful* projects fetch
A failed `/api/projects` fetch reports zero projects with `loading:false` — identical to a genuinely empty workspace — so the inbox **bounced a paying customer into `/onboarding`**, where rebuilding can provision a **duplicate workspace**.

- `resolveOnboardingState` gains `projectsLoaded` (= the query's `isSuccess`) and **holds `"loading"` rather than bouncing** until the fetch succeeds. Mirrors the existing inline guard in `use-onboarding-redirect.ts:63` — no new pattern.
- Both (and only) call sites updated: `use-onboarding.ts` and the inbox page. The new field is required, so a missed call site is a compile error.
- On the inbox, `onboardingState` gates only the redirect effect (not the render), so a failed fetch shows an empty inbox within the chrome — never an infinite spinner or a false bounce.

## The four behaviors (tests are the deliverable)
1. **A new project has `notifyEmail` = the owner's email** — `projects.test.ts` (seed / preserve-explicit / null-opt-out / no-email→null).
2. **Escalation on a fresh project fires the email path** — `chat.test.ts` asserts the alert is addressed `to` the seeded address, and sends **no** email when `notifyEmail` is null (the gap this closes).
3. **A failed `/api/projects` fetch does NOT route to onboarding** — `onboarding.test.ts` (pure helper) + `use-onboarding.test.tsx` (hook, gated on the *settled-error* query state) + `inbox/page.test.tsx` (render-level, at the real incident call site).
4. **A successful empty fetch DOES route a new user to onboarding** — same three layers.

## Verification
- **Gates green:** API 383/383, dashboard 423/423, both typechecks clean, prettier clean, no new lint.
- **Adversarial review** (4 lenses → per-finding verification → synthesis): **ship**, zero must-fix. All four behaviors mutation-verified (reverting either fix fails exactly the targeting tests; preservation cases stay green). The one valuable gap it surfaced — the inbox incident path lacked a render test — is now closed by the two `inbox/page.test.tsx` redirect-guard tests.

## Scope / notes
- Only these two fixes + their tests. No unrelated changes.
- Known non-blocking minors (out of scope, noted for later): `requireSession` already loads the user row Fix 1 re-fetches (a redundant cold-path read worth caching on context later); on a *persistent* projects outage the onboarding page holds the skeleton (strictly safer than the duplicate-workspace bug, self-heals on refetch).
- Dashboard touched → preview runs the `kind: nextjs` builder; a "No executable pnpm found" failure is the known transient flake — re-trigger once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
