### PR TITLE
feat(db): add nullable conversation.resolved_by column — PR1/2 (migration only)

### DIFF
--- a/apps/api/migrations/0015_conversation_resolved_by.sql
+++ b/apps/api/migrations/0015_conversation_resolved_by.sql
@@ -1,0 +1,21 @@
+-- Resolution attribution: WHO resolved a conversation (the actor), recorded
+-- alongside the existing `archived_at` resolve timestamp. Values: 'visitor' (the
+-- visitor clicked Resolve in the widget via /v1/resolve), 'admin' (an operator
+-- resolved from the dashboard PATCH), and 'bot' RESERVED for a future
+-- auto-resolve path that does NOT exist yet (no scheduler) — never written.
+-- Nullable: NULL = resolved before this column existed, or otherwise
+-- un-attributed → the UI shows a plain "Resolved" with no actor (honest, never a
+-- guessed name). `archived_at` stays the resolve timestamp; this column is purely
+-- the actor and does NOT change status derivation (still archived_at >
+-- escalated_at > open). Additive ADD COLUMN matching the 0010/0014 pattern;
+-- Ploy's ledger applies each file once, in filename order.
+--
+-- PHASE 1 of 2 (deliberate migrate-before-serve split, mirroring 0014). Ploy's
+-- deploy ordering between "apply migrations" and "new Worker serves traffic" is
+-- undocumented, so this PR ships ONLY the column — schema.ts is intentionally NOT
+-- changed, so the live Worker never SELECTs a column that might not exist yet
+-- (findOrCreateConversation on /v1/chat is the hottest path; no read can 500 on a
+-- missing column under any ordering). The /v1/resolve endpoint + admin
+-- attribution write + widget Resolve button + dashboard banner land in a
+-- follow-up PR once this column is live in prod.
+ALTER TABLE `conversation` ADD COLUMN `resolved_by` text;

--- a/apps/api/src/seed.test.ts
+++ b/apps/api/src/seed.test.ts
@@ -68,6 +68,26 @@ describe("production migrations", () => {
 		db.close();
 	});
 
+	it("adds the nullable conversation.resolved_by column (0015)", () => {
+		// Phase 1 of visitor-resolve: the resolution-actor column must exist in a
+		// freshly-migrated DB, nullable (NULL = resolved before this column / no
+		// actor → the UI shows a plain "Resolved", never a guessed actor). schema.ts
+		// deliberately doesn't declare it yet (migrate-before-serve, mirroring
+		// 0014), so this is the ground-truth check that the migration applies
+		// cleanly.
+		const db = migratedDb();
+		const cols = db.prepare("PRAGMA table_info('conversation')").all() as {
+			name: string;
+			type: string;
+			notnull: number;
+		}[];
+		const byName = Object.fromEntries(cols.map((c) => [c.name, c]));
+		expect(byName.resolved_by, "resolved_by column").toBeTruthy();
+		expect(byName.resolved_by.type.toUpperCase()).toContain("TEXT");
+		expect(byName.resolved_by.notnull, "resolved_by nullable").toBe(0);
+		db.close();
+	});
+
 	it("contain no seed file (the dev seed lives outside migrations/)", () => {
 		const offending = readdirSync(MIGRATIONS_DIR)
 			.filter((f) => f.endsWith(".sql"))


### PR DESCRIPTION
**PR 1 of 2** for visitor-initiated resolve + admin attribution. **Migration-only** — `schema.ts` is intentionally untouched.

## What
Adds one nullable column `conversation.resolved_by` (`text`) to record **who** resolved a conversation, alongside the existing `archived_at` resolve timestamp.

- `0015_conversation_resolved_by.sql` — single additive nullable `ALTER TABLE conversation ADD COLUMN resolved_by text;` (no NOT NULL, no default, no table rewrite → metadata-only on SQLite).
- `seed.test.ts` — asserts a freshly-migrated DB has the nullable `resolved_by` column (mirrors the 0014 phase-1 assertion).

## The actor contract (written by PR2)
- `'visitor'` — visitor clicks Resolve in the widget (`/v1/resolve`).
- `'admin'` — operator resolves from the dashboard PATCH.
- `'bot'` — **reserved, never written** (no auto-resolve path / scheduler exists).
- `NULL` — resolved before this column, or otherwise un-attributed → UI shows plain **"Resolved"** (honest, never a guessed actor).

`archived_at` stays the resolve timestamp; this column is purely the actor and does **not** change status derivation (still `archived_at > escalated_at > open`).

## Why migration-only (the 0014 phase-split, followed exactly)
Ploy's deploy ordering between "apply migrations" and "new Worker serves traffic" is undocumented. Shipping **only the column** (schema.ts untouched) means no live Worker read references `resolved_by`, so **no read can 500 under any deploy ordering**. This is the proven `0014` (#76→#77) pattern.

- Hand-authored SQL; **`drizzle-kit generate` not run**, `migrations/meta/` (frozen journal) untouched.
- `0015` is correctly next after `0014`; Ploy's ledger applies each file once in filename order.

## ⚠️ Sequencing (must hold)
1. Merge this PR → deploy to prod → **confirm `resolved_by` is live in prod**.
2. **Only then** open PR2 (schema.ts column + `/v1/resolve` + admin attribution + widget + dashboard). PR2 must **never** merge before this column is applied in prod (the hot path would `SELECT resolved_by` against a DB lacking it → 500 on `/v1/chat`), and the two phases must **never** be combined into one PR.

## Gates
- `pnpm --filter @llmchat/api test` → **432 passed** (incl. the new nullable-column assertion).
- `prettier --check` + `oxlint` → clean.
- Migration verified against a real `node:sqlite` engine (applies in filename order after 0014; column is `TEXT`, `notnull=0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)