### PR TITLE
fix(widget): keep the chat greeting visible after the first message

### DIFF
--- a/packages/widget/src/components/MessageList.test.tsx
+++ b/packages/widget/src/components/MessageList.test.tsx
@@ -291,3 +291,35 @@ describe("MessageList auto-scroll (useStickToBottom)", () => {
 		expect(container.querySelector(".llmchat-jump")).toBeInTheDocument();
 	});
 });
+
+describe("MessageList greeting", () => {
+	it("renders the greeting when there are no messages", () => {
+		render(
+			<MessageList
+				greeting="Hi Luca! How can I help?"
+				messages={[]}
+				typing={false}
+				error={null}
+			/>,
+		);
+		expect(screen.getByText("Hi Luca! How can I help?")).toBeInTheDocument();
+	});
+
+	it("keeps the greeting visible (and first) after the first message is sent", () => {
+		// Regression: the greeting used to be gated on messages.length === 0, so it
+		// vanished the moment the visitor sent. It must persist as the first
+		// assistant bubble above the thread.
+		const { container } = render(
+			<MessageList
+				greeting="Hi Luca! How can I help?"
+				messages={[msg("u1", "user", "hello")]}
+				typing={false}
+				error={null}
+			/>,
+		);
+		expect(screen.getByText("Hi Luca! How can I help?")).toBeInTheDocument();
+		const bubbles = container.querySelectorAll(".llmchat-msg");
+		expect(bubbles[0]).toHaveTextContent("Hi Luca! How can I help?");
+		expect(bubbles[1]).toHaveTextContent("hello");
+	});
+});

--- a/packages/widget/src/components/MessageList.tsx
+++ b/packages/widget/src/components/MessageList.tsx
@@ -98,11 +98,14 @@ export function MessageList({
 
 	return (
 		<div className="llmchat-messages" ref={containerRef}>
-			{messages.length === 0 && (
-				<div className="llmchat-msg llmchat-msg-assistant">
-					<Markdown content={greeting} />
-				</div>
-			)}
+			{/* The greeting is a persistent client-only node, NOT a member of the
+			   `messages` array: it always renders as the first assistant bubble so it
+			   stays put once the visitor sends. Keeping it out of `messages` insulates
+			   it from mergeMessages (it would otherwise look like an unmatched local
+			   tail entry) and from rating/scroll/poll logic. */}
+			<div className="llmchat-msg llmchat-msg-assistant">
+				<Markdown content={greeting} />
+			</div>
 			{messages.map((m) => {
 				if (!m.content) {
 					return null;

--- a/packages/widget/src/widget.tsx
+++ b/packages/widget/src/widget.tsx
@@ -368,7 +368,9 @@ function LiveWidget({
 			) : (
 				<>
 					<MessageList
-						greeting={`Hi ${name}! How can I help?`}
+						greeting={
+							name ? `Hi ${name}! How can I help?` : "Hi! How can I help?"
+						}
 						messages={displayMessages}
 						typing={loading}
 						error={sendFailed ? SEND_ERROR : null}


### PR DESCRIPTION
## What

The widget chat greeting (`Hi {name}! How can I help?`) used to vanish the moment the visitor sent their first message. It now **persists as the first message** in the chat.

## Root cause

In `MessageList.tsx` the greeting was a client-only empty-state element gated on `{messages.length === 0 && (...)}`. On first send, `messages.length` became ≥ 1, the guard flipped false, and the greeting disappeared. It was never a real message — purely a client render (the operator never sees it; it's never a server row).

## The fix (one file of logic + a guard + a test)

- **`MessageList.tsx`** — render the greeting as a permanent first assistant bubble, **outside** the `messages` array. Kept as a static client node (not injected as a synthetic message) so it stays insulated from `mergeMessages` (where it would otherwise look like an unmatched local tail entry), and from the rating / scroll-follow / poll logic.
- **`widget.tsx`** — since the greeting is now permanent, guard the empty-name case: `name ? \`Hi ${name}! …\` : "Hi! How can I help?"` so it never renders `Hi !`.
- **`MessageList.test.tsx`** — regression test locking the contract: greeting present when `messages` is empty **and** still first after a send.

## Verification

- `pnpm --filter @llmchat/widget test` → **92 passed** (+2 new).
- Widget builds clean (`vite build` → `dist/widget.js`, embedded into the api asset).
- Adversarial review: **ship**, zero blocking defects.
- Does **not** touch the bug-3 merge logic, escalation/resolve/holding flow, or rating — the greeting never enters the `messages` array. Scroll-follow keys (`useStickToBottom`) derive only from `messages`, so a static node doesn't perturb them.
- Same change also fixes the **showcase** (shares `MessageList`) — consistent.

## Out of scope (separate ticket)

The live widget **hardcodes** its greeting and ignores the configured `project.welcomeMessage` column (which is only rendered in the dashboard preview/onboarding). That plumbing gap is a real separate bug — **not** fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)