### PR TITLE
feat(widget): persist visitor identity in localStorage (skip the form on reload/return)

### DIFF
--- a/packages/widget/src/lib.test.ts
+++ b/packages/widget/src/lib.test.ts
@@ -1,8 +1,15 @@
 import { beforeEach, describe, expect, it } from "vitest";
 
-import { getOrCreateClientId, getText } from "./lib";
+import {
+	getOrCreateClientId,
+	getStoredIdentity,
+	getText,
+	setStoredIdentity,
+} from "./lib";
 
 import type { UIMessage } from "ai";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
 
 describe("getOrCreateClientId", () => {
 	beforeEach(() => {
@@ -17,6 +24,99 @@ describe("getOrCreateClientId", () => {
 	it("reuses an existing stored id instead of overwriting it", () => {
 		sessionStorage.setItem("llmchat_client_id", "existing-id");
 		expect(getOrCreateClientId()).toBe("existing-id");
+	});
+});
+
+describe("getStoredIdentity / setStoredIdentity", () => {
+	beforeEach(() => {
+		localStorage.clear();
+	});
+
+	it("round-trips name + email for a project", () => {
+		setStoredIdentity("pk_a", { name: "Luca", email: "luca@example.com" });
+		expect(getStoredIdentity("pk_a")).toEqual({
+			name: "Luca",
+			email: "luca@example.com",
+		});
+	});
+
+	it("returns null when nothing is stored (the form shows)", () => {
+		expect(getStoredIdentity("pk_a")).toBeNull();
+	});
+
+	it("trims surrounding whitespace from the stored name and email", () => {
+		setStoredIdentity("pk_a", { name: "  Luca  ", email: "  luca@x.com  " });
+		expect(getStoredIdentity("pk_a")).toEqual({
+			name: "Luca",
+			email: "luca@x.com",
+		});
+	});
+
+	it("returns null for malformed JSON — never throws (the form shows)", () => {
+		localStorage.setItem("llmchat_identity_pk_a", "{ not json");
+		expect(getStoredIdentity("pk_a")).toBeNull();
+	});
+
+	it("returns null for an empty name (must not skip the form into a 'Hi !' greeting)", () => {
+		localStorage.setItem(
+			"llmchat_identity_pk_a",
+			JSON.stringify({ name: "   ", email: "x@y.com", savedAt: Date.now() }),
+		);
+		expect(getStoredIdentity("pk_a")).toBeNull();
+	});
+
+	it("expires an entry older than the 30-day TTL (the form shows) and clears it", () => {
+		localStorage.setItem(
+			"llmchat_identity_pk_a",
+			JSON.stringify({
+				name: "Luca",
+				email: "luca@x.com",
+				savedAt: Date.now() - 31 * DAY_MS,
+			}),
+		);
+		expect(getStoredIdentity("pk_a")).toBeNull();
+		expect(localStorage.getItem("llmchat_identity_pk_a")).toBeNull(); // cleaned up
+	});
+
+	it("keeps an entry that is within the 30-day TTL", () => {
+		localStorage.setItem(
+			"llmchat_identity_pk_a",
+			JSON.stringify({
+				name: "Luca",
+				email: "luca@x.com",
+				savedAt: Date.now() - 1 * DAY_MS,
+			}),
+		);
+		expect(getStoredIdentity("pk_a")).toEqual({
+			name: "Luca",
+			email: "luca@x.com",
+		});
+	});
+
+	it("returns null when savedAt is missing (treated as expired)", () => {
+		localStorage.setItem(
+			"llmchat_identity_pk_a",
+			JSON.stringify({ name: "Luca", email: "luca@x.com" }),
+		);
+		expect(getStoredIdentity("pk_a")).toBeNull();
+	});
+
+	it("is keyed PER PROJECT — project A's identity does not prefill project B", () => {
+		setStoredIdentity("pk_a", { name: "Alice", email: "a@x.com" });
+		expect(getStoredIdentity("pk_b")).toBeNull();
+		expect(getStoredIdentity("pk_a")).toEqual({
+			name: "Alice",
+			email: "a@x.com",
+		});
+	});
+
+	it("writes to localStorage under a per-project key with a savedAt stamp", () => {
+		setStoredIdentity("pk_a", { name: "Luca", email: "luca@x.com" });
+		const raw = localStorage.getItem("llmchat_identity_pk_a");
+		expect(raw).not.toBeNull();
+		const parsed = JSON.parse(raw!) as Record<string, unknown>;
+		expect(parsed).toMatchObject({ name: "Luca", email: "luca@x.com" });
+		expect(typeof parsed.savedAt).toBe("number");
 	});
 });
 

--- a/packages/widget/src/lib.ts
+++ b/packages/widget/src/lib.ts
@@ -13,6 +13,85 @@ export function getOrCreateClientId(): string {
 	return id;
 }
 
+export interface StoredIdentity {
+	name: string;
+	email: string;
+}
+
+// Visitor identity (name/email) persists DIFFERENTLY from the clientId above, on
+// purpose: localStorage + a per-PROJECT key, vs the clientId's sessionStorage +
+// global key. Why diverge?
+//   - localStorage (not sessionStorage): a RETURNING visitor (new tab / after a
+//     close) is remembered, so they aren't re-asked for their name. The anonymous
+//     clientId only needs to survive a reload, so per-tab sessionStorage is enough.
+//   - per-project key (not global): identity is PII, so a multi-widget origin must
+//     not bleed one project's visitor into another project's form. An opaque
+//     clientId carries no PII, so a shared global key is fine for it.
+//   - 30-day TTL: bounds stale data and the shared-device window (a prior visitor on
+//     a kiosk machine isn't prefilled forever). The server conversation row stays
+//     authoritative — this is a convenience prefill only.
+const IDENTITY_KEY_PREFIX = "llmchat_identity_";
+const IDENTITY_TTL_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
+
+function identityKey(projectKey: string): string {
+	return `${IDENTITY_KEY_PREFIX}${projectKey}`;
+}
+
+/**
+ * The visitor's saved identity for this project, or null when missing, malformed,
+ * expired (>30 days), or empty-named (an empty name must not skip the form into a
+ * "Hi !" greeting — see the widget's name guard). Never throws: a disabled/blocked
+ * localStorage or bad JSON resolves to null (form shows).
+ */
+export function getStoredIdentity(projectKey: string): StoredIdentity | null {
+	try {
+		const raw = localStorage.getItem(identityKey(projectKey));
+		if (!raw) return null;
+		const parsed = JSON.parse(raw) as Record<string, unknown>;
+		const name = typeof parsed.name === "string" ? parsed.name : "";
+		const email = typeof parsed.email === "string" ? parsed.email : "";
+		const savedAt = typeof parsed.savedAt === "number" ? parsed.savedAt : 0;
+		const fresh = savedAt > 0 && Date.now() - savedAt <= IDENTITY_TTL_MS;
+		// Unusable (empty name → would skip into a "Hi !" greeting) or expired/stale →
+		// drop the entry (best-effort) and show the form.
+		if (!name.trim() || !fresh) {
+			try {
+				localStorage.removeItem(identityKey(projectKey));
+			} catch {
+				// best-effort cleanup
+			}
+			return null;
+		}
+		return { name, email };
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Persist the visitor's identity for this project, stamped with the current time
+ * for the TTL. Best-effort — a storage failure (private mode / quota / disabled) is
+ * swallowed (the form simply won't be skipped next time).
+ */
+export function setStoredIdentity(
+	projectKey: string,
+	identity: StoredIdentity,
+): void {
+	try {
+		localStorage.setItem(
+			identityKey(projectKey),
+			JSON.stringify({
+				// Normalize on store so a padded "  Luca  " can't surface as "Hi   Luca  !".
+				name: identity.name.trim(),
+				email: identity.email.trim(),
+				savedAt: Date.now(),
+			}),
+		);
+	} catch {
+		// ignore
+	}
+}
+
 /** Concatenated text content of a UI message (ignores non-text parts). */
 export function getText(m: UIMessage): string {
 	return m.parts

--- a/packages/widget/src/widget.identity.test.tsx
+++ b/packages/widget/src/widget.identity.test.tsx
@@ -1,0 +1,84 @@
+import { render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Keep the live widget off the network/model so we can assert purely on whether the
+// IdentifyForm gate is shown vs. skipped by the localStorage prefill.
+vi.mock("ai", () => ({ DefaultChatTransport: class {} }));
+vi.mock("@ai-sdk/react", () => ({
+	Chat: class {},
+	useChat: () => ({
+		messages: [],
+		sendMessage: vi.fn(async () => {}),
+		status: "ready",
+		error: null,
+	}),
+}));
+vi.mock("./widget-config", () => ({ useShowBranding: () => false }));
+
+import { setStoredIdentity } from "./lib";
+import * as serverMessages from "./useServerMessages";
+import { Widget } from "./widget";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+beforeEach(() => {
+	localStorage.clear();
+	sessionStorage.clear();
+	vi.spyOn(serverMessages, "useServerMessages").mockReturnValue({
+		serverMessages: [],
+		conversationId: null,
+		csatRating: null,
+		escalatedAt: null,
+		archivedAt: null,
+		refresh: vi.fn(),
+	});
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+function mount(projectKey = "pk_a") {
+	render(
+		<Widget
+			widgetMode="live"
+			projectKey={projectKey}
+			apiUrl="http://x"
+			brandColor="#4f46e5"
+			mode="inline"
+		/>,
+	);
+}
+
+describe("LiveWidget — identity prefill on mount (Luca #5)", () => {
+	it("shows the IdentifyForm when no identity is stored", () => {
+		mount();
+		expect(screen.getByPlaceholderText(/your name/i)).toBeInTheDocument();
+	});
+
+	it("SKIPS the form and personalizes the greeting when a valid identity is stored", () => {
+		setStoredIdentity("pk_a", { name: "Luca", email: "luca@example.com" });
+		mount("pk_a");
+		expect(screen.queryByPlaceholderText(/your name/i)).not.toBeInTheDocument();
+		expect(screen.getByText(/Hi Luca! How can I help/i)).toBeInTheDocument();
+	});
+
+	it("still shows the form when the stored identity is for a DIFFERENT project (per-project keying)", () => {
+		setStoredIdentity("pk_other", { name: "Luca", email: "luca@example.com" });
+		mount("pk_a");
+		expect(screen.getByPlaceholderText(/your name/i)).toBeInTheDocument();
+	});
+
+	it("still shows the form when the stored identity is EXPIRED (>30 days)", () => {
+		localStorage.setItem(
+			"llmchat_identity_pk_a",
+			JSON.stringify({
+				name: "Luca",
+				email: "luca@example.com",
+				savedAt: Date.now() - 31 * DAY_MS,
+			}),
+		);
+		mount("pk_a");
+		expect(screen.getByPlaceholderText(/your name/i)).toBeInTheDocument();
+	});
+});

--- a/packages/widget/src/widget.tsx
+++ b/packages/widget/src/widget.tsx
@@ -15,7 +15,12 @@ import { WidgetFrame } from "./components/WidgetFrame";
 import { rateConversation, shouldPromptCsat } from "./csat";
 import { requestEscalation } from "./escalation";
 import { requestResolve } from "./resolve";
-import { getOrCreateClientId, getText } from "./lib";
+import {
+	getOrCreateClientId,
+	getStoredIdentity,
+	getText,
+	setStoredIdentity,
+} from "./lib";
 import { mergeMessages } from "./messages-sync";
 import { rateMessage, useMessageRatings } from "./rating";
 import { ShowcaseChat } from "./ShowcaseChat";
@@ -158,7 +163,17 @@ function LiveWidget({
 
 	useEffect(() => {
 		setClientId(getOrCreateClientId());
-	}, []);
+		// Prefill from a prior visit (localStorage, per-project, ≤30d) so a returning
+		// or reloading visitor skips the IdentifyForm. Convenience only — the server
+		// conversation row stays authoritative for the model. getStoredIdentity returns
+		// null on empty/expired/malformed, so an absent/stale entry still shows the form.
+		const saved = getStoredIdentity(projectKey);
+		if (saved) {
+			setName(saved.name);
+			setEmail(saved.email);
+			setIdentified(true);
+		}
+	}, [projectKey]);
 
 	// Server decides whether the "Powered by" badge shows (plan-gated, tamper-
 	// proof). Defaults to shown until the server says otherwise.
@@ -363,7 +378,11 @@ function LiveWidget({
 					email={email}
 					onNameChange={setName}
 					onEmailChange={setEmail}
-					onSubmit={() => setIdentified(true)}
+					onSubmit={() => {
+						// Remember for next visit (IdentifyForm already blocks an empty name).
+						setStoredIdentity(projectKey, { name, email });
+						setIdentified(true);
+					}}
 				/>
 			) : (
 				<>

--- a/packages/widget/vitest.setup.ts
+++ b/packages/widget/vitest.setup.ts
@@ -5,6 +5,11 @@ import { afterEach } from "vitest";
 
 afterEach(() => {
 	cleanup();
+	// Reset web storage between tests so identity/clientId persistence (localStorage +
+	// sessionStorage) can't leak across cases — e.g. a test that submits the
+	// IdentifyForm now writes identity, which would otherwise skip a later mount's form.
+	localStorage.clear();
+	sessionStorage.clear();
 });
 
 // jsdom doesn't implement scrollIntoView (used by MessageList autoscroll).


### PR DESCRIPTION
## Why

`name`/`email`/`identified` were plain React state (reset on reload), so the IdentifyForm re-triggered even though the visitor already entered their details — and the server already had them (the model never re-asks; this was purely the client form gate). This adds a client-side prefill so a returning/reloading visitor skips the form. **The server conversation row stays authoritative** — this is convenience only.

## Design

- **localStorage, per-project key** `llmchat_identity_<projectKey>`, value `{ name, email, savedAt }`.
  - *localStorage* (not sessionStorage) → a **returning** visitor (new tab / after a close) is remembered.
  - *per-project key* (not global) → identity is PII, so a multi-widget origin can't bleed one project's visitor into another's form. (The anonymous `clientId` keeps its sessionStorage + global key — divergence documented in `lib.ts`.)
- **30-day TTL** → bounds stale data + the shared-device window. `getStoredIdentity` is tolerant (missing / malformed / expired / empty-name → `null` → form shows) and **never throws** (private-mode / quota safe). Name + email trimmed on store.
- **Read on mount** (next to `setClientId`) → prefill + `setIdentified(true)` to skip the form. **Write on submit** → `setStoredIdentity` (the form already blocks an empty name).

## Embed architecture (confirmed, as requested)

`mount.tsx` uses `document.currentScript` + `host.attachShadow` → the widget runs as a **same-origin script in the customer's page**. So this identity PII lands in the **customer's origin localStorage** (shared with their other scripts) — which is exactly why the **per-project key** matters. (The `/embed` route is the separate cross-origin-iframe option; it'd isolate to our origin.) This doesn't change the localStorage decision, just records where the PII lives.

## Preserved / not touched

- **Zero bug-1 interaction** (confirmed): `findOrCreateConversation` returns an existing row without overwriting name/email, and the model identity reads `conv.name`/`conv.email` (set at creation) — so the prefilled chat-body values can't change what the model sees on an existing conversation.
- IdentifyForm fields + **email-optional** unchanged; overwrite semantics unchanged; escalation/resolve/holding untouched.
- **Empty-name guard** ties to #93: a stored empty name never skips into a "Hi !" greeting.

## Verification

- **Widget 112 tests pass.** New: round-trip, TTL expiry + cleanup, malformed/missing/empty-name → null, **per-project keying**, trim, and mount-hydration (skips form + personalizes the greeting; **still shows the form** when storage is empty / expired / a different project).
- Bundle 900.83 kB (helpers only, no bloat). Adversarial review (correctness/security + scope/tests) → **ship**, zero blocking; I folded in the two worthwhile nits (trim-on-store, stale-entry cleanup).
- `vitest.setup.ts` now clears web storage between tests — necessary because form-submit now persists identity (fixed two pre-existing escalated/resolved tests that re-submit the form under the same projectKey).

## Known tradeoff (the explicit decision, documented in code)

On a shared/kiosk device, the 30-day localStorage entry means a new visitor in a fresh tab gets a new conversation **prefilled** with the prior visitor's name/email. The TTL bounds it; a shorter TTL or a "not you?" reset link could tighten it further (out of scope here).

Deploy: widget change — if the preview's `kind: nextjs` builder flakes, known transient, re-trigger once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)