### PR TITLE
fix(api,widget): stop the bot answering after escalation (Bug 3 holding message + idempotent escalate)

### DIFF
--- a/apps/api/src/lib/holding.ts
+++ b/apps/api/src/lib/holding.ts
@@ -1,0 +1,35 @@
+import { createUIMessageStream, createUIMessageStreamResponse } from "ai";
+
+/**
+ * The static, automated acknowledgement a visitor sees IN PLACE of an AI reply
+ * when they message a conversation that's escalated to a human. Clearly labelled
+ * automated and promises no timeline (honesty rail). Exported so the stream, the
+ * tests, and any client-side copy share one source of truth.
+ *
+ * Deliberately NOT placed in @/lib/llm: chat.test.ts mocks that whole module, and
+ * the guard needs the REAL builder to produce a drainable stream in tests.
+ */
+export const ESCALATED_HOLDING_MESSAGE =
+	"This is an automated message. Thanks — your reply has been added to the conversation and our support team will follow up here. Feel free to keep adding details in the meantime.";
+
+/**
+ * Return the escalation holding acknowledgement as a v6 UI message stream that the
+ * widget's useChat already renders — or, when `text` is null, an EMPTY stream that
+ * completes cleanly with NO bot bubble (the throttled/cooldown case). Makes no
+ * model call and writes nothing to the DB: a muted turn costs nothing. workerd-safe
+ * (pure stream + Response, no Node deps).
+ */
+export function holdingStreamResponse(text: string | null): Response {
+	const stream = createUIMessageStream({
+		execute: ({ writer }) => {
+			if (!text) return; // empty stream → useChat completes with no bubble
+			const id = crypto.randomUUID();
+			writer.write({ type: "start" });
+			writer.write({ type: "text-start", id });
+			writer.write({ type: "text-delta", id, delta: text });
+			writer.write({ type: "text-end", id });
+			writer.write({ type: "finish" });
+		},
+	});
+	return createUIMessageStreamResponse({ stream });
+}

--- a/apps/api/src/lib/kv.test.ts
+++ b/apps/api/src/lib/kv.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { publicLookupRateLimit, rateLimit } from "./kv";
+import { publicLookupRateLimit, rateLimit, shouldSendHolding } from "./kv";
 
 import type { Env } from "@/env";
 
@@ -60,6 +60,46 @@ describe("rateLimit", () => {
 		});
 		expect(result.ok).toBe(false);
 		expect(result.remaining).toBe(0);
+		errorSpy.mockRestore();
+	});
+});
+
+describe("shouldSendHolding", () => {
+	it("sends on the first turn, then stays quiet within the cooldown window", async () => {
+		const store = new Map<string, string>();
+		const env = envWithStore(store);
+		expect(await shouldSendHolding(env, "c1")).toBe(true); // first → send
+		expect(await shouldSendHolding(env, "c1")).toBe(false); // within ~5min → quiet
+		expect([...store.keys()][0]).toBe("holdmsg:c1");
+	});
+
+	it("throttles per conversation independently", async () => {
+		const store = new Map<string, string>();
+		const env = envWithStore(store);
+		await shouldSendHolding(env, "c1");
+		expect(await shouldSendHolding(env, "c1")).toBe(false);
+		expect(await shouldSendHolding(env, "c2")).toBe(true); // different conv → send
+	});
+
+	it("sends again once the cooldown window elapses", async () => {
+		vi.useFakeTimers();
+		try {
+			vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+			const store = new Map<string, string>();
+			const env = envWithStore(store);
+			expect(await shouldSendHolding(env, "c1")).toBe(true);
+			expect(await shouldSendHolding(env, "c1")).toBe(false);
+			vi.setSystemTime(new Date("2026-01-01T00:06:00Z")); // +6min > 5min cooldown
+			expect(await shouldSendHolding(env, "c1")).toBe(true);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("fails OPEN toward sending when STATE is unavailable (reassure, not dead-air)", async () => {
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		expect(await shouldSendHolding(envWithBrokenStore(), "c1")).toBe(true);
+		expect(errorSpy).toHaveBeenCalled();
 		errorSpy.mockRestore();
 	});
 });

--- a/apps/api/src/lib/kv.ts
+++ b/apps/api/src/lib/kv.ts
@@ -75,6 +75,44 @@ export async function rateLimit(
 	}
 }
 
+// One escalation "holding" acknowledgement per this window — so a waiting visitor
+// who sends several messages isn't spammed the same canned line each time.
+const HOLD_COOLDOWN_SECONDS = 300; // ~5 min
+
+/**
+ * Throttle the post-escalation holding acknowledgement. Returns true ⇒ SEND the
+ * ack now (the first post-escalation turn, or the first turn after the cooldown
+ * elapsed); false ⇒ stay quiet (the empty stream). Backed by the STATE binding
+ * with the same get/set + value-tracked-expiry pattern as rateLimit. FAILS OPEN
+ * toward SENDING — a STATE outage should reassure the visitor, not dead-air them.
+ */
+export async function shouldSendHolding(
+	env: Env,
+	conversationId: string,
+): Promise<boolean> {
+	const cacheKey = `holdmsg:${conversationId}`;
+	const now = Math.floor(Date.now() / 1000);
+	try {
+		const raw = await env.STATE.get(cacheKey);
+		if (raw) {
+			try {
+				const parsed = JSON.parse(raw) as { ts: number };
+				if (parsed.ts && now - parsed.ts < HOLD_COOLDOWN_SECONDS) {
+					return false; // still within the cooldown — stay quiet
+				}
+			} catch {
+				// Malformed entry — treat as no recent ack.
+			}
+		}
+		await env.STATE.set(cacheKey, JSON.stringify({ ts: now }));
+		return true;
+	} catch (err) {
+		// Fail open toward SENDING: reassure rather than leave the visitor in silence.
+		console.error("shouldSendHolding: state store unavailable, sending", err);
+		return true;
+	}
+}
+
 // Per-IP gate run BEFORE the project lookup on the public widget routes, so a
 // flood of requests bearing unknown/invalid project keys can't drive unbounded
 // DB lookups. Generous — a legit embed polls only a few times/sec, and many

--- a/apps/api/src/routes/chat.test.ts
+++ b/apps/api/src/routes/chat.test.ts
@@ -2,8 +2,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { db } from "@/lib/db";
 import { sendEmail } from "@/lib/email";
-import { publicLookupRateLimit } from "@/lib/kv";
+import { ESCALATED_HOLDING_MESSAGE } from "@/lib/holding";
+import { publicLookupRateLimit, shouldSendHolding } from "@/lib/kv";
 import { streamChat, summarizeForVisitor } from "@/lib/llm";
+import { sendEscalationSlack } from "@/lib/slack";
 import { isResponseBlocked, resolveAccess } from "@/lib/plan";
 import { reportMeterEvent } from "@/lib/stripe";
 
@@ -15,7 +17,9 @@ vi.mock("@/lib/db", () => ({ db: vi.fn() }));
 vi.mock("@/lib/kv", () => ({
 	rateLimit: vi.fn(async () => ({ ok: true })),
 	publicLookupRateLimit: vi.fn(async () => ({ ok: true })),
+	shouldSendHolding: vi.fn(async () => true),
 }));
+// NOT mocked: @/lib/holding — the guard returns a REAL drainable UI message stream.
 vi.mock("@/lib/llm", () => ({
 	streamChat: vi.fn(),
 	summarizeForVisitor: vi.fn(async () => null),
@@ -370,6 +374,109 @@ describe("POST /v1/chat — visitor identity (Bug 1: agent is identity-aware)", 
 			input.identity,
 		);
 		expect(system).not.toContain("# Visitor");
+		await settle();
+	});
+});
+
+describe("POST /v1/chat — escalation mutes the bot (Bug 3 holding message)", () => {
+	// Spy-capturing /chat db: conversation.findFirst returns convRow
+	// (escalatedAt/archivedAt/messageCount); insert is a spy so we can assert what a
+	// muted turn persisted (the user row only — never an assistant/usageEvent row).
+	function mockChatDb(
+		convRow: Record<string, unknown>,
+		sources: unknown[] = [],
+	) {
+		const valuesSpy = vi.fn((_row: unknown) =>
+			Object.assign(Promise.resolve([]), {
+				returning: async () => [{ id: "ue1" }],
+			}),
+		);
+		vi.mocked(db).mockReturnValue({
+			query: {
+				project: { findFirst: async () => project },
+				conversation: {
+					findFirst: async () => ({ id: "c1", messageCount: 1, ...convRow }),
+				},
+				source: { findMany: async () => sources },
+				systemPrompt: { findFirst: async () => undefined },
+			},
+			insert: () => ({ values: valuesSpy }),
+			update: () => ({ set: () => ({ where: async () => [] }) }),
+		} as unknown as ReturnType<typeof db>);
+		return { valuesSpy };
+	}
+
+	const ESCALATED = { escalatedAt: new Date(), archivedAt: null };
+
+	it("mutes the bot when escalated-and-unresolved — streams the holding ack, never calls the model", async () => {
+		mockChatDb(ESCALATED);
+		vi.mocked(shouldSendHolding).mockResolvedValueOnce(true);
+		const { ctx, settle } = makeCtx();
+		const res = await send(validBody, ctx);
+		expect(res.status).toBe(200);
+		// It's a UI message stream (what useChat parses), not a JSON body.
+		expect(res.headers.get("content-type")).toContain("text/event-stream");
+		expect(streamChat).not.toHaveBeenCalled();
+		expect(await res.text()).toContain(ESCALATED_HOLDING_MESSAGE);
+		await settle();
+	});
+
+	it("still persists the visitor message on a muted turn (operator sees it)", async () => {
+		const { valuesSpy } = mockChatDb(ESCALATED);
+		const { ctx, settle } = makeCtx();
+		await send(validBody, ctx);
+		// Silence the bot, not the visitor: exactly one insert — the 'user' row.
+		expect(valuesSpy).toHaveBeenCalledTimes(1);
+		expect((valuesSpy.mock.calls[0]![0] as { role?: string }).role).toBe(
+			"user",
+		);
+		await settle();
+	});
+
+	it("a non-escalated conversation answers normally (regression)", async () => {
+		mockChatDb({ escalatedAt: null, archivedAt: null });
+		streamOk();
+		const { ctx, settle } = makeCtx();
+		const res = await send(validBody, ctx);
+		expect(res.status).toBe(200);
+		expect(streamChat).toHaveBeenCalledTimes(1);
+		await settle();
+	});
+
+	it("an escalated-but-ARCHIVED (resolved) conversation answers normally (predicate boundary)", async () => {
+		mockChatDb({ escalatedAt: new Date(), archivedAt: new Date() });
+		streamOk();
+		const { ctx, settle } = makeCtx();
+		await send(validBody, ctx);
+		expect(streamChat).toHaveBeenCalledTimes(1);
+		await settle();
+	});
+
+	it("a muted turn is FREE — no usageEvent and no meter, even on an overage plan", async () => {
+		const { valuesSpy } = mockChatDb(ESCALATED);
+		setAccess({ plan: "growth", stripeCustomerId: "cus_9" });
+		const { ctx, settle } = makeCtx();
+		const res = await send(validBody, ctx);
+		await settle();
+		expect(res.status).toBe(200);
+		// Anchor to the guard: if the mute were removed, streamChat would run and
+		// this fails — so the "free" guarantee can't false-pass.
+		expect(streamChat).not.toHaveBeenCalled();
+		// Only the user row inserted (no usageEvent row); nothing metered.
+		expect(valuesSpy).toHaveBeenCalledTimes(1);
+		expect(reportMeterEvent).not.toHaveBeenCalled();
+	});
+
+	it("throttle: empty stream (no bubble) when shouldSendHolding is false — still free", async () => {
+		const { valuesSpy } = mockChatDb(ESCALATED);
+		vi.mocked(shouldSendHolding).mockResolvedValueOnce(false);
+		const { ctx, settle } = makeCtx();
+		const res = await send(validBody, ctx);
+		expect(res.status).toBe(200);
+		expect(streamChat).not.toHaveBeenCalled();
+		expect(await res.text()).not.toContain(ESCALATED_HOLDING_MESSAGE);
+		// Throttled turn is also free: only the user row, no usageEvent.
+		expect(valuesSpy).toHaveBeenCalledTimes(1);
 		await settle();
 	});
 });
@@ -758,6 +865,66 @@ describe("POST /v1/escalate — in-chat visitor summary (Bug 2)", () => {
 		});
 		await settle();
 	});
+});
+
+describe("POST /v1/escalate — idempotent (Bug 3)", () => {
+	function mockAlreadyEscalated() {
+		const valuesSpy = vi.fn((_row: unknown) =>
+			Object.assign(Promise.resolve([]), {
+				returning: async () => [{ id: "x" }],
+			}),
+		);
+		const setSpy = vi.fn((_p: unknown) => ({ where: async () => [] }));
+		vi.mocked(db).mockReturnValue({
+			query: {
+				project: {
+					findFirst: async () => ({
+						...project,
+						notifyEmail: "ops@acme.com",
+						inboundEmailLocal: "acme",
+						slackWebhookUrl: null,
+					}),
+				},
+				conversation: {
+					findFirst: async () => ({
+						id: "c1",
+						messageCount: 2,
+						name: null,
+						email: null,
+						escalatedAt: new Date(), // already escalated
+					}),
+				},
+				message: { findMany: async () => [] },
+			},
+			insert: () => ({ values: valuesSpy }),
+			update: () => ({ set: setSpy }),
+		} as unknown as ReturnType<typeof db>);
+		return { valuesSpy, setSpy };
+	}
+
+	it("a re-escalation on an already-escalated conversation is a no-op — no re-fire, no re-stamp, no recap", async () => {
+		const { valuesSpy, setSpy } = mockAlreadyEscalated();
+		const { ctx, settle } = makeCtx();
+		const res = await sendEscalate(
+			{ projectKey: "pk_live", clientId: "client_1", messages: [] },
+			ctx,
+		);
+		expect(res.status).toBe(200);
+		expect(await res.json()).toMatchObject({
+			ok: true,
+			summary: null,
+			alreadyEscalated: true,
+		});
+		expect(sendEmail).not.toHaveBeenCalled(); // no operator/customer re-notify
+		expect(sendEscalationSlack).not.toHaveBeenCalled();
+		expect(summarizeForVisitor).not.toHaveBeenCalled(); // no recap re-gen (Bug 2)
+		expect(valuesSpy).not.toHaveBeenCalled(); // no duplicate system row
+		expect(setSpy).not.toHaveBeenCalled(); // no escalatedAt re-stamp
+		await settle();
+	});
+	// The first-escalation happy path (escalatedAt null → full flow incl. the Bug-2
+	// recap) is covered by the "in-chat visitor summary" describe above, whose
+	// conversation mock has no escalatedAt → this guard is false → nothing skipped.
 });
 
 describe("public widget pre-lookup IP gate", () => {

--- a/apps/api/src/routes/chat.ts
+++ b/apps/api/src/routes/chat.ts
@@ -9,7 +9,11 @@ import {
 } from "@/lib/conversation-summary";
 import { db } from "@/lib/db";
 import { buildReplyToAddress, escapeHtml, sendEmail } from "@/lib/email";
-import { publicLookupRateLimit, rateLimit } from "@/lib/kv";
+import {
+	ESCALATED_HOLDING_MESSAGE,
+	holdingStreamResponse,
+} from "@/lib/holding";
+import { publicLookupRateLimit, rateLimit, shouldSendHolding } from "@/lib/kv";
 import { streamChat, summarizeForVisitor } from "@/lib/llm";
 import { isResponseBlocked, resolveAccess } from "@/lib/plan";
 import { captureEvent } from "@/lib/posthog";
@@ -227,6 +231,20 @@ export const chat = new Hono<AppContext>()
 			.set({ messageCount: nextSeq, updatedAt: new Date() })
 			.where(eq(conversation.id, conv.id));
 
+		// Holding-message guard: a human is in the loop (escalated and not yet
+		// resolved), so the bot must NOT answer over the handoff. The visitor message
+		// is already persisted above (the operator sees it) and messageCount is
+		// bumped, so returning here only skips the model call + the post-stream
+		// waitUntil — NO assistant row, NO usageEvent, NO Stripe meter: a muted turn
+		// is free. Instead of an AI reply we stream a static, automated holding
+		// acknowledgement (throttled to once per ~5 min so a waiting visitor isn't
+		// spammed; an empty stream completes cleanly with no bubble otherwise). The
+		// reopen latch (unarchive leaves escalatedAt set) is a ticketed follow-up.
+		if (conv.escalatedAt && !conv.archivedAt) {
+			const send = await shouldSendHolding(c.env, conv.id);
+			return holdingStreamResponse(send ? ESCALATED_HOLDING_MESSAGE : null);
+		}
+
 		let activePromptContent = project.systemPrompt;
 		const activePromptId = project.activeSystemPromptId;
 		if (activePromptId) {
@@ -386,6 +404,15 @@ export const chat = new Hono<AppContext>()
 		});
 		if (!conv) {
 			return c.json({ error: "no conversation" }, 404);
+		}
+		// Idempotent escalation: if already escalated, do nothing again — no duplicate
+		// system row, no escalatedAt re-stamp, no operator email/Slack, and skip the
+		// visitor-recap generation. A reloading visitor whose session-local "escalated"
+		// flag reset can re-POST /v1/escalate; this stops it re-firing notifications.
+		// (The widget also hydrates escalatedAt from /v1/messages to hide the CTA; this
+		// is the server-side backstop for races that hydration can't cover.)
+		if (conv.escalatedAt) {
+			return c.json({ ok: true, summary: null, alreadyEscalated: true });
 		}
 		// DB first: the escalation must be recorded and visible in the inbox
 		// regardless of whether any notification below succeeds.

--- a/apps/api/src/routes/widget-messages.test.ts
+++ b/apps/api/src/routes/widget-messages.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { db } from "@/lib/db";
+
+import { widgetMessages } from "./widget-messages";
+
+vi.mock("@/lib/db", () => ({ db: vi.fn() }));
+vi.mock("@/lib/kv", () => ({
+	rateLimit: vi.fn(async () => ({ ok: true })),
+	publicLookupRateLimit: vi.fn(async () => ({ ok: true })),
+}));
+vi.mock("@/lib/request", () => ({ clientIp: () => "1.2.3.4" }));
+
+const ENV = { vars: {}, DB: {} } as never;
+
+function mockDb(conv: Record<string, unknown> | null, rows: unknown[] = []) {
+	vi.mocked(db).mockReturnValue({
+		query: {
+			project: { findFirst: async () => ({ id: "p1" }) },
+			conversation: { findFirst: async () => conv },
+			message: { findMany: async () => rows },
+		},
+	} as unknown as ReturnType<typeof db>);
+}
+
+function getMessages() {
+	return widgetMessages.request(
+		"/messages?projectKey=pk&clientId=c1",
+		{ method: "GET" },
+		ENV,
+	);
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+});
+
+describe("GET /v1/messages — escalatedAt exposure (Bug 3)", () => {
+	it("returns escalatedAt so the widget can hydrate the handoff state on reload", async () => {
+		const when = new Date("2026-06-29T00:00:00.000Z");
+		mockDb({ id: "c1", csatRating: null, escalatedAt: when });
+		const res = await getMessages();
+		expect(res.status).toBe(200);
+		expect((await res.json()).escalatedAt).toBe(when.toISOString());
+	});
+
+	it("returns escalatedAt: null for a non-escalated conversation", async () => {
+		mockDb({ id: "c1", csatRating: null, escalatedAt: null });
+		expect((await (await getMessages()).json()).escalatedAt).toBeNull();
+	});
+
+	it("returns escalatedAt: null in the no-conversation branch (shape stability)", async () => {
+		mockDb(null);
+		const json = await (await getMessages()).json();
+		expect(json.conversationId).toBeNull();
+		expect(json.escalatedAt).toBeNull();
+	});
+});

--- a/apps/api/src/routes/widget-messages.ts
+++ b/apps/api/src/routes/widget-messages.ts
@@ -58,7 +58,12 @@ export const widgetMessages = new Hono<AppContext>().get(
 				a(e(ct.projectId, project.id), e(ct.clientId, clientId)),
 		});
 		if (!conv) {
-			return c.json({ conversationId: null, csatRating: null, messages: [] });
+			return c.json({
+				conversationId: null,
+				csatRating: null,
+				escalatedAt: null,
+				messages: [],
+			});
 		}
 
 		const rows = await db(c.env).query.message.findMany({
@@ -74,6 +79,9 @@ export const widgetMessages = new Hono<AppContext>().get(
 			conversationId: conv.id,
 			// Conversation-level CSAT so the widget never re-prompts a rated visitor.
 			csatRating: conv.csatRating,
+			// Lets the widget hydrate "escalated" on reload (hide the CTA, show the
+			// notice) so it can't re-fire /v1/escalate. Serializes to an ISO string.
+			escalatedAt: conv.escalatedAt,
 			messages: rows.map((m) => ({
 				id: m.id,
 				role: m.role,

--- a/packages/widget/src/escalation-threshold.test.ts
+++ b/packages/widget/src/escalation-threshold.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { resolveEscalationThreshold } from "./widget";
+import { deriveEscalated, resolveEscalationThreshold } from "./widget";
 
 describe("resolveEscalationThreshold", () => {
 	it("uses the configured value when it is a valid positive integer", () => {
@@ -17,5 +17,22 @@ describe("resolveEscalationThreshold", () => {
 		expect(resolveEscalationThreshold(0)).toBe(3);
 		expect(resolveEscalationThreshold(-4)).toBe(3);
 		expect(resolveEscalationThreshold(Number.NaN)).toBe(3);
+	});
+});
+
+describe("deriveEscalated", () => {
+	it("is escalated when escalated this session", () => {
+		expect(deriveEscalated(true, null)).toBe(true);
+	});
+
+	it("hydrates from the server feed (the reload case → CTA stays hidden)", () => {
+		// sessionEscalated=false but the feed reports an escalation — e.g. after a
+		// reload, before the visitor re-clicks anything.
+		expect(deriveEscalated(false, "2026-06-29T00:00:00.000Z")).toBe(true);
+		expect(deriveEscalated(false, 1_751_000_000)).toBe(true);
+	});
+
+	it("is NOT escalated when neither session nor feed says so", () => {
+		expect(deriveEscalated(false, null)).toBe(false);
 	});
 });

--- a/packages/widget/src/messages-sync.test.ts
+++ b/packages/widget/src/messages-sync.test.ts
@@ -112,4 +112,30 @@ describe("fetchMessages", () => {
 		);
 		await expect(fetchMessages("http://x", "pk", "c1")).rejects.toThrow(/429/);
 	});
+
+	it("carries escalatedAt through (lets the widget hydrate the handoff state)", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValue(
+				new Response(
+					JSON.stringify({
+						escalatedAt: "2026-06-29T00:00:00.000Z",
+						messages: [],
+					}),
+				),
+			),
+		);
+		const feed = await fetchMessages("http://x", "pk", "c1");
+		expect(feed.escalatedAt).toBe("2026-06-29T00:00:00.000Z");
+	});
+
+	it("defaults escalatedAt to null when the server omits it (staged-rollout safe)", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValue(new Response(JSON.stringify({ messages: [] }))),
+		);
+		expect(
+			(await fetchMessages("http://x", "pk", "c1")).escalatedAt,
+		).toBeNull();
+	});
 });

--- a/packages/widget/src/messages-sync.ts
+++ b/packages/widget/src/messages-sync.ts
@@ -17,6 +17,10 @@ export interface MessageFeed {
 	/** Conversation-level CSAT (1–5), null until rated. Lets the widget avoid
 	 * re-prompting an already-rated visitor. */
 	csatRating: number | null;
+	/** When the conversation was escalated to a human (ISO string from the
+	 * server), or null. Lets the widget hydrate "escalated" on reload so it hides
+	 * the "Talk to a human" CTA and never re-fires /v1/escalate. */
+	escalatedAt: string | number | null;
 	messages: ServerMessage[];
 }
 
@@ -36,6 +40,7 @@ export async function fetchMessages(
 	return {
 		conversationId: data.conversationId ?? null,
 		csatRating: data.csatRating ?? null,
+		escalatedAt: data.escalatedAt ?? null,
 		messages: data.messages ?? [],
 	};
 }

--- a/packages/widget/src/useServerMessages.test.tsx
+++ b/packages/widget/src/useServerMessages.test.tsx
@@ -81,6 +81,27 @@ describe("useServerMessages", () => {
 		]);
 	});
 
+	it("exposes escalatedAt from the feed (drives the widget's handoff state)", async () => {
+		const fetchMock = vi
+			.fn()
+			.mockResolvedValue(
+				new Response(
+					JSON.stringify({
+						escalatedAt: "2026-06-29T00:00:00.000Z",
+						messages: [],
+					}),
+				),
+			);
+		vi.stubGlobal("fetch", fetchMock);
+		const { result } = renderHook(() =>
+			useServerMessages("http://x", "pk", "c1", true),
+		);
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(0);
+		});
+		expect(result.current.escalatedAt).toBe("2026-06-29T00:00:00.000Z");
+	});
+
 	it("stops polling on unmount", async () => {
 		const fetchMock = vi.fn().mockResolvedValue(feedResponse([]));
 		vi.stubGlobal("fetch", fetchMock);

--- a/packages/widget/src/useServerMessages.ts
+++ b/packages/widget/src/useServerMessages.ts
@@ -19,11 +19,13 @@ export function useServerMessages(
 	serverMessages: ServerMessage[];
 	conversationId: string | null;
 	csatRating: number | null;
+	escalatedAt: string | number | null;
 	refresh: () => void;
 } {
 	const [serverMessages, setServerMessages] = useState<ServerMessage[]>([]);
 	const [conversationId, setConversationId] = useState<string | null>(null);
 	const [csatRating, setCsatRating] = useState<number | null>(null);
+	const [escalatedAt, setEscalatedAt] = useState<string | number | null>(null);
 	const abortRef = useRef<AbortController | null>(null);
 
 	const load = useCallback(async () => {
@@ -40,6 +42,7 @@ export function useServerMessages(
 			setServerMessages(feed.messages);
 			setConversationId(feed.conversationId);
 			setCsatRating(feed.csatRating);
+			setEscalatedAt(feed.escalatedAt);
 		} catch {
 			// Transient poll failure — keep showing the last good feed.
 		}
@@ -61,5 +64,5 @@ export function useServerMessages(
 		void load();
 	}, [load]);
 
-	return { serverMessages, conversationId, csatRating, refresh };
+	return { serverMessages, conversationId, csatRating, escalatedAt, refresh };
 }

--- a/packages/widget/src/widget.escalated.test.tsx
+++ b/packages/widget/src/widget.escalated.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// Keep the live widget off the network/model: stub the chat transport + hook and
+// the branding probe, and drive the server feed via a useServerMessages spy.
+vi.mock("ai", () => ({ DefaultChatTransport: class {} }));
+vi.mock("@ai-sdk/react", () => ({
+	Chat: class {},
+	useChat: () => ({
+		messages: [],
+		sendMessage: vi.fn(async () => {}),
+		status: "ready",
+		error: null,
+	}),
+}));
+vi.mock("./widget-config", () => ({ useShowBranding: () => false }));
+
+import * as serverMessages from "./useServerMessages";
+import { Widget } from "./widget";
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+/** A feed with enough visitor turns that the "Talk to a human" CTA WOULD show
+ * (>= the default threshold of 3) — so hiding it can only be the escalation. */
+function mockFeed(escalatedAt: string | null) {
+	vi.spyOn(serverMessages, "useServerMessages").mockReturnValue({
+		serverMessages: [1, 2, 3].map((n) => ({
+			id: `s${n}`,
+			role: "user",
+			content: `msg ${n}`,
+			sequence: n,
+			createdAt: n,
+		})),
+		conversationId: "c1",
+		csatRating: null,
+		escalatedAt,
+		refresh: vi.fn(),
+	});
+}
+
+async function mountIdentified(escalatedAt: string | null) {
+	mockFeed(escalatedAt);
+	render(
+		<Widget
+			widgetMode="live"
+			projectKey="pk"
+			apiUrl="http://x"
+			brandColor="#4f46e5"
+			mode="inline"
+		/>,
+	);
+	// Pass the pre-chat IdentifyForm gate so the conversation surface renders.
+	await userEvent.type(screen.getByPlaceholderText(/your name/i), "Test");
+	await userEvent.click(screen.getByRole("button", { name: /start chat/i }));
+}
+
+describe("LiveWidget — escalation hydration (Bug 3)", () => {
+	it("hydrates escalated from the feed: hides the CTA, shows the notice, keeps the composer typeable", async () => {
+		await mountIdentified("2026-06-29T00:00:00.000Z");
+		// NN6: the CTA is hidden purely from the server escalatedAt (escalatedLocal is
+		// false this session — the reload case) so /v1/escalate can't be re-fired.
+		expect(
+			screen.queryByRole("button", { name: /talk to a human/i }),
+		).not.toBeInTheDocument();
+		expect(
+			screen.getByText(/human operator has been notified/i),
+		).toBeInTheDocument();
+		// NN1: silence the bot, not the visitor — the message input stays enabled.
+		expect(
+			screen.getByRole("textbox", { name: /message/i }),
+		).not.toBeDisabled();
+	});
+
+	it("a non-escalated feed with the same message count DOES show the CTA (proves it's escalation that hides it)", async () => {
+		await mountIdentified(null);
+		expect(
+			screen.getByRole("button", { name: /talk to a human/i }),
+		).toBeInTheDocument();
+	});
+});

--- a/packages/widget/src/widget.tsx
+++ b/packages/widget/src/widget.tsx
@@ -96,6 +96,19 @@ export function resolveEscalationThreshold(value?: number): number {
 		: DEFAULT_ESCALATION_THRESHOLD;
 }
 
+/**
+ * Whether the conversation is escalated to a human — true if escalated this
+ * session OR the server feed reports an escalation. Hydrating from the server
+ * means a reload keeps the handoff state: the "Talk to a human" CTA stays hidden
+ * (so the visitor can't re-fire /v1/escalate) and the notice keeps showing.
+ */
+export function deriveEscalated(
+	sessionEscalated: boolean,
+	feedEscalatedAt: string | number | null,
+): boolean {
+	return sessionEscalated || feedEscalatedAt != null;
+}
+
 function LiveWidget({
 	projectKey,
 	apiUrl,
@@ -109,7 +122,7 @@ function LiveWidget({
 	const [name, setName] = useState("");
 	const [email, setEmail] = useState("");
 	const [identified, setIdentified] = useState(false);
-	const [escalated, setEscalated] = useState(false);
+	const [escalatedLocal, setEscalatedLocal] = useState(false);
 	const [escalating, setEscalating] = useState(false);
 	const [escalateFailed, setEscalateFailed] = useState(false);
 	// Visitor-facing recap returned by /v1/escalate; null = no card (honesty rail).
@@ -148,8 +161,16 @@ function LiveWidget({
 
 	// Poll the persisted feed while chatting so admin replies from the
 	// dashboard appear without a refresh.
-	const { serverMessages, conversationId, csatRating, refresh } =
-		useServerMessages(apiUrl, projectKey, clientId, open && identified);
+	const {
+		serverMessages,
+		conversationId,
+		csatRating,
+		escalatedAt: serverEscalatedAt,
+		refresh,
+	} = useServerMessages(apiUrl, projectKey, clientId, open && identified);
+	// Escalated this session OR per the server feed (hydrates on reload so the
+	// "Talk to a human" CTA can't reappear and re-fire /v1/escalate).
+	const escalated = deriveEscalated(escalatedLocal, serverEscalatedAt);
 
 	// Per-message thumbs: optimistic, rolling back if the request fails.
 	const sendRating = useCallback(
@@ -264,7 +285,7 @@ function LiveWidget({
 				})),
 			});
 			setEscalationSummary(summary);
-			setEscalated(true);
+			setEscalatedLocal(true);
 			refresh();
 		} catch {
 			setEscalateFailed(true);


### PR DESCRIPTION
## Bug 3 — the bot keeps answering after escalation

Once a visitor escalates to a human, the bot must stop talking over the handoff. It didn't: `/v1/chat` had no escalation guard, so every post-escalation visitor message still got a streamed AI reply — directly contradicting the "a human will take over" notice.

### What it does now
When a conversation is **escalated and not yet resolved** (`escalatedAt` set, `archivedAt` null), `/v1/chat` early-returns a **stream-shaped holding acknowledgement** instead of an AI reply. The guard sits **after** the visitor message is persisted (the operator still sees it) and **before** model resolution, so it skips `streamChat` *and* the post-stream `waitUntil`.

- **lib/holding.ts** — `holdingStreamResponse()` emits a v6 UI message stream the widget's `useChat` already renders (or an **empty stream → no bubble** when throttled), with no model call. `ESCALATED_HOLDING_MESSAGE` is clearly automated and promises no timeline.
- **Throttle** (`shouldSendHolding`, lib/kv.ts) — one ack per **~5 min** per conversation (STATE, value-tracked expiry), **fail-open toward sending** so a STATE outage reassures rather than dead-airs.
- **Idempotent `/v1/escalate`** — an already-escalated conversation **no-ops** (no duplicate system row, no re-stamp, no operator email/Slack, no recap re-gen). Folded in because the widget's session-local `escalated` flag let a *reloading* visitor re-fire your operator notifications.
- **Widget hydration** — `escalatedAt` is exposed in `/v1/messages`; the widget derives `escalated` from it, so a reload **hides the "Talk to a human" CTA** (can't re-fire escalate) and shows the handoff notice.

### Non-negotiables — held & tested
| # | Guarantee | Proof |
|---|---|---|
| 1 | **Silence the bot, not the visitor** | user message persisted before the guard; composer stays typeable. **LiveWidget mount test** asserts the input is enabled + CTA hidden when the feed reports escalation |
| 2 | **Silenced turns are free** | early return skips the `waitUntil`. Test asserts (anchored to `streamChat` not-called) **no usageEvent + no meter, even on an overage plan** — and the throttled turn too |
| 3 | **Idempotent escalate preserves Bug 2** | re-escalation → no email/Slack/recap/system-row/re-stamp; the first-escalation recap flow is untouched (its tests have no `escalatedAt` → guard false) |
| 4 | **Honesty rail** | the holding copy is explicitly automated, no timeline |
| 5 | **Predicate `escalatedAt && !archivedAt`** | boundary tested: escalated+archived (resolved) answers normally |

### Adversarial review (3 reviewers)
API + widget **ship** (no `breaksIt`): guard placement, the v6 chunk run, the empty-stream clean completion, metering-free, idempotency, and the reload hydration all verified against the codebase + AI SDK source. Tests came back **ship-with-fixes** → fixed: anchored the overage-free test to `streamChat`-not-called (so it can't pass if the mute were deleted), asserted the throttled turn is free, and **added the LiveWidget mount test** pinning NN1 (composer enabled) + NN6 (CTA hidden on reload) to real assertions.

### Tests
`pnpm --filter @llmchat/api test` → **431 passing**; `pnpm --filter @llmchat/widget test` → **88 passing**. Lint/format clean; widget bundle re-embeds.

### Known limitation (ticketed, NOT fixed here)
`escalatedAt` is never cleared, so an **archive → unarchive reopen stays muted** (the bot doesn't resume). This needs either clearing `escalatedAt` on resolve or a status column — bigger than this fix. Also ticketed per the plan: operator notification on post-escalation messages (the holding ack mitigates dead-air for launch), and the resolved-then-revisited inbox-filter gap.

### Notes
- A reviewer flagged that the **paywall short-circuits before the guard**, so a capped/unsubscribed escalated workspace 402s a follow-up (pre-existing paywall behavior, not introduced here).
- Out of scope (untouched): Bug 1, Bug 2, Luca's escalation-email flow, IdentifyForm.

### ⚠️ Pre-existing build note (unchanged from #87/#88)
`pnpm --filter @llmchat/api build` (tsc) is still red on the pre-existing `valuesSpy` zero-arg-mock error in Luca's escalate test (`origin/main`, commit `461865e`) — left untouched per scope; my new tests type their mock args, so they add **no** new tsc errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
