### PR TITLE
feat: visitor-initiated resolve + resolve attribution (PR2/2)

### DIFF
--- a/apps/api/src/routes/chat.test.ts
+++ b/apps/api/src/routes/chat.test.ts
@@ -946,3 +946,136 @@ describe("public widget pre-lookup IP gate", () => {
 		expect(projectFindFirst).not.toHaveBeenCalled();
 	});
 });
+
+function sendResolve(body: unknown, ctx: ReturnType<typeof makeCtx>["ctx"]) {
+	return chat.request(
+		"/resolve",
+		{
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify(body),
+		},
+		ENV,
+		ctx as unknown as CtxArg,
+	);
+}
+
+describe("POST /v1/resolve — visitor-initiated resolve (Bug 4, Decision B)", () => {
+	// Mocks just the conversation row's escalated/archived state + captures the
+	// conversation update payload (setSpy) so we can assert the archivedAt write
+	// (or its absence). convRow === null → no conversation (404 path).
+	// `updateReturning` is what the atomic conditional UPDATE ... RETURNING yields:
+	// [{ id }] = the write won (archived), [] = it lost the race to a concurrent
+	// escalate (isNull(escalatedAt) predicate matched 0 rows).
+	function mockResolveDb(
+		convRow: Record<string, unknown> | null,
+		updateReturning: unknown[] = [{ id: "c1" }],
+	) {
+		const setSpy = vi.fn((_p: unknown) => ({
+			where: () => ({ returning: async () => updateReturning }),
+		}));
+		vi.mocked(db).mockReturnValue({
+			query: {
+				project: { findFirst: async () => project },
+				conversation: {
+					findFirst: async () =>
+						convRow === null ? undefined : { id: "c1", ...convRow },
+				},
+			},
+			update: () => ({ set: setSpy }),
+		} as unknown as ReturnType<typeof db>);
+		return { setSpy };
+	}
+
+	const body = { projectKey: "pk_live", clientId: "client_1" };
+
+	it("resolves a non-escalated conversation: sets archivedAt + resolvedBy 'visitor'", async () => {
+		const { setSpy } = mockResolveDb({ escalatedAt: null, archivedAt: null });
+		const { ctx } = makeCtx();
+		const res = await sendResolve(body, ctx);
+		expect(res.status).toBe(200);
+		expect(await res.json()).toMatchObject({ ok: true, resolved: true });
+		expect(setSpy).toHaveBeenCalledTimes(1);
+		const payload = setSpy.mock.calls[0]![0] as {
+			archivedAt?: unknown;
+			resolvedBy?: unknown;
+		};
+		expect(payload.archivedAt).toBeInstanceOf(Date);
+		expect(payload.resolvedBy).toBe("visitor");
+	});
+
+	it("DECISION B: an escalated conversation is NOT resolved — archivedAt stays unset so the bug-3 holding guard holds", async () => {
+		const { setSpy } = mockResolveDb({
+			escalatedAt: new Date(),
+			archivedAt: null,
+		});
+		const { ctx } = makeCtx();
+		const res = await sendResolve(body, ctx);
+		// Benign no-op — 200, NOT 409/500.
+		expect(res.status).toBe(200);
+		expect(await res.json()).toMatchObject({
+			ok: true,
+			resolved: false,
+			reason: "escalated",
+		});
+		// Load-bearing: no archivedAt write → `escalatedAt && !archivedAt` stays
+		// true → the bot stays muted over the live human handoff (protects Bug 3).
+		expect(setSpy).not.toHaveBeenCalled();
+	});
+
+	it("is idempotent: an already-resolved conversation is a no-op", async () => {
+		const { setSpy } = mockResolveDb({
+			escalatedAt: null,
+			archivedAt: new Date(),
+		});
+		const { ctx } = makeCtx();
+		const res = await sendResolve(body, ctx);
+		expect(res.status).toBe(200);
+		expect(await res.json()).toMatchObject({
+			ok: true,
+			resolved: true,
+			alreadyResolved: true,
+		});
+		expect(setSpy).not.toHaveBeenCalled();
+	});
+
+	it("already-resolved wins over the escalated block (archived + escalated → idempotent no-op)", async () => {
+		const { setSpy } = mockResolveDb({
+			escalatedAt: new Date(),
+			archivedAt: new Date(),
+		});
+		const { ctx } = makeCtx();
+		const res = await sendResolve(body, ctx);
+		expect(await res.json()).toMatchObject({ alreadyResolved: true });
+		expect(setSpy).not.toHaveBeenCalled();
+	});
+
+	it("returns 404 when the visitor has no conversation", async () => {
+		mockResolveDb(null);
+		const { ctx } = makeCtx();
+		const res = await sendResolve(body, ctx);
+		expect(res.status).toBe(404);
+	});
+
+	it("DECISION B (race): if escalation lands between read and write, the atomic update no-ops — bot stays muted", async () => {
+		// Snapshot reads a non-escalated conv, but the conditional UPDATE matches 0
+		// rows (a concurrent /v1/escalate stamped escalatedAt in the window), so the
+		// `isNull(escalatedAt)` predicate makes the write lose the race.
+		const { setSpy } = mockResolveDb(
+			{ escalatedAt: null, archivedAt: null },
+			[], // RETURNING [] — 0 rows updated
+		);
+		const { ctx } = makeCtx();
+		const res = await sendResolve(body, ctx);
+		expect(res.status).toBe(200);
+		expect(await res.json()).toMatchObject({
+			ok: true,
+			resolved: false,
+			reason: "escalated",
+		});
+		// The write was ATTEMPTED but matched no escalated-free row → archivedAt
+		// never lands on the escalated conversation, so `escalatedAt && !archivedAt`
+		// stays true and the bot stays muted over the live handoff.
+		expect(setSpy).toHaveBeenCalledTimes(1);
+	});
+});

--- a/apps/api/src/routes/chat.ts
+++ b/apps/api/src/routes/chat.ts
@@ -22,8 +22,10 @@ import { sendEscalationSlack } from "@/lib/slack";
 import { reportMeterEvent } from "@/lib/stripe";
 
 import {
+	and as andWhere,
 	conversation,
 	eq,
+	isNull,
 	message as messageTable,
 	usageEvent,
 } from "@llmchat/db";
@@ -87,10 +89,19 @@ const escalateBody = z.object({
 		.max(200),
 });
 
+// Visitor-resolve identifies its own conversation by (projectKey, clientId) —
+// never a client-trusted conversation id (tenant-safe, mirrors /v1/escalate).
+const resolveBody = z.object({
+	projectKey: z.string().max(128),
+	clientId: z.string().max(128),
+});
+
 const RATE_LIMIT_MAX = 20;
 const RATE_LIMIT_WINDOW = 60 * 60;
 // Escalations trigger notification emails — keep the budget much tighter.
 const ESCALATE_RATE_LIMIT_MAX = 5;
+// Visitor-resolve is a cheap idempotent DB write (no email/Slack); modest cap.
+const RESOLVE_RATE_LIMIT_MAX = 10;
 // Hard ceiling on the in-chat visitor recap generation so a slow/hung gpt-5-nano
 // call can never delay the escalate response. On timeout the recap is dropped
 // (summary: null) — the escalation itself is already recorded.
@@ -545,4 +556,80 @@ export const chat = new Hono<AppContext>()
 		// empty, so the widget simply shows no card. Escalation already succeeded.
 		const summary = await summaryPromise;
 		return c.json({ ok: true, summary });
+	})
+	.post("/resolve", zValidator("json", resolveBody), async (c) => {
+		const { projectKey, clientId } = c.req.valid("json");
+
+		// Per-IP gate BEFORE the project lookup — bounds invalid-key DB floods.
+		const ip = clientIp(c);
+		const gate = await publicLookupRateLimit(c.env, ip);
+		if (!gate.ok) {
+			return c.json({ error: "rate limit exceeded" }, 429);
+		}
+
+		const project = await loadProject(c.env, projectKey);
+		if (!project) {
+			return c.json({ error: "invalid project key" }, 404);
+		}
+		const rl = await rateLimit(
+			c.env,
+			`resolve:${project.id}:${ip}`,
+			RESOLVE_RATE_LIMIT_MAX,
+			RATE_LIMIT_WINDOW,
+		);
+		if (!rl.ok) {
+			return c.json({ error: "rate limit exceeded" }, 429);
+		}
+		// Tenant-safe: the visitor's own conversation, by (projectId, clientId) —
+		// never a client-supplied id. Banked rule: and(), never bare eq().
+		const conv = await db(c.env).query.conversation.findFirst({
+			where: (ct, { and, eq: e }) =>
+				and(e(ct.projectId, project.id), e(ct.clientId, clientId)),
+		});
+		if (!conv) {
+			return c.json({ error: "no conversation" }, 404);
+		}
+		// Idempotent: already resolved → no-op (mirrors escalate's alreadyEscalated).
+		// A reloading visitor whose session-local "resolved" flag reset can re-POST;
+		// this stops a second archivedAt re-stamp.
+		if (conv.archivedAt) {
+			return c.json({ ok: true, resolved: true, alreadyResolved: true });
+		}
+		// Decision B — protect the bug-3 holding guard. A human is handling an
+		// escalated conversation, so a VISITOR must NOT resolve it: setting
+		// archivedAt would flip the `escalatedAt && !archivedAt` guard false and let
+		// the bot answer over the live handoff. The operator closes escalated chats
+		// from the dashboard instead. Benign 200 no-op (NOT 409/500) so a race —
+		// visitor taps Resolve just as escalation lands — settles cleanly: the
+		// widget re-polls and shows the escalated state instead of an error band.
+		if (conv.escalatedAt) {
+			return c.json({ ok: true, resolved: false, reason: "escalated" });
+		}
+		// Atomic with the Decision B guard: archive ONLY while not escalated. The
+		// read-time `if (conv.escalatedAt)` above gives the friendly response in the
+		// common case; this `isNull(escalatedAt)` write predicate closes the TOCTOU
+		// window where a concurrent /v1/escalate stamps escalatedAt between the
+		// findFirst and this update — without it a visitor-set archivedAt on a
+		// just-escalated row would flip the holding guard (`escalatedAt &&
+		// !archivedAt`, chat.ts) false and un-mute the bot over a live handoff.
+		const updated = await db(c.env)
+			.update(conversation)
+			.set({
+				archivedAt: new Date(),
+				resolvedBy: "visitor",
+				updatedAt: new Date(),
+			})
+			.where(
+				andWhere(
+					eq(conversation.id, conv.id),
+					isNull(conversation.escalatedAt),
+				),
+			)
+			.returning({ id: conversation.id });
+		if (updated.length === 0) {
+			// A concurrent escalation won the race — leave the bot muted; the widget
+			// re-polls /v1/messages and shows the escalated state.
+			return c.json({ ok: true, resolved: false, reason: "escalated" });
+		}
+		return c.json({ ok: true, resolved: true });
 	});

--- a/apps/api/src/routes/conversations.test.ts
+++ b/apps/api/src/routes/conversations.test.ts
@@ -84,6 +84,9 @@ let conversationTagSelects: number;
 let insertSpy: ReturnType<typeof vi.fn>;
 let deleteSpy: ReturnType<typeof vi.fn>;
 let updateSpy: ReturnType<typeof vi.fn>;
+/** Captures the .set() payload of the most recent update (e.g. the archive
+ * PATCH) so tests can assert archivedAt / resolvedBy attribution. */
+let setSpy: ReturnType<typeof vi.fn>;
 
 /** Records the shape of every message-table query so tests can assert the
  * content-search queries are scoped via a conversation join. */
@@ -105,7 +108,10 @@ function mockDb(state: State) {
 		},
 	}));
 	deleteSpy = vi.fn(() => ({ where: async () => [] }));
-	updateSpy = vi.fn(() => ({ set: () => ({ where: async () => [] }) }));
+	setSpy = vi.fn((_payload: Record<string, unknown>) => ({
+		where: async () => [],
+	}));
+	updateSpy = vi.fn(() => ({ set: setSpy }));
 
 	function builder(distinct: boolean) {
 		const q = { table: null as unknown, joined: false };
@@ -943,6 +949,29 @@ describe("conversation IDOR — tenant scoping on mutations", () => {
 		});
 		expect(res.status).toBe(200);
 		expect(updateSpy).toHaveBeenCalled();
+	});
+
+	it("PATCH archive attributes the resolve to 'admin'; reopen clears archivedAt + resolvedBy (Bug 4)", async () => {
+		mockDb({
+			role: "agent",
+			project: PROJECT,
+			conv: { id: "c1", projectId: "p1", messageCount: 2 },
+		});
+		await send("/projects/p1/conversations/c1", "PATCH", { archived: true });
+		expect(setSpy.mock.calls[0]![0]).toMatchObject({ resolvedBy: "admin" });
+		expect(setSpy.mock.calls[0]![0].archivedAt).toBeInstanceOf(Date);
+
+		// Reopen: archivedAt AND resolvedBy both clear (no stale attribution).
+		mockDb({
+			role: "agent",
+			project: PROJECT,
+			conv: { id: "c1", projectId: "p1", messageCount: 2 },
+		});
+		await send("/projects/p1/conversations/c1", "PATCH", { archived: false });
+		expect(setSpy.mock.calls[0]![0]).toMatchObject({
+			archivedAt: null,
+			resolvedBy: null,
+		});
 	});
 
 	it("PATCH read 404s a cross-tenant conversation id — never writes a read receipt", async () => {

--- a/apps/api/src/routes/conversations.ts
+++ b/apps/api/src/routes/conversations.ts
@@ -555,7 +555,12 @@ export const conversations = new Hono<AppContext>()
 			if (archived !== undefined) {
 				await db(c.env)
 					.update(conversation)
-					.set({ archivedAt: archived ? new Date() : null })
+					.set({
+						archivedAt: archived ? new Date() : null,
+						// Attribution mirror of archivedAt: an operator resolving from the
+						// dashboard is recorded as "admin"; reopening clears both.
+						resolvedBy: archived ? "admin" : null,
+					})
 					.where(
 						and(eq(conversation.id, id), eq(conversation.projectId, projectId)),
 					);

--- a/apps/api/src/routes/widget-messages.test.ts
+++ b/apps/api/src/routes/widget-messages.test.ts
@@ -56,3 +56,23 @@ describe("GET /v1/messages — escalatedAt exposure (Bug 3)", () => {
 		expect(json.escalatedAt).toBeNull();
 	});
 });
+
+describe("GET /v1/messages — archivedAt exposure (Bug 4 resolved-state hydration)", () => {
+	it("returns archivedAt so the widget can hydrate the resolved state on reload", async () => {
+		const when = new Date("2026-06-29T00:00:00.000Z");
+		mockDb({ id: "c1", csatRating: null, escalatedAt: null, archivedAt: when });
+		const res = await getMessages();
+		expect(res.status).toBe(200);
+		expect((await res.json()).archivedAt).toBe(when.toISOString());
+	});
+
+	it("returns archivedAt: null for a non-resolved conversation", async () => {
+		mockDb({ id: "c1", csatRating: null, escalatedAt: null, archivedAt: null });
+		expect((await (await getMessages()).json()).archivedAt).toBeNull();
+	});
+
+	it("returns archivedAt: null in the no-conversation branch (shape stability)", async () => {
+		mockDb(null);
+		expect((await (await getMessages()).json()).archivedAt).toBeNull();
+	});
+});

--- a/apps/api/src/routes/widget-messages.ts
+++ b/apps/api/src/routes/widget-messages.ts
@@ -62,6 +62,7 @@ export const widgetMessages = new Hono<AppContext>().get(
 				conversationId: null,
 				csatRating: null,
 				escalatedAt: null,
+				archivedAt: null,
 				messages: [],
 			});
 		}
@@ -82,6 +83,10 @@ export const widgetMessages = new Hono<AppContext>().get(
 			// Lets the widget hydrate "escalated" on reload (hide the CTA, show the
 			// notice) so it can't re-fire /v1/escalate. Serializes to an ISO string.
 			escalatedAt: conv.escalatedAt,
+			// Same pattern for "resolved": lets the widget hydrate the resolved state
+			// on reload (hide the Resolve button, show the notice). Raw timestamp →
+			// ISO string, mirroring escalatedAt; the widget derives the boolean.
+			archivedAt: conv.archivedAt,
 			messages: rows.map((m) => ({
 				id: m.id,
 				role: m.role,

--- a/apps/dashboard/src/app/inbox/_components/ConversationList.tsx
+++ b/apps/dashboard/src/app/inbox/_components/ConversationList.tsx
@@ -38,6 +38,7 @@ function ConversationRow({
 	onSelect: () => void;
 }) {
 	const escalated = Boolean(conversation.escalatedAt);
+	const resolved = Boolean(conversation.archivedAt);
 	const unread = Boolean(conversation.unread);
 	return (
 		<button
@@ -108,11 +109,16 @@ function ConversationRow({
 					</p>
 				)}
 				<div className="mt-0.5 flex flex-wrap items-center gap-1.5">
-					{escalated && (
+					{/* Resolved takes precedence over Escalated (matches deriveStatus). */}
+					{resolved ? (
+						<span className="inline-flex h-4 items-center rounded-full bg-ck-accent/15 px-1.5 text-[10px] font-semibold text-ck-accent">
+							Resolved
+						</span>
+					) : escalated ? (
 						<span className="inline-flex h-4 items-center rounded-full bg-ck-warn/15 px-1.5 text-[10px] font-semibold text-ck-warn">
 							Escalated
 						</span>
-					)}
+					) : null}
 					{conversation.tags?.map((t) => (
 						<TagChip key={t.id} tag={t} />
 					))}

--- a/apps/dashboard/src/app/inbox/_components/DetailPanel.test.tsx
+++ b/apps/dashboard/src/app/inbox/_components/DetailPanel.test.tsx
@@ -86,6 +86,27 @@ describe("DetailPanel", () => {
 		expect(screen.getByText(/escalated to a human/i)).toBeInTheDocument();
 	});
 
+	it("shows the resolved banner with the actor when resolved (Bug 4 attribution)", () => {
+		setup({ archivedAt: "2026-06-16T05:02:00.000Z", resolvedBy: "visitor" });
+		expect(screen.getByText(/resolved by the visitor/i)).toBeInTheDocument();
+	});
+
+	it("attributes an admin resolve to the team", () => {
+		setup({ archivedAt: "2026-06-16T05:02:00.000Z", resolvedBy: "admin" });
+		expect(screen.getByText(/resolved by your team/i)).toBeInTheDocument();
+	});
+
+	it("falls back to a plain 'Resolved' when the actor is null (legacy rows — never a guessed actor)", () => {
+		setup({ archivedAt: "2026-06-16T05:02:00.000Z", resolvedBy: null });
+		expect(screen.getByText(/^resolved$/i)).toBeInTheDocument();
+		expect(screen.queryByText(/resolved by/i)).not.toBeInTheDocument();
+	});
+
+	it("shows no resolved banner when not resolved", () => {
+		setup({ archivedAt: null });
+		expect(screen.queryByText(/^resolved/i)).not.toBeInTheDocument();
+	});
+
 	it("shows the CSAT score honestly when rated", () => {
 		setup({ csatRating: 4 });
 		expect(screen.getByText(/4 \/ 5/)).toBeInTheDocument();

--- a/apps/dashboard/src/app/inbox/_components/DetailPanel.tsx
+++ b/apps/dashboard/src/app/inbox/_components/DetailPanel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import {
+	Check,
 	Clock,
 	Globe,
 	Mail,
@@ -138,6 +139,24 @@ export function DetailPanel({
 						</div>
 						<p className="mt-1 text-xs text-ck-warn/80">
 							{formatFullDate(conversation.escalatedAt)}
+						</p>
+					</div>
+				)}
+
+				{conversation.archivedAt && (
+					<div className="m-4 rounded-[10px] bg-ck-accent/12 p-3">
+						<div className="flex items-center gap-2">
+							<Check className="size-4 text-ck-accent" />
+							<span className="text-xs font-semibold text-ck-accent">
+								{conversation.resolvedBy === "visitor"
+									? "Resolved by the visitor"
+									: conversation.resolvedBy === "admin"
+										? "Resolved by your team"
+										: "Resolved"}
+							</span>
+						</div>
+						<p className="mt-1 text-xs text-ck-accent/80">
+							{formatFullDate(conversation.archivedAt)}
 						</p>
 					</div>
 				)}

--- a/apps/dashboard/src/app/inbox/_components/types.ts
+++ b/apps/dashboard/src/app/inbox/_components/types.ts
@@ -16,6 +16,11 @@ export interface Conversation {
 	messageCount: number;
 	escalatedAt: string | null;
 	archivedAt: string | null;
+	/** Who resolved the conversation: "visitor" (clicked Resolve in the widget),
+	 * "admin" (operator resolved here), or null for legacy/un-attributed resolves
+	 * → render a plain "Resolved" with no actor. Optional so existing fixtures
+	 * needn't set it. */
+	resolvedBy?: string | null;
 	createdAt: string;
 	updatedAt: string;
 	/** Tags attached to this conversation (added by the list API; [] when none). */

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -189,6 +189,15 @@ export const conversation = sqliteTable(
 		// Columns were shipped ahead of this code in migration 0014 (phase 1).
 		summary: text(),
 		summaryMessageCount: integer(),
+		// Who resolved the conversation (the actor), recorded alongside archivedAt
+		// (the resolve timestamp). "visitor" = clicked Resolve in the widget via
+		// /v1/resolve; "admin" = operator resolved from the dashboard PATCH; "bot"
+		// is RESERVED for a future auto-resolve path that doesn't exist yet (never
+		// written). NULL = resolved before this column, or otherwise un-attributed
+		// → the UI shows a plain "Resolved", never a guessed actor. Does not affect
+		// status derivation (still archivedAt > escalatedAt > open). Column shipped
+		// ahead of this code in migration 0015 (phase 1).
+		resolvedBy: text(),
 		createdAt: createdAt(),
 		updatedAt: timestamp()
 			.notNull()

--- a/packages/widget/src/components/ResolveSection.tsx
+++ b/packages/widget/src/components/ResolveSection.tsx
@@ -1,0 +1,31 @@
+import { CheckIcon } from "./icons";
+
+/**
+ * Visitor "Mark resolved" band shown below the message list (mirrors
+ * EscalationSection; reuses the .llmchat-escalate button band). Hidden while
+ * escalated — an escalated conversation can only be resolved by the operator
+ * (Decision B, also enforced server-side in /v1/resolve).
+ */
+export function ResolveSection({
+	pending,
+	failed,
+	onResolve,
+}: {
+	pending: boolean;
+	failed: boolean;
+	onResolve: () => void;
+}) {
+	return (
+		<div className="llmchat-escalate">
+			<button type="button" onClick={onResolve} disabled={pending}>
+				<CheckIcon />
+				{pending ? "Resolving…" : "Mark resolved"}
+			</button>
+			{failed && (
+				<p className="llmchat-error" role="alert">
+					We couldn&apos;t mark this resolved. Please try again.
+				</p>
+			)}
+		</div>
+	);
+}

--- a/packages/widget/src/components/ResolvedNotice.tsx
+++ b/packages/widget/src/components/ResolvedNotice.tsx
@@ -1,0 +1,15 @@
+const RESOLVED_NOTICE = "This conversation has been marked resolved.";
+
+/**
+ * One-time post-resolve band shown below the message list (mirrors
+ * EscalationNotice; reuses the .llmchat-escalated band). Actor-neutral copy: the
+ * widget only knows the conversation is resolved (from the feed's archivedAt),
+ * not whether the visitor or an operator resolved it.
+ */
+export function ResolvedNotice() {
+	return (
+		<div className="llmchat-escalated" role="status">
+			<p className="llmchat-escalated-notice">{RESOLVED_NOTICE}</p>
+		</div>
+	);
+}

--- a/packages/widget/src/components/icons.tsx
+++ b/packages/widget/src/components/icons.tsx
@@ -121,6 +121,25 @@ export function StarIcon({
 	);
 }
 
+export function CheckIcon({ className }: IconProps) {
+	return (
+		<svg
+			className={className}
+			width="16"
+			height="16"
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="2"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			aria-hidden="true"
+		>
+			<path d="M20 6 9 17l-5-5" />
+		</svg>
+	);
+}
+
 export function AgentIcon({ className }: IconProps) {
 	return (
 		<svg

--- a/packages/widget/src/messages-sync.ts
+++ b/packages/widget/src/messages-sync.ts
@@ -21,6 +21,10 @@ export interface MessageFeed {
 	 * server), or null. Lets the widget hydrate "escalated" on reload so it hides
 	 * the "Talk to a human" CTA and never re-fires /v1/escalate. */
 	escalatedAt: string | number | null;
+	/** When the conversation was resolved/archived (ISO string from the server),
+	 * or null. Lets the widget hydrate "resolved" on reload so it hides the
+	 * "Mark resolved" button and shows the resolved notice. */
+	archivedAt: string | number | null;
 	messages: ServerMessage[];
 }
 
@@ -41,6 +45,7 @@ export async function fetchMessages(
 		conversationId: data.conversationId ?? null,
 		csatRating: data.csatRating ?? null,
 		escalatedAt: data.escalatedAt ?? null,
+		archivedAt: data.archivedAt ?? null,
 		messages: data.messages ?? [],
 	};
 }

--- a/packages/widget/src/resolve.ts
+++ b/packages/widget/src/resolve.ts
@@ -1,0 +1,34 @@
+export interface ResolvePayload {
+	projectKey: string;
+	clientId: string;
+}
+
+export interface ResolveResult {
+	/** True when the conversation is now resolved (or already was). False when the
+	 * server declined — an escalated conversation a visitor can't resolve
+	 * (Decision B); the caller re-polls instead of showing an error. */
+	resolved: boolean;
+}
+
+/**
+ * POST the visitor-resolve request; throws on network failure or non-2xx. The
+ * server returns a benign `{ resolved: false, reason: "escalated" }` (still 200)
+ * when a visitor tries to resolve an escalated conversation — a human is handling
+ * it — so the caller treats `resolved` as the source of truth, not the HTTP
+ * status, and re-polls to surface the escalated state.
+ */
+export async function requestResolve(
+	apiUrl: string,
+	payload: ResolvePayload,
+): Promise<ResolveResult> {
+	const res = await fetch(`${apiUrl}/v1/resolve`, {
+		method: "POST",
+		headers: { "content-type": "application/json" },
+		body: JSON.stringify(payload),
+	});
+	if (!res.ok) {
+		throw new Error(`resolve failed: ${res.status}`);
+	}
+	const data = (await res.json().catch(() => ({}))) as { resolved?: unknown };
+	return { resolved: data.resolved === true };
+}

--- a/packages/widget/src/useServerMessages.ts
+++ b/packages/widget/src/useServerMessages.ts
@@ -20,12 +20,14 @@ export function useServerMessages(
 	conversationId: string | null;
 	csatRating: number | null;
 	escalatedAt: string | number | null;
+	archivedAt: string | number | null;
 	refresh: () => void;
 } {
 	const [serverMessages, setServerMessages] = useState<ServerMessage[]>([]);
 	const [conversationId, setConversationId] = useState<string | null>(null);
 	const [csatRating, setCsatRating] = useState<number | null>(null);
 	const [escalatedAt, setEscalatedAt] = useState<string | number | null>(null);
+	const [archivedAt, setArchivedAt] = useState<string | number | null>(null);
 	const abortRef = useRef<AbortController | null>(null);
 
 	const load = useCallback(async () => {
@@ -43,6 +45,7 @@ export function useServerMessages(
 			setConversationId(feed.conversationId);
 			setCsatRating(feed.csatRating);
 			setEscalatedAt(feed.escalatedAt);
+			setArchivedAt(feed.archivedAt);
 		} catch {
 			// Transient poll failure — keep showing the last good feed.
 		}
@@ -64,5 +67,12 @@ export function useServerMessages(
 		void load();
 	}, [load]);
 
-	return { serverMessages, conversationId, csatRating, escalatedAt, refresh };
+	return {
+		serverMessages,
+		conversationId,
+		csatRating,
+		escalatedAt,
+		archivedAt,
+		refresh,
+	};
 }

--- a/packages/widget/src/widget.resolved.test.tsx
+++ b/packages/widget/src/widget.resolved.test.tsx
@@ -23,27 +23,31 @@ afterEach(() => {
 	vi.restoreAllMocks();
 });
 
-/** A feed with enough visitor turns that the "Talk to a human" CTA WOULD show
- * (>= the default threshold of 3) — so hiding it can only be the escalation. */
-function mockFeed(escalatedAt: string | null) {
+/** A feed with a real exchange (>=1 visitor + >=1 bot message) so the "Mark
+ * resolved" CTA is eligible — then archivedAt alone decides whether it shows the
+ * button or the resolved notice. */
+function mockFeed(archivedAt: string | null) {
 	vi.spyOn(serverMessages, "useServerMessages").mockReturnValue({
-		serverMessages: [1, 2, 3].map((n) => ({
-			id: `s${n}`,
-			role: "user",
-			content: `msg ${n}`,
-			sequence: n,
-			createdAt: n,
-		})),
+		serverMessages: [
+			{ id: "s1", role: "user", content: "hi", sequence: 1, createdAt: 1 },
+			{
+				id: "s2",
+				role: "assistant",
+				content: "hello",
+				sequence: 2,
+				createdAt: 2,
+			},
+		],
 		conversationId: "c1",
 		csatRating: null,
-		escalatedAt,
-		archivedAt: null,
+		escalatedAt: null,
+		archivedAt,
 		refresh: vi.fn(),
 	});
 }
 
-async function mountIdentified(escalatedAt: string | null) {
-	mockFeed(escalatedAt);
+async function mountIdentified(archivedAt: string | null) {
+	mockFeed(archivedAt);
 	render(
 		<Widget
 			widgetMode="live"
@@ -58,27 +62,26 @@ async function mountIdentified(escalatedAt: string | null) {
 	await userEvent.click(screen.getByRole("button", { name: /start chat/i }));
 }
 
-describe("LiveWidget — escalation hydration (Bug 3)", () => {
-	it("hydrates escalated from the feed: hides the CTA, shows the notice, keeps the composer typeable", async () => {
+describe("LiveWidget — resolved hydration (Bug 4)", () => {
+	it("hydrates resolved from the feed: hides the Resolve button and shows the notice", async () => {
 		await mountIdentified("2026-06-29T00:00:00.000Z");
-		// NN6: the CTA is hidden purely from the server escalatedAt (escalatedLocal is
-		// false this session — the reload case) so /v1/escalate can't be re-fired.
+		// The button is hidden purely from the server archivedAt (resolvedLocal is
+		// false this session — the reload case), mirroring the escalation pattern.
 		expect(
-			screen.queryByRole("button", { name: /talk to a human/i }),
+			screen.queryByRole("button", { name: /mark resolved/i }),
 		).not.toBeInTheDocument();
-		expect(
-			screen.getByText(/human operator has been notified/i),
-		).toBeInTheDocument();
-		// NN1: silence the bot, not the visitor — the message input stays enabled.
+		expect(screen.getByText(/marked resolved/i)).toBeInTheDocument();
+		// Composer stays enabled post-resolve (no precedent for disabling it).
 		expect(
 			screen.getByRole("textbox", { name: /message/i }),
 		).not.toBeDisabled();
 	});
 
-	it("a non-escalated feed with the same message count DOES show the CTA (proves it's escalation that hides it)", async () => {
+	it("a non-resolved feed with the same exchange DOES show the Resolve button", async () => {
 		await mountIdentified(null);
 		expect(
-			screen.getByRole("button", { name: /talk to a human/i }),
+			screen.getByRole("button", { name: /mark resolved/i }),
 		).toBeInTheDocument();
+		expect(screen.queryByText(/marked resolved/i)).not.toBeInTheDocument();
 	});
 });

--- a/packages/widget/src/widget.tsx
+++ b/packages/widget/src/widget.tsx
@@ -9,9 +9,12 @@ import { EscalationSection } from "./components/EscalationSection";
 import { IdentifyForm } from "./components/IdentifyForm";
 import { MessageList } from "./components/MessageList";
 import { PoweredBy } from "./components/PoweredBy";
+import { ResolvedNotice } from "./components/ResolvedNotice";
+import { ResolveSection } from "./components/ResolveSection";
 import { WidgetFrame } from "./components/WidgetFrame";
 import { rateConversation, shouldPromptCsat } from "./csat";
 import { requestEscalation } from "./escalation";
+import { requestResolve } from "./resolve";
 import { getOrCreateClientId, getText } from "./lib";
 import { mergeMessages } from "./messages-sync";
 import { rateMessage, useMessageRatings } from "./rating";
@@ -109,6 +112,19 @@ export function deriveEscalated(
 	return sessionEscalated || feedEscalatedAt != null;
 }
 
+/**
+ * Whether the conversation is resolved — true if resolved this session OR the
+ * server feed reports it archived. Hydrating from the server keeps the resolved
+ * state across reload: the "Mark resolved" button stays hidden and the resolved
+ * notice keeps showing (mirrors deriveEscalated).
+ */
+export function deriveResolved(
+	sessionResolved: boolean,
+	feedArchivedAt: string | number | null,
+): boolean {
+	return sessionResolved || feedArchivedAt != null;
+}
+
 function LiveWidget({
 	projectKey,
 	apiUrl,
@@ -125,6 +141,9 @@ function LiveWidget({
 	const [escalatedLocal, setEscalatedLocal] = useState(false);
 	const [escalating, setEscalating] = useState(false);
 	const [escalateFailed, setEscalateFailed] = useState(false);
+	const [resolvedLocal, setResolvedLocal] = useState(false);
+	const [resolving, setResolving] = useState(false);
+	const [resolveFailed, setResolveFailed] = useState(false);
 	// Visitor-facing recap returned by /v1/escalate; null = no card (honesty rail).
 	const [escalationSummary, setEscalationSummary] = useState<string | null>(
 		null,
@@ -166,11 +185,15 @@ function LiveWidget({
 		conversationId,
 		csatRating,
 		escalatedAt: serverEscalatedAt,
+		archivedAt: serverArchivedAt,
 		refresh,
 	} = useServerMessages(apiUrl, projectKey, clientId, open && identified);
 	// Escalated this session OR per the server feed (hydrates on reload so the
 	// "Talk to a human" CTA can't reappear and re-fire /v1/escalate).
 	const escalated = deriveEscalated(escalatedLocal, serverEscalatedAt);
+	// Resolved this session OR per the server feed (hydrates on reload like
+	// escalated, so the "Mark resolved" button stays hidden and the notice shows).
+	const resolved = deriveResolved(resolvedLocal, serverArchivedAt);
 
 	// Per-message thumbs: optimistic, rolling back if the request fails.
 	const sendRating = useCallback(
@@ -214,13 +237,19 @@ function LiveWidget({
 		(m) => m.role === "user",
 	).length;
 	const threshold = resolveEscalationThreshold(escalationThreshold);
-	const showEscalation = !escalated && userMessageCount >= threshold;
+	// Hide the escalate CTA once escalated OR resolved (resolved wins — terminal).
+	const showEscalation =
+		!escalated && !resolved && userMessageCount >= threshold;
 
 	// A "real exchange" = at least one persisted visitor message and one bot
 	// reply. Only then (and only when not already rated) do we prompt on close.
 	const hasRealExchange =
 		serverMessages.some((m) => m.role === "user") &&
 		serverMessages.some((m) => m.role === "assistant");
+	// Offer "Mark resolved" once there's a real exchange and the conversation is
+	// neither escalated (Decision B — the operator closes escalated chats) nor
+	// already resolved.
+	const showResolve = !escalated && !resolved && hasRealExchange;
 	const csatEligible = shouldPromptCsat({
 		hasRealExchange,
 		alreadyRated: csatRating != null || csatRated,
@@ -294,6 +323,30 @@ function LiveWidget({
 		}
 	}
 
+	async function handleResolve() {
+		if (resolving) {
+			return;
+		}
+		setResolving(true);
+		setResolveFailed(false);
+		try {
+			const { resolved: didResolve } = await requestResolve(apiUrl, {
+				projectKey,
+				clientId,
+			});
+			// didResolve === false = the server declined (escalated — Decision B);
+			// don't flip local resolved, just re-poll so the escalated state surfaces.
+			if (didResolve) {
+				setResolvedLocal(true);
+			}
+			refresh();
+		} catch {
+			setResolveFailed(true);
+		} finally {
+			setResolving(false);
+		}
+	}
+
 	return (
 		<WidgetFrame
 			inline={inline}
@@ -328,7 +381,19 @@ function LiveWidget({
 							onEscalate={handleEscalate}
 						/>
 					)}
-					{escalated && <EscalationNotice summary={escalationSummary} />}
+					{showResolve && (
+						<ResolveSection
+							pending={resolving}
+							failed={resolveFailed}
+							onResolve={handleResolve}
+						/>
+					)}
+					{/* Resolved wins (terminal) over the escalation notice. */}
+					{resolved ? (
+						<ResolvedNotice />
+					) : (
+						escalated && <EscalationNotice summary={escalationSummary} />
+					)}
 					<Composer
 						value={text}
 						disabled={loading}


### PR DESCRIPTION
**PR 2 of 2** for visitor-initiated resolve. Phase-1 column (`resolved_by`) is **already live in prod** via #91 (migration `0015`) — so this PR safely adds `schema.ts` + the endpoint/widget/dashboard.

## What
A visitor clicks **"Mark resolved"** in the widget → their conversation is marked resolved (`archivedAt` + `resolvedBy: "visitor"`); the dashboard shows **who** resolved it. Operators keep resolving from the dashboard (now attributed `"admin"`).

## Server
- **`POST /v1/resolve`** (public, mirrors `/v1/escalate`): tenant-safe lookup by `(projectId, clientId)` — never a client-trusted id — `publicLookupRateLimit` + per-project `rateLimit`, idempotent.
- **Decision B (protects bug 3):** an **escalated** conversation can't be visitor-resolved. Two layers:
  1. read-time benign `200 {resolved:false, reason:"escalated"}` (not 409/500), and
  2. the write is **atomic** — `.where(and(eq(id), isNull(escalatedAt))).returning()`, so a concurrent `/v1/escalate` that races in **cannot** land `archivedAt` on a live handoff and un-mute the bot. (This closes a TOCTOU hole an adversarial review caught.)
- **Admin PATCH** now stamps `resolvedBy: "admin"` (and `null` on reopen, clearing both). `"bot"` is **reserved, never written**.
- **`GET /v1/messages`** exposes `archivedAt` (both branches) so the widget hydrates resolved-state on reload, mirroring `escalatedAt`.
- `schema.ts`: `resolvedBy: text()` (nullable) — matches migration `0015`.

## Widget (mirrors the bug-3 escalation idiom)
- New `ResolveSection` + `ResolvedNotice` (reuse `.llmchat-escalate` / `.llmchat-escalated`), `deriveResolved` + `handleResolve` paralleling escalation; `archivedAt` threaded through the feed (`MessageFeed` → `fetchMessages` → `useServerMessages` → `deriveResolved`).
- **Resolved wins** over escalated; the Resolve button is hidden while escalated (Decision B, client side). Composer stays enabled; **CSAT, rating, and the `WidgetFrame` header are untouched** (CSAT still fires on close).

## Dashboard
- `DetailPanel`: **"Resolved by the visitor / your team"** banner; `resolvedBy == null` → plain **"Resolved"** (legacy rows — never a guessed actor).
- `ConversationList`: a **"Resolved"** chip (precedence over Escalated, matching `deriveStatus`). `resolvedBy` flows through the full-row API passthrough; `types.ts` adds it optional.

## Tests
`/v1/resolve` (resolve · idempotent · **Decision B: escalated → `archivedAt` NOT written** · **TOCTOU race → atomic no-op** · 404) · admin attribution + reopen-clears · `/v1/messages` archivedAt · widget resolved-reload hydration · DetailPanel banner + null fallback.

## Gates
- api **442** · widget **90** · dashboard **431** — all pass. Widget + dashboard **build** green. api tsc: no new errors. prettier + oxlint clean.

## Adversarial review
4-agent review run pre-PR. One real finding (the TOCTOU race) — **fixed atomically + tested**. Everything else refuted (tenant-safety, rate-limits, feed threading, gating precedence, dashboard passthrough, schema↔migration match).

## Known limitation (ticketed, out of scope)
Resolved-then-revisited: a resolved non-escalated conversation that gets a new message keeps the bot answering while still showing "Resolved" — the existing **reopen-latch** follow-up; documented in code, no behavior change here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)