### PR TITLE
fix(widget): make the pressed like/dislike thumb look pressed (Bug 5)

### DIFF
--- a/packages/widget/src/styles.ts
+++ b/packages/widget/src/styles.ts
@@ -533,8 +533,22 @@ export const widgetStyles = `
 	background: #f3f4f6;
 	color: #4b5563;
 }
+/* Pressed = unmistakable: fill the thumb (this CSS fill overrides the inline
+   fill="none" on the outline icons) and tint the button, so a registered vote
+   reads as clearly selected instead of a faint outline recolor. */
 .llmchat-rate-btn[aria-pressed="true"] {
 	color: var(--brand);
+	background: color-mix(in srgb, var(--brand) 12%, transparent);
+}
+.llmchat-rate-btn[aria-pressed="true"] svg {
+	fill: currentColor;
+}
+/* "Helpful" presses positive/brand; "Not helpful" presses to a distinct, muted
+   "noted" state — the filled thumb registers the vote without reading as
+   celebratory, and the darker tint keeps it clearly apart from the brand thumb. */
+.llmchat-rate-btn[aria-label="Not helpful"][aria-pressed="true"] {
+	color: #4b5563;
+	background: #e5e7eb;
 }
 .llmchat-rate-btn:focus-visible {
 	outline: none;


### PR DESCRIPTION
## Bug 5 — the pressed like/dislike thumb didn't look pressed

The rating **logic was already correct** (and tested): the optimistic override flips `aria-pressed` in the same render, the rated message's id is stable so the highlight survives re-render, the 2.5s poll, and reload (via the persisted `message.rating`), and the dashboard's read-only indicator already works. The only problem was **visual**: the "pressed" feedback was a thin hollow-outline thumb merely **recolored** gray→`var(--brand)` — which reads as "nothing happened."

**Fix (CSS-only, 14 lines in `packages/widget/src/styles.ts`):** on `aria-pressed="true"`, **fill the thumb** (`svg { fill: currentColor }` overrides the inline `fill="none"`) and add a brand-tinted background, so a registered vote is unmistakably selected. "Helpful" presses positive/brand; "Not helpful" presses to a distinct muted-gray "noted" state so a downvote registers without reading as celebratory.

### Before → After (CDP-captured, light panel, 3 brand colors)
| | Un-pressed | Liked (pressed) | Disliked (pressed) |
|---|---|---|---|
| **Before** | hollow gray thumb | thin hollow **outline**, only recolored brand (easy to miss) | thin hollow outline, recolored brand |
| **After** | hollow gray thumb *(unchanged)* | **filled brand thumb** on a brand tint | **filled dark-gray thumb** on a gray tint — distinct from "liked" |

Verified with headless-chromium screenshots across `--brand` = indigo / green / pink: the pressed state is unmistakable and obviously distinct from un-pressed in every hue; un-pressed/hover/focus are unchanged.

### Guarantees
- **No logic touched** — the diff is `styles.ts` only. `rate()`, `useMessageRatings`/`effective()`, `displayMessages`, the poll, and the message-id keying are unmodified; widget tests **88/88** green (incl. the `aria-pressed` assertions). The press still persists across re-render / poll / reload via the unchanged wiring.
- **Robust** — `fill: currentColor` correctly overrides the SVG presentation attribute; `color-mix(in srgb, var(--brand) 12%, transparent)` matches the existing widget token usage; `[aria-label="Not helpful"]` targets the dislike button precisely; the dislike gray (#4b5563 on #e5e7eb) is ~6:1 (AA). Adversarially reviewed → ship (the one pale-brand contrast edge is pre-existing and strictly *improved* by the solid fill).

### Out of scope (untouched)
The admin display (already correct), the known "a rating arriving after a thread is open won't refresh live until re-open" caveat, and Bugs 1–4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
