### PR TITLE
fix(api,widget): stop the holding ack once a human replies + anchor it in chronological order

### DIFF
--- a/apps/api/src/lib/holding.ts
+++ b/apps/api/src/lib/holding.ts
@@ -1,16 +1,11 @@
 import { createUIMessageStream, createUIMessageStreamResponse } from "ai";
 
-/**
- * The static, automated acknowledgement a visitor sees IN PLACE of an AI reply
- * when they message a conversation that's escalated to a human. Clearly labelled
- * automated and promises no timeline (honesty rail). Exported so the stream, the
- * tests, and any client-side copy share one source of truth.
- *
- * Deliberately NOT placed in @/lib/llm: chat.test.ts mocks that whole module, and
- * the guard needs the REAL builder to produce a drainable stream in tests.
- */
-export const ESCALATED_HOLDING_MESSAGE =
-	"This is an automated message. Thanks — your reply has been added to the conversation and our support team will follow up here. Feel free to keep adding details in the meantime.";
+// The holding-ack copy now lives in @llmchat/shared/holding (single source of
+// truth shared with the widget, which recognizes it to anchor the bubble). Re-
+// exported here so existing `import { ESCALATED_HOLDING_MESSAGE } from "@/lib/holding"`
+// callers (and chat.test.ts, which deliberately does NOT mock this module so the
+// guard gets the REAL stream builder below) keep working unchanged.
+export { ESCALATED_HOLDING_MESSAGE } from "@llmchat/shared/holding";
 
 /**
  * Return the escalation holding acknowledgement as a v6 UI message stream that the

--- a/apps/api/src/routes/chat.test.ts
+++ b/apps/api/src/routes/chat.test.ts
@@ -385,12 +385,18 @@ describe("POST /v1/chat — escalation mutes the bot (Bug 3 holding message)", (
 	function mockChatDb(
 		convRow: Record<string, unknown>,
 		sources: unknown[] = [],
+		opts: { adminReply?: boolean } = {},
 	) {
 		const valuesSpy = vi.fn((_row: unknown) =>
 			Object.assign(Promise.resolve([]), {
 				returning: async () => [{ id: "ue1" }],
 			}),
 		);
+		// Captures the (column, value) pairs the admin-reply probe's `where` builds, so
+		// a test can assert the predicate is scoped to THIS conversation AND role admin
+		// (a dropped conversationId scope = cross-conversation leak; role "user" = wrong
+		// signal — neither could false-pass a bare `opts.adminReply` mock otherwise).
+		const adminProbeEqs: Array<[unknown, unknown]> = [];
 		vi.mocked(db).mockReturnValue({
 			query: {
 				project: { findFirst: async () => project },
@@ -399,11 +405,36 @@ describe("POST /v1/chat — escalation mutes the bot (Bug 3 holding message)", (
 				},
 				source: { findMany: async () => sources },
 				systemPrompt: { findFirst: async () => undefined },
+				// The Problem-2 "has a human replied?" probe (role: admin). Defaults to
+				// no admin reply, so existing escalated tests keep hitting the ack path.
+				message: {
+					findFirst: async (args?: {
+						where?: (
+							f: Record<string, string>,
+							o: {
+								and: (...x: unknown[]) => unknown;
+								eq: (c: unknown, v: unknown) => unknown;
+							},
+						) => unknown;
+					}) => {
+						args?.where?.(
+							{ conversationId: "conversationId", role: "role" },
+							{
+								and: (...x: unknown[]) => x,
+								eq: (c: unknown, v: unknown) => {
+									adminProbeEqs.push([c, v]);
+									return null;
+								},
+							},
+						);
+						return opts.adminReply ? { id: "admin_msg_1" } : undefined;
+					},
+				},
 			},
 			insert: () => ({ values: valuesSpy }),
 			update: () => ({ set: () => ({ where: async () => [] }) }),
 		} as unknown as ReturnType<typeof db>);
-		return { valuesSpy };
+		return { valuesSpy, adminProbeEqs };
 	}
 
 	const ESCALATED = { escalatedAt: new Date(), archivedAt: null };
@@ -478,6 +509,47 @@ describe("POST /v1/chat — escalation mutes the bot (Bug 3 holding message)", (
 		// Throttled turn is also free: only the user row, no usageEvent.
 		expect(valuesSpy).toHaveBeenCalledTimes(1);
 		await settle();
+	});
+
+	// Problem 2: once a human (admin) is actively replying, the bot goes FULLY silent
+	// — no "we'll follow up" ack (it's contradictory) and still no model call.
+	it("a human (admin) has replied → fully silent: no ack, no model call, throttle NOT consulted", async () => {
+		const { valuesSpy } = mockChatDb(ESCALATED, [], { adminReply: true });
+		const { ctx, settle } = makeCtx();
+		const res = await send(validBody, ctx);
+		expect(res.status).toBe(200);
+		// Bot stays muted (anchored to streamChat so the mute can't false-pass)...
+		expect(streamChat).not.toHaveBeenCalled();
+		// ...and the ack is suppressed — the visitor sees the real human reply via polling.
+		expect(await res.text()).not.toContain(ESCALATED_HOLDING_MESSAGE);
+		// Lazy throttle: the admin-replied path returns BEFORE shouldSendHolding, so it
+		// never dirties the STATE cooldown timestamp.
+		expect(shouldSendHolding).not.toHaveBeenCalled();
+		// Still free + visitor message still persisted (operator sees it).
+		expect(valuesSpy).toHaveBeenCalledTimes(1);
+		await settle();
+	});
+
+	it("NO human reply yet (waiting gap) → the throttle IS consulted and the ack fires", async () => {
+		mockChatDb(ESCALATED, [], { adminReply: false });
+		vi.mocked(shouldSendHolding).mockResolvedValueOnce(true);
+		const { ctx, settle } = makeCtx();
+		const res = await send(validBody, ctx);
+		// The gap path reaches the throttle (proves it's only suppressed once a human is in).
+		expect(shouldSendHolding).toHaveBeenCalledTimes(1);
+		expect(await res.text()).toContain(ESCALATED_HOLDING_MESSAGE);
+		expect(streamChat).not.toHaveBeenCalled();
+		await settle();
+	});
+
+	it("the human-reply probe is scoped to THIS conversation AND role admin (no cross-conversation / wrong-role leak)", async () => {
+		const { adminProbeEqs } = mockChatDb(ESCALATED, [], { adminReply: false });
+		const { ctx, settle } = makeCtx();
+		await send(validBody, ctx);
+		await settle();
+		// Locks the predicate: eq(conversationId, conv.id) AND eq(role, "admin").
+		expect(adminProbeEqs).toContainEqual(["conversationId", "c1"]);
+		expect(adminProbeEqs).toContainEqual(["role", "admin"]);
 	});
 });
 

--- a/apps/api/src/routes/chat.ts
+++ b/apps/api/src/routes/chat.ts
@@ -247,11 +247,27 @@ export const chat = new Hono<AppContext>()
 		// is already persisted above (the operator sees it) and messageCount is
 		// bumped, so returning here only skips the model call + the post-stream
 		// waitUntil — NO assistant row, NO usageEvent, NO Stripe meter: a muted turn
-		// is free. Instead of an AI reply we stream a static, automated holding
-		// acknowledgement (throttled to once per ~5 min so a waiting visitor isn't
-		// spammed; an empty stream completes cleanly with no bubble otherwise). The
-		// reopen latch (unarchive leaves escalatedAt set) is a ticketed follow-up.
+		// is free. The bot stays muted in BOTH branches below (neither calls the model).
+		// The reopen latch (unarchive leaves escalatedAt set) is a ticketed follow-up.
 		if (conv.escalatedAt && !conv.archivedAt) {
+			// Once an operator (role "admin") has actually replied, a human owns the
+			// conversation and is responding directly — so SUPPRESS the automated
+			// "we'll follow up" ack too: re-serving it while a human is actively
+			// replying is contradictory. Go fully silent (empty stream, no bubble); the
+			// visitor sees the operator's real replies via /v1/messages polling. The ack
+			// only fires while no human (admin) reply exists yet — the waiting gap (so an
+			// operator who replied before escalation suppresses even the first ack, which
+			// is correct: a human is already engaged). Evaluate the
+			// throttle LAZILY (only in the no-admin branch) so this admin-replied path
+			// never dirties the STATE cooldown timestamp.
+			const adminReplied = await db(c.env).query.message.findFirst({
+				where: (m, { and, eq: e }) =>
+					and(e(m.conversationId, conv.id), e(m.role, "admin")),
+				columns: { id: true },
+			});
+			if (adminReplied) {
+				return holdingStreamResponse(null);
+			}
 			const send = await shouldSendHolding(c.env, conv.id);
 			return holdingStreamResponse(send ? ESCALATED_HOLDING_MESSAGE : null);
 		}

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -4,7 +4,8 @@
 	"private": true,
 	"type": "module",
 	"exports": {
-		".": "./src/index.ts"
+		".": "./src/index.ts",
+		"./holding": "./src/holding.ts"
 	},
 	"scripts": {
 		"format": "prettier --write .",

--- a/packages/shared/src/holding.ts
+++ b/packages/shared/src/holding.ts
@@ -1,0 +1,13 @@
+/**
+ * The static, automated acknowledgement a visitor sees IN PLACE of an AI reply
+ * when they message a conversation that's escalated to a human. Clearly labelled
+ * automated and promises no timeline (honesty rail).
+ *
+ * Lives in @llmchat/shared (exposed via the narrow `@llmchat/shared/holding`
+ * subpath, NOT the barrel) so it's the single source of truth shared by the api
+ * (which streams it) and the widget (which recognizes it to anchor the holding
+ * bubble in chronological order). The subpath keeps the lean widget IIFE bundle
+ * from pulling the barrel's models snapshot + its import-time validation.
+ */
+export const ESCALATED_HOLDING_MESSAGE =
+	"This is an automated message. Thanks — your reply has been added to the conversation and our support team will follow up here. Feel free to keep adding details in the meantime.";

--- a/packages/widget/package.json
+++ b/packages/widget/package.json
@@ -17,6 +17,7 @@
 	},
 	"dependencies": {
 		"@ai-sdk/react": "^3.0.0",
+		"@llmchat/shared": "workspace:*",
 		"ai": "6.0.27",
 		"react": "^19.0.0",
 		"react-dom": "^19.0.0",

--- a/packages/widget/src/messages-sync.test.ts
+++ b/packages/widget/src/messages-sync.test.ts
@@ -1,3 +1,4 @@
+import { ESCALATED_HOLDING_MESSAGE } from "@llmchat/shared/holding";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { fetchMessages, mergeMessages } from "./messages-sync";
@@ -85,6 +86,86 @@ describe("mergeMessages", () => {
 			],
 		);
 		expect(merged.map((m) => m.content)).toEqual(["help", "On it!", "thanks"]);
+	});
+});
+
+describe("mergeMessages — holding-ack anchoring (Bug 3 / Problem 1)", () => {
+	const HOLD = {
+		id: "lh",
+		role: "assistant",
+		content: ESCALATED_HOLDING_MESSAGE,
+	};
+
+	it("anchors the holding ack right after the visitor turn it acknowledges — ABOVE a later admin reply, not floating at the bottom", () => {
+		const merged = mergeMessages(
+			[srv(1, "user", "help me"), srv(2, "admin", "human here")],
+			[{ id: "l1", role: "user", content: "help me" }, HOLD],
+		);
+		expect(merged.map((m) => `${m.role}:${m.content}`)).toEqual([
+			"user:help me",
+			`assistant:${ESCALATED_HOLDING_MESSAGE}`,
+			"admin:human here",
+		]);
+		// The contradiction we're fixing: the ack must NOT be the last row when a
+		// human has replied below it.
+		expect(merged[merged.length - 1]!.role).toBe("admin");
+	});
+
+	it("keeps the holding ack anchored when a LATER visitor turn is persisted (no float to the bottom)", () => {
+		const merged = mergeMessages(
+			[srv(1, "user", "first"), srv(2, "user", "second")],
+			[
+				{ id: "l1", role: "user", content: "first" },
+				HOLD,
+				{ id: "l2", role: "user", content: "second" },
+			],
+		);
+		expect(merged.map((m) => m.content)).toEqual([
+			"first",
+			ESCALATED_HOLDING_MESSAGE,
+			"second",
+		]);
+	});
+
+	it("anchors N holding acks, each after its OWN triggering visitor turn", () => {
+		const merged = mergeMessages(
+			[srv(1, "user", "q1"), srv(2, "user", "q2")],
+			[
+				{ id: "l1", role: "user", content: "q1" },
+				{ id: "h1", role: "assistant", content: ESCALATED_HOLDING_MESSAGE },
+				{ id: "l2", role: "user", content: "q2" },
+				{ id: "h2", role: "assistant", content: ESCALATED_HOLDING_MESSAGE },
+			],
+		);
+		expect(merged.map((m) => m.id)).toEqual(["s1", "h1", "s2", "h2"]);
+	});
+
+	it("does NOT anchor the normal in-flight pair — a streaming (non-holding) assistant reply still tails", () => {
+		const merged = mergeMessages(
+			[srv(1, "user", "hello")],
+			[
+				{ id: "l1", role: "user", content: "hello" },
+				{ id: "l2", role: "assistant", content: "streaming answer…" },
+			],
+		);
+		expect(merged.map((m) => m.id)).toEqual(["s1", "l2"]);
+	});
+
+	it("tails a holding with no preceding persisted message yet (transient, pre-poll)", () => {
+		const merged = mergeMessages(
+			[], // nothing persisted yet
+			[{ id: "l1", role: "user", content: "q1" }, HOLD],
+		);
+		expect(merged.map((m) => m.id)).toEqual(["l1", "lh"]);
+	});
+
+	it("the anchored holding ack is never rateable", () => {
+		const merged = mergeMessages(
+			[srv(1, "user", "help me")],
+			[{ id: "l1", role: "user", content: "help me" }, HOLD],
+		);
+		const ack = merged.find((m) => m.content === ESCALATED_HOLDING_MESSAGE);
+		expect(ack?.rateable).toBeFalsy();
 	});
 });
 

--- a/packages/widget/src/messages-sync.ts
+++ b/packages/widget/src/messages-sync.ts
@@ -1,3 +1,5 @@
+import { ESCALATED_HOLDING_MESSAGE } from "@llmchat/shared/holding";
+
 import type { DisplayMessage } from "./components/MessageList";
 import type { Rating } from "./rating";
 
@@ -56,28 +58,67 @@ export async function fetchMessages(
  * in-flight user message and the streaming assistant reply).
  *
  * Each local message is matched against one unconsumed server message with the
- * same role+content; matched ones are dropped (already persisted), unmatched
- * ones (still streaming / in flight / failed) are appended after the feed.
+ * same role+content; matched ones are dropped (already persisted) and rendered via
+ * the feed. Unmatched ones (still streaming / in flight / failed) are appended
+ * after the feed — EXCEPT the escalation holding ack.
+ *
+ * The holding ack is client-only (streamed, never persisted → never matches a
+ * server row), so a plain tail-dump would float it to the BOTTOM, below later admin
+ * replies and subsequent visitor turns. We instead ANCHOR it to the server slot of
+ * the visitor message it acknowledges (its nearest preceding matched local), so it
+ * renders in correct chronological order. Only the holding row is anchored — the
+ * normal in-flight pair (just-sent user + streaming reply) legitimately tails.
  */
 export function mergeMessages(
 	server: ServerMessage[],
 	local: DisplayMessage[],
 ): DisplayMessage[] {
 	const consumed = new Set<number>();
-	const tail: DisplayMessage[] = [];
-	for (const l of local) {
+	// Match each local message to a server index (or -1 = unmatched), in local order.
+	const matched: number[] = local.map((l) => {
 		const idx = server.findIndex(
 			(s, i) =>
 				!consumed.has(i) && s.role === l.role && s.content === l.content,
 		);
-		if (idx >= 0) {
-			consumed.add(idx);
-		} else {
-			tail.push(l);
+		if (idx >= 0) consumed.add(idx);
+		return idx;
+	});
+
+	// Holding acks (unmatched assistant rows with the shared ack content) → keyed by
+	// the server index they anchor after. Everything else unmatched → the tail.
+	const anchored = new Map<number, DisplayMessage[]>();
+	const tail: DisplayMessage[] = [];
+	for (let i = 0; i < local.length; i++) {
+		if (matched[i]! >= 0) continue; // persisted → rendered via the feed
+		const l = local[i]!;
+		const isHolding =
+			l.role === "assistant" && l.content === ESCALATED_HOLDING_MESSAGE;
+		if (isHolding) {
+			// Anchor = the server index of the nearest preceding matched local (the
+			// visitor message this ack replied to).
+			let anchor = -1;
+			for (let j = i - 1; j >= 0; j--) {
+				const m = matched[j]!;
+				if (m >= 0) {
+					anchor = m;
+					break;
+				}
+			}
+			if (anchor >= 0) {
+				const existing = anchored.get(anchor);
+				if (existing) existing.push(l);
+				else anchored.set(anchor, [l]);
+				continue;
+			}
+			// No preceding persisted message yet (transient, pre-poll) — tail for now;
+			// it anchors once the visitor message lands in the feed.
 		}
+		tail.push(l);
 	}
-	return [
-		...server.map((s) => ({
+
+	const out: DisplayMessage[] = [];
+	server.forEach((s, i) => {
+		out.push({
 			id: s.id,
 			role: s.role,
 			content: s.content,
@@ -85,7 +126,9 @@ export function mergeMessages(
 			// Only persisted assistant messages can be rated (they have a stable
 			// DB id); in-flight local messages can't until the feed catches up.
 			rateable: s.role === "assistant",
-		})),
-		...tail,
-	];
+		});
+		const holds = anchored.get(i);
+		if (holds) out.push(...holds);
+	});
+	return [...out, ...tail];
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -131,7 +131,7 @@ importers:
         version: 5.100.9(react@19.2.5)
       better-auth:
         specifier: 1.6.9
-        version: 1.6.9(@cloudflare/workers-types@4.20260504.1)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260504.1)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(kysely@0.28.17))(next@15.1.0(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@3.2.6(@types/debug@4.1.13)(@types/node@22.19.17)(jiti@1.21.7)(jsdom@25.0.1)(tsx@4.21.0)(yaml@2.9.0))
+        version: 1.6.9(@cloudflare/workers-types@4.20260504.1)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260504.1)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(kysely@0.28.17))(next@15.1.0(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@3.2.6(@types/debug@4.1.13)(@types/node@22.19.17)(jiti@1.21.7)(jsdom@25.0.1)(tsx@4.21.0)(yaml@2.9.0))
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -146,7 +146,7 @@ importers:
         version: 0.460.0(react@19.2.5)
       next:
         specifier: 15.1.0
-        version: 15.1.0(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 15.1.0(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -231,7 +231,7 @@ importers:
         version: 1.6.9(@cloudflare/workers-types@4.20260504.1)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260504.1)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(kysely@0.28.17))(next@15.1.0(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@3.2.6(@types/debug@4.1.13)(@types/node@22.19.17)(jiti@1.21.7)(jsdom@26.1.0)(tsx@4.21.0)(yaml@2.9.0))
       next:
         specifier: 15.1.0
-        version: 15.1.0(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 15.1.0(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -289,7 +289,7 @@ importers:
         version: 1.6.9(@cloudflare/workers-types@4.20260504.1)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260504.1)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(kysely@0.28.17))(next@15.1.0(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@3.2.6(@types/debug@4.1.13)(@types/node@22.19.17)(jiti@1.21.7)(jsdom@26.1.0)(tsx@4.21.0)(yaml@2.9.0))
       next:
         specifier: 15.1.0
-        version: 15.1.0(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 15.1.0(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -365,6 +365,9 @@ importers:
       '@ai-sdk/react':
         specifier: ^3.0.0
         version: 3.0.177(react@19.2.5)(zod@4.4.3)
+      '@llmchat/shared':
+        specifier: workspace:*
+        version: link:../shared
       ai:
         specifier: 6.0.27
         version: 6.0.27(zod@4.4.3)
@@ -5750,7 +5753,7 @@ snapshots:
     dependencies:
       '@content-collections/core': 0.15.1(typescript@5.9.2)
       '@content-collections/integrations': 0.5.0(@content-collections/core@0.15.1(typescript@5.9.2))
-      next: 15.1.0(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      next: 15.1.0(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
@@ -7702,7 +7705,7 @@ snapshots:
 
   baseline-browser-mapping@2.10.27: {}
 
-  better-auth@1.6.9(@cloudflare/workers-types@4.20260504.1)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260504.1)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(kysely@0.28.17))(next@15.1.0(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@3.2.6(@types/debug@4.1.13)(@types/node@22.19.17)(jiti@1.21.7)(jsdom@25.0.1)(tsx@4.21.0)(yaml@2.9.0)):
+  better-auth@1.6.9(@cloudflare/workers-types@4.20260504.1)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260504.1)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(kysely@0.28.17))(next@15.1.0(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@3.2.6(@types/debug@4.1.13)(@types/node@22.19.17)(jiti@1.21.7)(jsdom@25.0.1)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
       '@better-auth/core': 1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260504.1)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/drizzle-adapter': 1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260504.1)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260504.1)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(kysely@0.28.17))
@@ -7725,7 +7728,7 @@ snapshots:
       better-sqlite3: 12.9.0
       drizzle-kit: 0.31.10
       drizzle-orm: 0.45.2(@cloudflare/workers-types@4.20260504.1)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(kysely@0.28.17)
-      next: 15.1.0(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      next: 15.1.0(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
       vitest: 3.2.6(@types/debug@4.1.13)(@types/node@22.19.17)(jiti@1.21.7)(jsdom@25.0.1)(tsx@4.21.0)(yaml@2.9.0)
@@ -7756,7 +7759,7 @@ snapshots:
       better-sqlite3: 12.9.0
       drizzle-kit: 0.31.10
       drizzle-orm: 0.45.2(@cloudflare/workers-types@4.20260504.1)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(kysely@0.28.17)
-      next: 15.1.0(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      next: 15.1.0(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
       vitest: 3.2.6(@types/debug@4.1.13)(@types/node@22.19.17)(jiti@1.21.7)(jsdom@26.1.0)(tsx@4.21.0)(yaml@2.9.0)
@@ -9223,7 +9226,7 @@ snapshots:
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
 
-  next@15.1.0(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+  next@15.1.0(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
       '@next/env': 15.1.0
       '@swc/counter': 0.1.3
@@ -9233,7 +9236,7 @@ snapshots:
       postcss: 8.4.31
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
-      styled-jsx: 5.1.6(react@19.2.5)
+      styled-jsx: 5.1.6(@babel/core@7.29.0)(react@19.2.5)
     optionalDependencies:
       '@next/swc-darwin-arm64': 15.1.0
       '@next/swc-darwin-x64': 15.1.0
@@ -9843,10 +9846,12 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.7
 
-  styled-jsx@5.1.6(react@19.2.5):
+  styled-jsx@5.1.6(@babel/core@7.29.0)(react@19.2.5):
     dependencies:
       client-only: 0.0.1
       react: 19.2.5
+    optionalDependencies:
+      '@babel/core': 7.29.0
 
   stylis@4.4.0: {}
 


### PR DESCRIPTION
Two complementary fixes to the post-escalation holding message (bug 3), both visible in the real escalation flow.

## Problem 2 (priority) — the ack fired even while a human was actively replying

The guard only checked `escalatedAt && !archivedAt`, so the "our support team will follow up" ack was re-served (every ~5 min) for every escalated visitor message — even after an operator had joined and was responding. Contradictory.

**Fix** (`chat.ts`): inside the guard, probe for an `admin`-role message in the conversation. If one exists → `holdingStreamResponse(null)` (fully silent — no ack, no model call; the visitor sees the operator's real replies via polling). Otherwise → the throttled ack (the waiting gap).
- **Bot stays muted in BOTH branches** — neither calls `streamChat`, so the free-muted-turn property holds (no assistant row / usageEvent / meter).
- **Throttle is lazy** — `shouldSendHolding` is only evaluated in the no-admin branch, so the admin-replied path never dirties the STATE cooldown.
- The probe is scoped to **this conversation AND role `admin`** (operator replies; visitor/inbound replies are role `user`, so they never trip suppression).

## Problem 1 — the ack rendered out of order (floated to the bottom)

The ack is streamed but never persisted (no sequence), so `mergeMessages` tail-dumped it below later admin replies / visitor turns.

**Fix** (`messages-sync.ts`): anchor the holding row to the server slot of the visitor message it acknowledges, so it renders in chronological order. **Only the holding row is anchored** — the normal in-flight pair (just-sent user + streaming reply) still tails; handles N holdings; no duplication (a holding can never both anchor and tail, and never matches a server row).

## Constant sharing
`ESCALATED_HOLDING_MESSAGE` moved to `@llmchat/shared` via a **narrow `./holding` subpath** (not the barrel — keeps the lean widget IIFE free of the models snapshot + its import-time validation; verified the built bundle excludes it, size unchanged at 900 kB). `apps/api/src/lib/holding.ts` re-exports it, so `chat.test.ts`'s import + its deliberate non-mock of that module are unchanged.

## Verification
- **shared 38 / api 446 / widget 98** pass. New tests: admin→silent (no ack, no model, throttle untouched), gap→ack+throttle-consulted, probe-scoping (no cross-conversation/wrong-role leak), anchoring (correct slot above a later admin reply, no float, N holdings, in-flight still tails, transient pre-poll, non-rateable).
- Adversarial review (correctness×2 + integration/scope) → **ship**, zero blocking; I closed the one worthwhile note (the predicate-scope test) and softened a comment.
- Preserves the bug-3 mute guarantee, the free-muted-turn property, and Decision-B (`/v1/resolve` sets `archivedAt` → the guard short-circuits; no interaction). Does not touch escalation-email, resolve, bug-1/2, or the reopen-latch.

## Notes
- Within-session ordering only — a full reload drops the unpersisted ack (by design).
- `pnpm-lock.yaml` carries the widget→shared workspace link plus benign optional-peer (`@babel/core`) re-resolution churn.

Deploy: widget + shared change — if the preview's `kind: nextjs` builder flakes "No executable pnpm found", known transient, re-trigger once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)