### PR TITLE
fix(api): default TRUSTED_CLIENT_IP_HEADER to x-real-ip (Ploy's forwarded header)

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -49,12 +49,12 @@ INBOUND_EMAIL_DOMAIN=example.com
 # Unset ⇒ all inbound-email webhooks are rejected (fail-closed).
 RESEND_INBOUND_WEBHOOK_SECRET=
 # The request header Ploy's edge sets with the real client IP, used for ALL
-# IP-scoped rate limiting (widget + Better Auth). MUST match what the edge
-# actually forwards. Defaults to cf-connecting-ip; set to whatever Ploy forwards
-# in prod (e.g. x-real-ip). CRITICAL: if this header is absent in prod, Better
-# Auth's getIp() returns null and AUTH RATE LIMITING IS SILENTLY SKIPPED (and the
-# widget per-IP limits collapse to a single shared bucket). Verify the header
-# reaches the worker. We never trust x-forwarded-for (client-spoofable).
+# IP-scoped rate limiting (widget + Better Auth). Defaults to x-real-ip — what
+# Ploy forwards for the api worker — so leaving this EMPTY is correct for our
+# infra out-of-the-box (the default no longer depends on this var being set, which
+# previously collapsed every visitor into one "unknown" bucket when unset). Only
+# override for a different host (e.g. Cloudflare's cf-connecting-ip). We never
+# trust x-forwarded-for (client-spoofable).
 TRUSTED_CLIENT_IP_HEADER=
 
 # --- Billing (Stripe) ---

--- a/apps/api/src/auth.test.ts
+++ b/apps/api/src/auth.test.ts
@@ -83,14 +83,14 @@ describe("buildAuthOptions", () => {
 		expect(typeof rl.customStorage?.set).toBe("function");
 	});
 
-	it("trusts only the configured client-IP header for getIp (default cf-connecting-ip, never bare x-forwarded-for)", () => {
+	it("trusts only the configured client-IP header for getIp (default x-real-ip, never bare x-forwarded-for)", () => {
 		expect(buildAuthOptions(env()).advanced.ipAddress.ipAddressHeaders).toEqual(
-			["cf-connecting-ip"],
+			["x-real-ip"],
 		);
 		expect(
-			buildAuthOptions(env({ TRUSTED_CLIENT_IP_HEADER: "x-real-ip" })).advanced
-				.ipAddress.ipAddressHeaders,
-		).toEqual(["x-real-ip"]);
+			buildAuthOptions(env({ TRUSTED_CLIENT_IP_HEADER: "cf-connecting-ip" }))
+				.advanced.ipAddress.ipAddressHeaders,
+		).toEqual(["cf-connecting-ip"]);
 	});
 
 	it("refuses to build with a missing or too-short BETTER_AUTH_SECRET (fail closed)", () => {

--- a/apps/api/src/auth.ts
+++ b/apps/api/src/auth.ts
@@ -75,8 +75,9 @@ export function buildAuthOptions(env: Env) {
 			customStorage: createAuthRateLimitStorage(env),
 		},
 		// Make Better Auth's getIp() trust ONLY the operator-configured edge header
-		// (default cf-connecting-ip), never the spoofable x-forwarded-for. Without
-		// this, an attacker rotates x-forwarded-for to evade the per-IP auth limits.
+		// (default x-real-ip — Ploy's forwarded client IP), never the spoofable
+		// x-forwarded-for. Without this, an attacker rotates x-forwarded-for to evade
+		// the per-IP auth limits.
 		advanced: {
 			ipAddress: { ipAddressHeaders: trustedIpHeaders(env) },
 		},

--- a/apps/api/src/lib/request.test.ts
+++ b/apps/api/src/lib/request.test.ts
@@ -15,8 +15,14 @@ function ctx(
 }
 
 describe("clientIp", () => {
-	it("reads the default trusted header (cf-connecting-ip)", () => {
-		expect(clientIp(ctx({ "cf-connecting-ip": "9.9.9.9" }))).toBe("9.9.9.9");
+	it("reads the default trusted header (x-real-ip — Ploy's forwarded client IP)", () => {
+		expect(clientIp(ctx({ "x-real-ip": "9.9.9.9" }))).toBe("9.9.9.9");
+	});
+
+	it("ignores cf-connecting-ip by default (no longer the baked-in header)", () => {
+		// The durable fix: the default now matches our infra (Ploy/x-real-ip), so a
+		// deploy that lost TRUSTED_CLIENT_IP_HEADER no longer collapses to "unknown".
+		expect(clientIp(ctx({ "cf-connecting-ip": "9.9.9.9" }))).toBe("unknown");
 	});
 
 	it("does NOT fall back to a spoofable x-forwarded-for", () => {
@@ -27,30 +33,32 @@ describe("clientIp", () => {
 		);
 	});
 
-	it("honors the TRUSTED_CLIENT_IP_HEADER override", () => {
+	it("honors the TRUSTED_CLIENT_IP_HEADER override (redirects away from the default)", () => {
+		// Override to cf-connecting-ip: proves the override still works by picking it
+		// over the now-default x-real-ip (a different host can still configure it).
 		expect(
 			clientIp(
 				ctx(
 					{ "x-real-ip": "7.7.7.7", "cf-connecting-ip": "9.9.9.9" },
-					{ TRUSTED_CLIENT_IP_HEADER: "x-real-ip" },
+					{ TRUSTED_CLIENT_IP_HEADER: "cf-connecting-ip" },
 				),
 			),
-		).toBe("7.7.7.7");
+		).toBe("9.9.9.9");
 	});
 
 	it("trims, and falls back to 'unknown' when the trusted header is missing", () => {
-		expect(clientIp(ctx({ "cf-connecting-ip": "  4.4.4.4 " }))).toBe("4.4.4.4");
+		expect(clientIp(ctx({ "x-real-ip": "  4.4.4.4 " }))).toBe("4.4.4.4");
 		expect(clientIp(ctx({}))).toBe("unknown");
 	});
 });
 
 describe("trustedIpHeaders (for Better Auth getIp)", () => {
 	it("is exactly the one trusted header — never x-forwarded-for", () => {
-		expect(trustedIpHeaders()).toEqual(["cf-connecting-ip"]);
+		expect(trustedIpHeaders()).toEqual(["x-real-ip"]);
 		expect(
 			trustedIpHeaders({
-				vars: { TRUSTED_CLIENT_IP_HEADER: "x-real-ip" },
+				vars: { TRUSTED_CLIENT_IP_HEADER: "cf-connecting-ip" },
 			} as Env),
-		).toEqual(["x-real-ip"]);
+		).toEqual(["cf-connecting-ip"]);
 	});
 });

--- a/apps/api/src/lib/request.ts
+++ b/apps/api/src/lib/request.ts
@@ -1,9 +1,13 @@
 import type { Env } from "@/env";
 
-/** The header Ploy's edge populates with the real client IP. Ploy's authoritative
- * header isn't documented in the SDK/types, so it's operator-configurable via
- * TRUSTED_CLIENT_IP_HEADER and defaults to Cloudflare's `cf-connecting-ip`. */
-const DEFAULT_TRUSTED_IP_HEADER = "cf-connecting-ip";
+/** The header Ploy's edge populates with the real client IP. Ploy forwards the
+ * client IP in `x-real-ip` for the api worker, so that's the baked-in default —
+ * correct out-of-the-box for our infra without depending on an env var being set
+ * (a missing/lost TRUSTED_CLIENT_IP_HEADER previously collapsed every visitor into
+ * one "unknown" rate-limit bucket → outage). Still operator-overridable via
+ * TRUSTED_CLIENT_IP_HEADER for a different host (e.g. Cloudflare's
+ * `cf-connecting-ip`). */
+const DEFAULT_TRUSTED_IP_HEADER = "x-real-ip";
 
 function trustedIpHeader(env?: Env): string {
 	return env?.vars.TRUSTED_CLIENT_IP_HEADER || DEFAULT_TRUSTED_IP_HEADER;
@@ -18,7 +22,7 @@ export function trustedIpHeaders(env?: Env): string[] {
 /**
  * Client IP for rate-limit keys. workerd sits behind Ploy's proxy, so we read
  * ONLY the trusted edge-set header (TRUSTED_CLIENT_IP_HEADER, default
- * `cf-connecting-ip`). We deliberately do NOT fall back to a bare
+ * `x-real-ip`). We deliberately do NOT fall back to a bare
  * `x-forwarded-for`: that header is client-supplied and lets an attacker rotate
  * it to evade — or pollute — IP-scoped rate limits. An absent trusted header
  * yields "unknown" (a shared bucket) rather than a forgeable per-request key.


### PR DESCRIPTION
## Why

The recurring widget outage + "IP shows unknown" traces to `clientIp()` defaulting to `cf-connecting-ip` (Cloudflare's header) while our hosting (Ploy) forwards the client IP in `x-real-ip`. We'd been relying on the `TRUSTED_CLIENT_IP_HEADER` env var being set in prod to bridge that — but that dependency is fragile: unset/lost-on-deploy → every visitor resolves to `"unknown"` → one shared rate-limit bucket → outage (happened twice). Luca (owns Ploy) confirmed the durable fix is to bake the correct header into the default.

## The change (one line + tests/docs)

- `request.ts`: `DEFAULT_TRUSTED_IP_HEADER` `cf-connecting-ip` → **`x-real-ip`**. Now correct out-of-the-box for our infra; no longer depends on the env var being set.
- `TRUSTED_CLIENT_IP_HEADER` stays as an **override** for a different host (e.g. Cloudflare's `cf-connecting-ip`).
- The `"unknown"` fallback and the deliberate never-trust-`x-forwarded-for` rule are **unchanged**.
- Tests updated for the new default + one asserting the override redirects *away* from it; refreshed the stale `.env.example` and `auth.ts` comments.

## Verification

- API **443 tests pass** (incl. new: default reads `x-real-ip`; `cf-connecting-ip` is ignored by default; override → `cf-connecting-ip` still works; `trustedIpHeaders()` default → `["x-real-ip"]`).
- The change is centralized in `DEFAULT_TRUSTED_IP_HEADER`, so both the widget rate-limit path (`clientIp`) and Better Auth's `getIp` (`trustedIpHeaders`) pick it up.
- **x-real-ip is correct for our infra per Luca (Ploy owner) — authoritative.** Circumstantial corroboration: when I probed prod during the earlier rate-limit investigation, buckets were keying per-*real*-IP (the escalate gate passed while chat was exhausted for the same IP), i.e. the header was resolving — consistent with `x-real-ip` being what Ploy forwards. I can't introspect Ploy's edge header injection directly from here (no header-echo endpoint), so Luca's confirmation is the basis; the env override remains as the safety valve.

## ⚠️ Note on composition with #94

The task referenced "#94's IP-fallback hardening (just merged)" — but **#94 was reverted** just before this (PR #95, live in prod). So `rateLimitSubject` (per-clientId fallback) and the missing-header warn-once alarm are **not on main**. This change composes with the current (pre-#94) `clientIp`, and is actually **more** important without #94's fallback: getting the default header right is now the primary defense against the "unknown"-collapse outage. Re-landing #94's fallback hardening (tracked) would layer on top cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)