### PR TITLE
June changelog post + stop dev traffic polluting PostHog

### DIFF
--- a/apps/dashboard/.env.example
+++ b/apps/dashboard/.env.example
@@ -12,3 +12,6 @@ NEXT_PUBLIC_POSTHOG_KEY=
 # Ingest host (EU cloud). Defaults to EU in code; use https://us.i.posthog.com
 # for a US-region PostHog project.
 NEXT_PUBLIC_POSTHOG_HOST=https://eu.i.posthog.com
+# Capture is skipped on localhost so dev sessions never pollute production
+# analytics. Set to true only when testing the PostHog integration itself.
+NEXT_PUBLIC_POSTHOG_CAPTURE_DEV=

--- a/apps/dashboard/src/components/PostHogProvider.tsx
+++ b/apps/dashboard/src/components/PostHogProvider.tsx
@@ -16,8 +16,17 @@ const POSTHOG_KEY = process.env.NEXT_PUBLIC_POSTHOG_KEY;
 const POSTHOG_HOST =
 	process.env.NEXT_PUBLIC_POSTHOG_HOST ?? "https://eu.i.posthog.com";
 
+// Dev servers run with the same production key from .env, so localhost
+// sessions land in production analytics. Skip capture locally;
+// NEXT_PUBLIC_POSTHOG_CAPTURE_DEV=true opts back in when testing capture.
+function isLocalhostSession() {
+	if (process.env.NEXT_PUBLIC_POSTHOG_CAPTURE_DEV === "true") return false;
+	const host = window.location.hostname;
+	return host === "localhost" || host === "127.0.0.1";
+}
+
 function initPostHog() {
-	if (!POSTHOG_KEY || posthog.__loaded) return;
+	if (!POSTHOG_KEY || posthog.__loaded || isLocalhostSession()) return;
 	posthog.init(POSTHOG_KEY, {
 		api_host: POSTHOG_HOST,
 		capture_pageview: false, // handled manually for the App Router

--- a/apps/marketing/.env.example
+++ b/apps/marketing/.env.example
@@ -12,6 +12,9 @@ NEXT_PUBLIC_POSTHOG_KEY=
 # Ingest host (EU cloud). Defaults to EU in code; use https://us.i.posthog.com
 # for a US-region PostHog project.
 NEXT_PUBLIC_POSTHOG_HOST=https://eu.i.posthog.com
+# Capture is skipped on localhost so dev sessions never pollute production
+# analytics. Set to true only when testing the PostHog integration itself.
+NEXT_PUBLIC_POSTHOG_CAPTURE_DEV=
 
 # --- Google Search Console ---
 # Site-ownership verification token GSC gives you for the "HTML tag" method

--- a/apps/marketing/content/blog/llmchat-changelog-june-2026.md
+++ b/apps/marketing/content/blog/llmchat-changelog-june-2026.md
@@ -1,0 +1,35 @@
+---
+title: "Changelog: June 2026 — launch month"
+description: "We launched on Product Hunt. Also: smarter escalation, a full dashboard restyle, workspace-wide search, annual plans, and a security hardening pass."
+date: "2026-07-01"
+category: "Changelog"
+featured: false
+---
+
+June was launch month. Here's everything that shipped.
+
+**We're live — and we launched on Product Hunt.** Clanker Support is officially open to everyone, and we spent launch day on Product Hunt answering questions. If you missed it, the [launch announcement](/blog/clanker-support-is-live-on-product-hunt) covers what we built and why. To everyone who tried the widget, signed up, or asked us hard questions: thank you.
+
+**Escalation got a lot smarter.** This was the month's biggest product theme. When a conversation escalates to your team, the agent now passes along an in-chat summary of what's been discussed, so the customer isn't asked to repeat themselves. The agent is identity-aware — it stops re-asking for a name and email it already has. And once a conversation is escalated, the bot stays quiet instead of talking over your team.
+
+**Escalation emails the customer, and replies thread back.** When a conversation escalates, the customer gets an email — and their reply threads straight back into the same conversation in your inbox. No lost threads, even after they close the tab.
+
+**Visitors can resolve their own conversations.** Customers can mark a conversation resolved from the widget, and the inbox now records who resolved each conversation — visitor, agent, or your team.
+
+**The widget remembers returning visitors.** Visitor identity now persists across reloads, so returning customers skip the contact form and land back in their conversation. The greeting stays visible after the first message, and while a reply streams in, the latest turn stays pinned in view.
+
+**Privacy controls per project.** You can set a privacy policy URL per project, and the widget shows a consent notice above the composer until the visitor sends their first message. Useful if you operate in regions where that's not optional.
+
+**Dashboard restyle.** The whole dashboard got a design pass — inbox, projects, sources, settings, and billing — plus a new command bar shell. Same product, much easier on the eyes.
+
+**⌘K search.** Workspace-wide global search with deep links into inbox conversations. This checks off the conversation search we promised in the May changelog.
+
+**Inbox: AI triage summaries.** Every conversation in the inbox now shows a one-line AI summary, so you can scan a full queue without opening each thread.
+
+**Typed knowledge sources.** Sources are now typed — add plain text or structured Q&A pairs directly from the dashboard, with per-type rollups so you can see what the bot is drawing from.
+
+**Workspaces and annual plans.** You can create and delete workspaces, and the pricing page got a redesign: annual plans, an Enterprise tier, and richer quotas per plan.
+
+**Security hardening pass.** We swept conversation access paths for authorization gaps, added signature verification on inbound email webhooks, and made auth rate-limiting durable. Not glamorous, but this is the layer everything else sits on.
+
+Next up: Slack notifications and a public API for pulling usage data.

--- a/apps/marketing/src/components/PostHogProvider.tsx
+++ b/apps/marketing/src/components/PostHogProvider.tsx
@@ -14,8 +14,17 @@ const POSTHOG_KEY = process.env.NEXT_PUBLIC_POSTHOG_KEY;
 const POSTHOG_HOST =
 	process.env.NEXT_PUBLIC_POSTHOG_HOST ?? "https://eu.i.posthog.com";
 
+// Dev servers run with the same production key from .env, so localhost
+// sessions land in production analytics. Skip capture locally;
+// NEXT_PUBLIC_POSTHOG_CAPTURE_DEV=true opts back in when testing capture.
+function isLocalhostSession() {
+	if (process.env.NEXT_PUBLIC_POSTHOG_CAPTURE_DEV === "true") return false;
+	const host = window.location.hostname;
+	return host === "localhost" || host === "127.0.0.1";
+}
+
 function initPostHog() {
-	if (!POSTHOG_KEY || posthog.__loaded) return;
+	if (!POSTHOG_KEY || posthog.__loaded || isLocalhostSession()) return;
 	posthog.init(POSTHOG_KEY, {
 		api_host: POSTHOG_HOST,
 		// Marketing traffic is anonymous — only build profiles once a visitor

--- a/apps/showcase/.env.example
+++ b/apps/showcase/.env.example
@@ -19,3 +19,6 @@ NEXT_PUBLIC_POSTHOG_KEY=
 # Ingest host (EU cloud). Defaults to EU in code; use https://us.i.posthog.com
 # for a US-region PostHog project.
 NEXT_PUBLIC_POSTHOG_HOST=https://eu.i.posthog.com
+# Capture is skipped on localhost so dev sessions never pollute production
+# analytics. Set to true only when testing the PostHog integration itself.
+NEXT_PUBLIC_POSTHOG_CAPTURE_DEV=

--- a/apps/showcase/src/components/PostHogProvider.tsx
+++ b/apps/showcase/src/components/PostHogProvider.tsx
@@ -14,8 +14,17 @@ const POSTHOG_KEY = process.env.NEXT_PUBLIC_POSTHOG_KEY;
 const POSTHOG_HOST =
 	process.env.NEXT_PUBLIC_POSTHOG_HOST ?? "https://eu.i.posthog.com";
 
+// Dev servers run with the same production key from .env, so localhost
+// sessions land in production analytics. Skip capture locally;
+// NEXT_PUBLIC_POSTHOG_CAPTURE_DEV=true opts back in when testing capture.
+function isLocalhostSession() {
+	if (process.env.NEXT_PUBLIC_POSTHOG_CAPTURE_DEV === "true") return false;
+	const host = window.location.hostname;
+	return host === "localhost" || host === "127.0.0.1";
+}
+
 function initPostHog() {
-	if (!POSTHOG_KEY || posthog.__loaded) return;
+	if (!POSTHOG_KEY || posthog.__loaded || isLocalhostSession()) return;
 	posthog.init(POSTHOG_KEY, {
 		api_host: POSTHOG_HOST,
 		// The showcase is anonymous demo traffic — only build profiles once a


### PR DESCRIPTION
## What's happening

PostHog traffic review surfaced two things: dev sessions on localhost were being captured into production analytics (localhost:3001/3002 referrers, dashboard routes in pageview data), and the blog's changelog cadence stopped at May while June was launch month.

## Changes

- **Analytics hygiene**: initPostHog in marketing, dashboard, and showcase now skips capture on localhost. NEXT_PUBLIC_POSTHOG_CAPTURE_DEV=true opts back in when testing the integration itself (documented in each .env.example).
- **New blog post**: "Changelog: June 2026 — launch month", grounded in June git history — Product Hunt launch, escalation overhaul, dashboard restyle, ⌘K search, typed sources, annual plans, security hardening pass.

## Verification

- content-collections build passes (post frontmatter validates against the posts schema)
- tsc --noEmit clean on all three touched apps
- prettier --check clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)