### PR TITLE
feat(dashboard): adopt Chatbase-style UI (design only)

### DIFF
--- a/apps/dashboard/src/app/globals.css
+++ b/apps/dashboard/src/app/globals.css
@@ -10,41 +10,50 @@
 	 * the same hue family (marketing itself is dark-only). Aligning these
 	 * variables is the leverage point — shadcn primitives inherit automatically.
 	 */
+	/*
+	 * LIGHT is now the default (Chatbase-style adoption): a warm near-white
+	 * canvas, white cards, hairline borders, and a MONOCHROME near-black primary
+	 * (Chatbase uses black buttons + black user bubbles, not a color brand). These
+	 * shadcn tokens drive components/ui/* (dialogs, Sheet, ⌘K palette, Sonner,
+	 * auth pages); they're kept in lockstep with the --ck-* set below so those
+	 * surfaces match the shell/inbox. Semantic destructive/success/warning/info
+	 * stay colored.
+	 */
 	:root {
-		--background: 220 33% 98%; /* faint slate canvas — white cards pop on it */
-		--foreground: 221 39% 11%; /* #111827 brand neutral */
+		--background: 60 6% 97%; /* #F7F7F6 warm near-white canvas */
+		--foreground: 0 0% 10%; /* #1A1A1A near-black text */
 		--card: 0 0% 100%;
-		--card-foreground: 221 39% 11%;
+		--card-foreground: 0 0% 10%;
 		--popover: 0 0% 100%;
-		--popover-foreground: 221 39% 11%;
-		--primary: 239 84% 67%; /* indigo-500 #6366F1 — unified brand indigo (matches mockups) */
+		--popover-foreground: 0 0% 10%;
+		--primary: 0 0% 10%; /* near-black primary (Chatbase) */
 		--primary-foreground: 0 0% 100%;
-		--secondary: 220 33% 96%;
-		--secondary-foreground: 221 39% 11%;
-		--muted: 220 33% 96%;
-		--muted-foreground: 221 14% 43%;
-		--accent: 220 33% 96%;
-		--accent-foreground: 221 39% 11%;
+		--secondary: 0 0% 96%;
+		--secondary-foreground: 0 0% 10%;
+		--muted: 0 0% 96%;
+		--muted-foreground: 0 0% 45%; /* #737373 muted gray */
+		--accent: 0 0% 96%;
+		--accent-foreground: 0 0% 10%;
 		--destructive: 0 84.2% 60.2%;
 		--destructive-foreground: 210 40% 98%;
-		--success: 142.1 76.2% 36.3%;
+		--success: 142.1 71% 40%;
 		--success-foreground: 138 76% 97%;
 		--warning: 38 92% 50%;
 		--warning-foreground: 48 96% 89%;
 		--info: 221.2 83.2% 53.3%;
 		--info-foreground: 210 40% 98%;
-		--border: 220 22% 90%;
-		--input: 220 22% 90%;
-		--ring: 239 84% 67%;
+		--border: 0 0% 92%; /* #EBEBEB hairline */
+		--input: 0 0% 92%;
+		--ring: 0 0% 10%;
 		--radius: 0.5rem;
-		--sidebar-background: 220 33% 98%;
-		--sidebar-foreground: 221 20% 35%;
-		--sidebar-primary: 239 84% 67%;
+		--sidebar-background: 60 6% 97%;
+		--sidebar-foreground: 0 0% 35%;
+		--sidebar-primary: 0 0% 10%;
 		--sidebar-primary-foreground: 0 0% 100%;
-		--sidebar-accent: 220 33% 94%;
-		--sidebar-accent-foreground: 221 39% 11%;
-		--sidebar-border: 220 22% 90%;
-		--sidebar-ring: 239 84% 67%;
+		--sidebar-accent: 0 0% 94%;
+		--sidebar-accent-foreground: 0 0% 10%;
+		--sidebar-border: 0 0% 92%;
+		--sidebar-ring: 0 0% 10%;
 	}
 
 	.dark {
@@ -99,22 +108,24 @@
 	 * bare in raw CSS; go through a `ck-*` utility, or wrap it `rgb(var(--ck-*))`.
 	 */
 	:root {
-		--ck-board: 231 229 223;
-		--ck-app: 246 246 247;
-		--ck-sidebar: 251 251 252;
+		--ck-board: 244 244 243;
+		--ck-app: 247 247 246; /* #F7F7F6 canvas */
+		--ck-sidebar: 247 247 246; /* match app so the white active pill pops */
 		--ck-topbar: 255 255 255;
-		--ck-border: 236 236 239;
-		--ck-text: 24 24 27;
-		--ck-muted: 91 91 100;
-		--ck-faint: 154 154 163;
-		--ck-disabled: 182 182 191;
-		--ck-navhover: 240 240 243;
+		--ck-border: 236 236 236; /* #ECECEC hairline */
+		--ck-text: 26 26 26; /* #1A1A1A */
+		--ck-muted: 122 122 125; /* #7A7A7D */
+		--ck-faint: 150 150 155;
+		--ck-disabled: 182 182 186;
+		--ck-navhover: 240 240 239;
 		--ck-card: 255 255 255;
-		--ck-track: 235 235 240;
-		--ck-chip: 240 240 243;
-		--ck-accent: 79 70 229; /* indigo-600 #4f46e5 — light-mode accent */
-		--ck-accent-hover: 67 56 202; /* #4338ca */
-		--ck-warn: 180 83 9; /* amber #b45309 — overage/reference only, never a fake limit */
+		--ck-track: 234 234 233;
+		--ck-chip: 241 241 240; /* gray AI/visitor bubble + subtle fills */
+		--ck-accent: 26 26 26; /* near-black — Chatbase primary (black buttons/bubbles) */
+		--ck-accent-hover: 60 60 66; /* black can't darken → hover lightens */
+		--ck-good: 22 163 74; /* #16A34A — CSAT / resolved / positive */
+		--ck-link: 37 99 235; /* #2563EB — text links */
+		--ck-warn: 180 83 9; /* amber #b45309 — escalated only, never a fake limit */
 	}
 
 	.dark {
@@ -131,8 +142,10 @@
 		--ck-card: 20 22 27;
 		--ck-track: 37 40 50;
 		--ck-chip: 27 30 37;
-		--ck-accent: 99 102 241; /* indigo-500 #6366f1 — dark-mode accent */
+		--ck-accent: 99 102 241; /* indigo-500 #6366f1 — dark-mode accent (kept) */
 		--ck-accent-hover: 118 121 242; /* #7679f2 */
+		--ck-good: 74 222 128; /* green — CSAT / resolved / positive */
+		--ck-link: 96 165 250; /* blue — links */
 		--ck-warn: 224 161 63; /* #e0a13f */
 	}
 

--- a/apps/dashboard/src/app/inbox/_components/ConversationList.tsx
+++ b/apps/dashboard/src/app/inbox/_components/ConversationList.tsx
@@ -48,15 +48,15 @@ function ConversationRow({
 			className={cn(
 				"flex w-full items-start gap-3 rounded-[10px] px-3 py-2.5 text-left transition-colors",
 				selected
-					? "bg-ck-accent/10 ring-1 ring-inset ring-ck-accent/25"
-					: "hover:bg-ck-navhover",
+					? "border border-ck-border bg-ck-card shadow-sm"
+					: "border border-transparent hover:bg-ck-navhover",
 			)}
 		>
 			<div className="relative shrink-0">
 				<span
 					className={cn(
 						"flex size-9 items-center justify-center rounded-full text-xs font-bold",
-						selected ? "bg-ck-accent text-white" : "bg-ck-chip text-ck-muted",
+						selected ? "bg-ck-text text-white" : "bg-ck-chip text-ck-muted",
 					)}
 				>
 					{initials(conversation.name)}
@@ -111,7 +111,7 @@ function ConversationRow({
 				<div className="mt-0.5 flex flex-wrap items-center gap-1.5">
 					{/* Resolved takes precedence over Escalated (matches deriveStatus). */}
 					{resolved ? (
-						<span className="inline-flex h-4 items-center rounded-full bg-ck-accent/15 px-1.5 text-[10px] font-semibold text-ck-accent">
+						<span className="inline-flex h-4 items-center rounded-full bg-ck-good/15 px-1.5 text-[10px] font-semibold text-ck-good">
 							Resolved
 						</span>
 					) : escalated ? (

--- a/apps/dashboard/src/app/inbox/_components/DetailPanel.tsx
+++ b/apps/dashboard/src/app/inbox/_components/DetailPanel.tsx
@@ -1,15 +1,6 @@
 "use client";
 
-import {
-	Check,
-	Clock,
-	Globe,
-	Mail,
-	MessageCircle,
-	Monitor,
-	Star,
-	TriangleAlert,
-} from "lucide-react";
+import { Check, Star, TriangleAlert } from "lucide-react";
 
 import { CopyButton } from "@/components/ds";
 import { cn } from "@/lib/utils";
@@ -36,31 +27,27 @@ function Section({
 	);
 }
 
+/** Chatbase-style detail row: gray label left, bold value right-aligned. */
 function Field({
-	icon,
 	label,
 	value,
 	mono,
 }: {
-	icon: React.ReactNode;
 	label: string;
 	value: React.ReactNode;
 	mono?: boolean;
 }) {
 	return (
-		<div className="flex items-start gap-3">
-			<span className="mt-0.5 text-ck-faint [&_svg]:size-4">{icon}</span>
-			<div className="min-w-0 flex-1">
-				<p className="text-xs font-medium text-ck-faint">{label}</p>
-				<p
-					className={cn(
-						"break-words text-sm text-ck-text",
-						mono && "font-mono text-xs",
-					)}
-				>
-					{value}
-				</p>
-			</div>
+		<div className="flex items-baseline justify-between gap-3">
+			<span className="shrink-0 text-xs text-ck-faint">{label}</span>
+			<span
+				className={cn(
+					"min-w-0 break-words text-right text-sm font-medium text-ck-text",
+					mono && "font-mono text-xs",
+				)}
+			>
+				{value}
+			</span>
 		</div>
 	);
 }
@@ -99,7 +86,7 @@ export function DetailPanel({
 	const device = parseDevice(conversation.userAgent);
 
 	return (
-		<div className="flex min-h-0 flex-col bg-ck-sidebar">
+		<div className="flex min-h-0 flex-col bg-ck-card">
 			{/* Identity + Copy email (LIVE) */}
 			<div className="flex flex-col items-center gap-3 border-b border-ck-border px-6 py-6">
 				<span className="flex size-16 items-center justify-center rounded-2xl bg-ck-accent text-lg font-bold text-white">
@@ -144,10 +131,10 @@ export function DetailPanel({
 				)}
 
 				{conversation.archivedAt && (
-					<div className="m-4 rounded-[10px] bg-ck-accent/12 p-3">
+					<div className="m-4 rounded-[10px] bg-ck-good/12 p-3">
 						<div className="flex items-center gap-2">
-							<Check className="size-4 text-ck-accent" />
-							<span className="text-xs font-semibold text-ck-accent">
+							<Check className="size-4 text-ck-good" />
+							<span className="text-xs font-semibold text-ck-good">
 								{conversation.resolvedBy === "visitor"
 									? "Resolved by the visitor"
 									: conversation.resolvedBy === "admin"
@@ -155,7 +142,7 @@ export function DetailPanel({
 										: "Resolved"}
 							</span>
 						</div>
-						<p className="mt-1 text-xs text-ck-accent/80">
+						<p className="mt-1 text-xs text-ck-good/80">
 							{formatFullDate(conversation.archivedAt)}
 						</p>
 					</div>
@@ -163,32 +150,18 @@ export function DetailPanel({
 
 				{/* LIVE — real captured fields only. */}
 				<Section title="Contact">
+					<Field label="Email" value={conversation.email ?? "Not provided"} />
 					<Field
-						icon={<Mail />}
-						label="Email"
-						value={conversation.email ?? "Not provided"}
-					/>
-					<Field
-						icon={<Globe />}
 						label="IP address"
 						value={conversation.ipAddress ?? "Unknown"}
 						mono
 					/>
+					<Field label="Device" value={device ?? "Unknown"} />
 					<Field
-						icon={<Monitor />}
-						label="Device"
-						value={device ?? "Unknown"}
-					/>
-					<Field
-						icon={<Clock />}
 						label="Started"
 						value={formatFullDate(conversation.createdAt)}
 					/>
-					<Field
-						icon={<MessageCircle />}
-						label="Messages"
-						value={conversation.messageCount}
-					/>
+					<Field label="Messages" value={conversation.messageCount} />
 				</Section>
 
 				<Section title="CSAT rating">
@@ -201,7 +174,7 @@ export function DetailPanel({
 										className={cn(
 											"size-4",
 											n <= conversation.csatRating!
-												? "text-ck-warn"
+												? "text-ck-good"
 												: "text-ck-disabled",
 										)}
 										fill={

--- a/apps/dashboard/src/app/inbox/_components/InboxPanes.tsx
+++ b/apps/dashboard/src/app/inbox/_components/InboxPanes.tsx
@@ -67,12 +67,14 @@ export function InboxPanes({
 	detailsEmptyState,
 }: InboxPanesProps) {
 	return (
-		<div className="flex min-h-0 flex-1">
+		// White content surface (Chatbase): the panes sit on white with hairline
+		// dividers, against the gray nav rail + frame behind them.
+		<div className="flex min-h-0 flex-1 bg-ck-card">
 			{/* Left — conversation list (full-width on mobile, fixed rail from md) */}
 			<div
 				data-pane="list"
 				className={cn(
-					"min-h-0 flex-col border-r border-ck-border md:w-80 md:shrink-0",
+					"min-h-0 flex-col border-r border-ck-border md:w-[360px] md:shrink-0 lg:w-[370px]",
 					hasSelection ? "hidden md:flex" : "flex w-full",
 				)}
 			>
@@ -128,7 +130,7 @@ export function InboxPanes({
 			{/* Right — details aside (desktop only) */}
 			<aside
 				data-pane="details"
-				className="hidden w-72 shrink-0 border-l border-ck-border lg:flex lg:flex-col"
+				className="hidden w-[300px] shrink-0 border-l border-ck-border lg:flex lg:flex-col"
 			>
 				{details ?? detailsEmptyState}
 			</aside>

--- a/apps/dashboard/src/app/inbox/_components/ListFilters.test.tsx
+++ b/apps/dashboard/src/app/inbox/_components/ListFilters.test.tsx
@@ -24,16 +24,20 @@ function setup(props: Partial<React.ComponentProps<typeof ListFilters>> = {}) {
 	return { onSearch, onStatusChange, onTagIdsChange, unmount };
 }
 
+/** The status/tag filters live in a popover (moved off the main rail) — open it
+ * before asserting the controls inside. */
+async function openFilters(user: ReturnType<typeof userEvent.setup>) {
+	await user.click(screen.getByRole("button", { name: /filters/i }));
+}
+
 const billing = { id: "t1", name: "Billing", color: "#6366f1", count: 3 };
 
 describe("ListFilters", () => {
-	it("renders the Inbox heading and the real stat aggregates (LIVE)", () => {
+	it("renders the Inbox heading and the real conversation total (LIVE)", () => {
 		setup({ stats: { total: 7, escalated: 1, resolved: 2, avgRating: 4 } });
 		expect(screen.getByRole("heading", { name: "Inbox" })).toBeInTheDocument();
-		// "Conversations" is the stats-card label (unique to the restored panel);
-		// its value is the real total.
-		expect(screen.getByText("Conversations")).toBeInTheDocument();
-		expect(screen.getByText("7")).toBeInTheDocument();
+		// The header subtitle is the real server total (not a placeholder).
+		expect(screen.getByText(/7 conversations/i)).toBeInTheDocument();
 	});
 
 	it("reports the typed search query upward", async () => {
@@ -42,8 +46,10 @@ describe("ListFilters", () => {
 		expect(onSearch).toHaveBeenCalledWith("x");
 	});
 
-	it("offers the four LIVE status views and marks the active one", () => {
+	it("offers the four LIVE status views and marks the active one", async () => {
+		const user = userEvent.setup();
 		setup({ tags: [] });
+		await openFilters(user);
 		for (const label of ["Open", "Resolved", "Escalated", "All"]) {
 			expect(screen.getByRole("radio", { name: label })).toBeInTheDocument();
 		}
@@ -52,17 +58,19 @@ describe("ListFilters", () => {
 	});
 
 	it("reports the chosen status upward", async () => {
+		const user = userEvent.setup();
 		const { onStatusChange } = setup();
-		await userEvent.click(screen.getByRole("radio", { name: "Resolved" }));
+		await openFilters(user);
+		await user.click(screen.getByRole("radio", { name: "Resolved" }));
 		expect(onStatusChange).toHaveBeenCalledWith("resolved");
 	});
 
-	it("renders the ROADMAP status concepts as dimmed, non-interactive labels (never a filter)", () => {
+	it("renders the ROADMAP status concepts as dimmed, non-interactive labels (never a filter)", async () => {
+		const user = userEvent.setup();
 		setup();
-		// Present for layout parity…
+		await openFilters(user);
 		expect(screen.getByText("Unassigned")).toBeInTheDocument();
 		expect(screen.getByText("AI-handled")).toBeInTheDocument();
-		// …but NOT real controls — they are not radios/buttons, so they can't filter.
 		expect(
 			screen.queryByRole("radio", { name: /unassigned/i }),
 		).not.toBeInTheDocument();
@@ -71,32 +79,41 @@ describe("ListFilters", () => {
 		).not.toBeInTheDocument();
 	});
 
-	it("renders an 'All' chip plus a chip per real workspace tag (data-driven, not sample labels)", () => {
+	it("renders an 'All' chip plus a chip per real workspace tag (data-driven, not sample labels)", async () => {
+		const user = userEvent.setup();
 		setup({ tags: [billing] });
+		await openFilters(user);
 		expect(screen.getByRole("button", { name: "All" })).toBeInTheDocument();
 		expect(screen.getByRole("button", { name: /Billing/ })).toBeInTheDocument();
 	});
 
 	it("toggles a tag id upward when its chip is clicked", async () => {
+		const user = userEvent.setup();
 		const { onTagIdsChange } = setup({ tags: [billing] });
-		await userEvent.click(screen.getByRole("button", { name: /Billing/ }));
+		await openFilters(user);
+		await user.click(screen.getByRole("button", { name: /Billing/ }));
 		expect(onTagIdsChange).toHaveBeenCalledWith(["t1"]);
 	});
 
 	it("clears the tag filter when 'All' is clicked", async () => {
+		const user = userEvent.setup();
 		const { onTagIdsChange } = setup({ tags: [billing], tagIds: ["t1"] });
-		await userEvent.click(screen.getByRole("button", { name: "All" }));
+		await openFilters(user);
+		await user.click(screen.getByRole("button", { name: "All" }));
 		expect(onTagIdsChange).toHaveBeenCalledWith([]);
 	});
 
-	it("shows the Manage affordance only when onManageTags is provided (admin/owner)", () => {
+	it("shows the Manage affordance only when onManageTags is provided (admin/owner)", async () => {
+		const user = userEvent.setup();
 		const { unmount } = setup({ tags: [billing] });
+		await openFilters(user);
 		expect(
 			screen.queryByRole("button", { name: /manage/i }),
 		).not.toBeInTheDocument();
 		unmount();
 		const onManageTags = vi.fn();
 		setup({ tags: [billing], onManageTags });
+		await openFilters(user);
 		expect(screen.getByRole("button", { name: /manage/i })).toBeInTheDocument();
 	});
 });

--- a/apps/dashboard/src/app/inbox/_components/ListFilters.tsx
+++ b/apps/dashboard/src/app/inbox/_components/ListFilters.tsx
@@ -4,6 +4,7 @@ import { Search, SlidersHorizontal } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 
+import { pluralize } from "./format";
 import { InboxStats } from "./InboxStats";
 import { STATUS_FILTERS, type StatusFilter } from "./status";
 import type { ConversationStats, Tag } from "./types";
@@ -72,9 +73,16 @@ export function ListFilters({
 
 	return (
 		<div className="flex flex-col gap-3 border-b border-ck-border px-4 pb-3 pt-4">
-			<h1 className="text-lg font-bold tracking-[-0.01em] text-ck-text">
-				Inbox
-			</h1>
+			<div>
+				<h1 className="text-lg font-bold tracking-[-0.01em] text-ck-text">
+					Inbox
+				</h1>
+				{stats && (
+					<p className="mt-0.5 text-xs text-ck-faint">
+						{pluralize(stats.total, "conversation")}
+					</p>
+				)}
+			</div>
 
 			{/* Real project-wide aggregates (LIVE) — honest 0s when empty. */}
 			<InboxStats stats={stats} />
@@ -87,7 +95,7 @@ export function ListFilters({
 					onChange={(e) => onSearch(e.target.value)}
 					placeholder="Search conversations…"
 					aria-label="Search conversations"
-					className="h-9 w-full rounded-[10px] border border-ck-border bg-ck-card pl-9 pr-3 text-sm text-ck-text outline-none placeholder:text-ck-faint focus-visible:border-ck-accent"
+					className="h-9 w-full rounded-[10px] border border-transparent bg-ck-chip pl-9 pr-3 text-sm text-ck-text outline-none placeholder:text-ck-faint focus-visible:border-ck-accent focus-visible:bg-ck-card"
 				/>
 			</div>
 

--- a/apps/dashboard/src/app/inbox/_components/ListFilters.tsx
+++ b/apps/dashboard/src/app/inbox/_components/ListFilters.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import { Search, SlidersHorizontal } from "lucide-react";
+import { RefreshCw, Search, SlidersHorizontal } from "lucide-react";
+import { useState } from "react";
 
 import { cn } from "@/lib/utils";
 
 import { pluralize } from "./format";
-import { InboxStats } from "./InboxStats";
 import { STATUS_FILTERS, type StatusFilter } from "./status";
 import type { ConversationStats, Tag } from "./types";
 
@@ -13,7 +13,7 @@ const FALLBACK_DOT = "#6b7280";
 
 /**
  * ROADMAP status concepts from the target design we do NOT have (assignment +
- * AI-triage). Rendered as dimmed, non-interactive pills so the status row
+ * AI-triage). Rendered as dimmed, non-interactive pills so the filter panel
  * matches the design's layout without faking a filter that does nothing. Our
  * real views (Open / Resolved / Escalated / All) stay live alongside them.
  */
@@ -28,17 +28,26 @@ function chipBase(active: boolean) {
 	);
 }
 
+function iconBtn(active?: boolean) {
+	return cn(
+		"relative inline-flex size-8 shrink-0 items-center justify-center rounded-[10px] border border-ck-border transition-colors",
+		active
+			? "bg-ck-navhover text-ck-text"
+			: "bg-ck-card text-ck-muted hover:bg-ck-navhover hover:text-ck-text",
+	);
+}
+
 /**
- * The inbox list-pane header + filters, stacked vertically to match the target
- * design: "Inbox" + a real total, the conversation search, the LIVE
- * filter-by-tag chip row (All + each real workspace tag), and the LIVE status
- * pills. The tag chips drive the same `tagIds` state the popover used to — this
- * is purely a presentation swap over the existing OR-filter engine.
+ * The inbox list-pane header — Chatbase "Chat logs" style: a title + the real
+ * conversation total, a compact toolbar (a Filters toggle + refresh), and the
+ * conversation search. The tag + status FILTERS collapse behind the Filters
+ * button (moved off the main rail so the list reads clean); they still drive the
+ * same `tagIds` / `status` state — a presentation move only, over the existing
+ * OR-filter engine.
  *
  * Honesty rail: the total is the real server aggregate (or nothing while it
- * loads — never a placeholder number); the tag chips are real workspace tags
- * (data-driven, never the design's sample labels); the two ROADMAP status pills
- * are visibly dimmed and inert.
+ * loads — never a placeholder); the tag chips are real workspace tags (never the
+ * design's sample labels); the two ROADMAP status pills are visibly dimmed/inert.
  */
 export function ListFilters({
 	stats,
@@ -50,6 +59,7 @@ export function ListFilters({
 	tagIds,
 	onTagIdsChange,
 	onManageTags,
+	onRefresh,
 }: {
 	/** Real project-wide aggregates (server-side); undefined while loading. */
 	stats?: ConversationStats;
@@ -62,8 +72,14 @@ export function ListFilters({
 	onTagIdsChange: (ids: string[]) => void;
 	/** Admin/owner only — omit to hide the manage affordance. */
 	onManageTags?: () => void;
+	/** Refetch the list + stats (toolbar refresh). */
+	onRefresh?: () => void;
 }) {
+	const [filtersOpen, setFiltersOpen] = useState(false);
 	const selected = new Set(tagIds);
+	// Active-filter badge on the Filters toggle (status ≠ the default "open" view
+	// counts as one).
+	const activeCount = tagIds.length + (status === "open" ? 0 : 1);
 
 	function toggleTag(id: string) {
 		onTagIdsChange(
@@ -73,19 +89,46 @@ export function ListFilters({
 
 	return (
 		<div className="flex flex-col gap-3 border-b border-ck-border px-4 pb-3 pt-4">
-			<div>
-				<h1 className="text-lg font-bold tracking-[-0.01em] text-ck-text">
-					Inbox
-				</h1>
-				{stats && (
-					<p className="mt-0.5 text-xs text-ck-faint">
-						{pluralize(stats.total, "conversation")}
-					</p>
-				)}
-			</div>
+			<div className="flex items-start justify-between gap-2">
+				<div>
+					<h1 className="text-lg font-bold tracking-[-0.01em] text-ck-text">
+						Inbox
+					</h1>
+					{stats && (
+						<p className="mt-0.5 text-xs text-ck-faint">
+							{pluralize(stats.total, "conversation")}
+						</p>
+					)}
+				</div>
 
-			{/* Real project-wide aggregates (LIVE) — honest 0s when empty. */}
-			<InboxStats stats={stats} />
+				<div className="flex items-center gap-1">
+					<button
+						type="button"
+						aria-label="Filters"
+						aria-expanded={filtersOpen}
+						onClick={() => setFiltersOpen((v) => !v)}
+						className={iconBtn(filtersOpen)}
+					>
+						<SlidersHorizontal className="size-4" />
+						{activeCount > 0 && (
+							<span className="absolute -right-1 -top-1 flex size-4 items-center justify-center rounded-full bg-ck-accent text-[9px] font-bold text-white">
+								{activeCount}
+							</span>
+						)}
+					</button>
+
+					{onRefresh && (
+						<button
+							type="button"
+							aria-label="Refresh"
+							onClick={onRefresh}
+							className={iconBtn()}
+						>
+							<RefreshCw className="size-4" />
+						</button>
+					)}
+				</div>
+			</div>
 
 			{/* Conversation search (LIVE) */}
 			<div className="relative">
@@ -99,98 +142,101 @@ export function ListFilters({
 				/>
 			</div>
 
-			{/* Filter by tag (LIVE) — All + real workspace tags */}
-			<div className="flex flex-col gap-1.5">
-				<div className="flex items-center justify-between">
-					<span className="text-[11px] font-semibold uppercase tracking-wider text-ck-faint">
-						Filter by tag
-					</span>
-					{onManageTags && (
-						<button
-							type="button"
-							onClick={onManageTags}
-							className="inline-flex items-center gap-1 text-[11px] font-medium text-ck-faint hover:text-ck-text"
-						>
-							<SlidersHorizontal className="size-3" />
-							Manage
-						</button>
-					)}
-				</div>
-				<div className="flex flex-wrap gap-1.5">
-					<button
-						type="button"
-						onClick={() => onTagIdsChange([])}
-						aria-pressed={tagIds.length === 0}
-						className={chipBase(tagIds.length === 0)}
-					>
-						All
-					</button>
-					{tags.map((tag) => {
-						const active = selected.has(tag.id);
-						return (
-							<button
-								key={tag.id}
-								type="button"
-								onClick={() => toggleTag(tag.id)}
-								aria-pressed={active}
-								className={chipBase(active)}
-							>
-								<span
-									className="size-2 shrink-0 rounded-full"
-									style={{ backgroundColor: tag.color ?? FALLBACK_DOT }}
-								/>
-								<span className="max-w-[8rem] truncate">{tag.name}</span>
-							</button>
-						);
-					})}
-					{tags.length === 0 && (
-						<span className="text-xs text-ck-faint">No tags yet</span>
-					)}
-				</div>
-			</div>
-
-			{/* Status (LIVE views + dimmed ROADMAP concepts) */}
-			<div className="flex flex-col gap-1.5">
-				<span className="text-[11px] font-semibold uppercase tracking-wider text-ck-faint">
-					Status
-				</span>
-				<div
-					className="flex flex-wrap gap-1.5"
-					role="radiogroup"
-					aria-label="Filter conversations by status"
-				>
-					{STATUS_FILTERS.map((s) => {
-						const active = status === s.value;
-						return (
-							<button
-								key={s.value}
-								type="button"
-								role="radio"
-								aria-checked={active}
-								onClick={() => onStatusChange(s.value)}
-								className={chipBase(active)}
-							>
-								{s.label}
-							</button>
-						);
-					})}
-					{/* ROADMAP — dimmed, inert. Assignment + AI-triage aren't built; shown
-					    so the layout matches the design, never wired to anything. */}
-					{ROADMAP_STATUSES.map((label) => (
-						<span
-							key={label}
-							aria-disabled="true"
-							title="Coming soon"
-							className="inline-flex h-7 cursor-not-allowed items-center gap-1.5 rounded-full border border-dashed border-ck-border px-3 text-xs font-medium text-ck-disabled"
-						>
-							{label}
-							<span className="text-[9px] font-semibold uppercase tracking-wide text-ck-disabled">
-								soon
-							</span>
+			{/* Filters — collapsed by default (moved off the main rail). */}
+			{filtersOpen && (
+				<div className="flex flex-col gap-4 rounded-[10px] border border-ck-border bg-ck-card p-3">
+					{/* Status (LIVE views + dimmed ROADMAP concepts) */}
+					<div className="flex flex-col gap-1.5">
+						<span className="text-[11px] font-semibold uppercase tracking-wider text-ck-faint">
+							Status
 						</span>
-					))}
+						<div
+							className="flex flex-wrap gap-1.5"
+							role="radiogroup"
+							aria-label="Filter conversations by status"
+						>
+							{STATUS_FILTERS.map((s) => {
+								const active = status === s.value;
+								return (
+									<button
+										key={s.value}
+										type="button"
+										role="radio"
+										aria-checked={active}
+										onClick={() => onStatusChange(s.value)}
+										className={chipBase(active)}
+									>
+										{s.label}
+									</button>
+								);
+							})}
+							{ROADMAP_STATUSES.map((label) => (
+								<span
+									key={label}
+									aria-disabled="true"
+									title="Coming soon"
+									className="inline-flex h-7 cursor-not-allowed items-center gap-1.5 rounded-full border border-dashed border-ck-border px-3 text-xs font-medium text-ck-disabled"
+								>
+									{label}
+									<span className="text-[9px] font-semibold uppercase tracking-wide text-ck-disabled">
+										soon
+									</span>
+								</span>
+							))}
+						</div>
+					</div>
+
+					{/* Filter by tag (LIVE) — All + real workspace tags */}
+					<div className="flex flex-col gap-1.5">
+						<div className="flex items-center justify-between">
+							<span className="text-[11px] font-semibold uppercase tracking-wider text-ck-faint">
+								Filter by tag
+							</span>
+							{onManageTags && (
+								<button
+									type="button"
+									onClick={onManageTags}
+									className="inline-flex items-center gap-1 text-[11px] font-medium text-ck-faint hover:text-ck-text"
+								>
+									<SlidersHorizontal className="size-3" />
+									Manage
+								</button>
+							)}
+						</div>
+						<div className="flex flex-wrap gap-1.5">
+							<button
+								type="button"
+								onClick={() => onTagIdsChange([])}
+								aria-pressed={tagIds.length === 0}
+								className={chipBase(tagIds.length === 0)}
+							>
+								All
+							</button>
+							{tags.map((tag) => {
+								const active = selected.has(tag.id);
+								return (
+									<button
+										key={tag.id}
+										type="button"
+										onClick={() => toggleTag(tag.id)}
+										aria-pressed={active}
+										className={chipBase(active)}
+									>
+										<span
+											className="size-2 shrink-0 rounded-full"
+											style={{ backgroundColor: tag.color ?? FALLBACK_DOT }}
+										/>
+										<span className="max-w-[8rem] truncate">{tag.name}</span>
+									</button>
+								);
+							})}
+							{tags.length === 0 && (
+								<span className="text-xs text-ck-faint">No tags yet</span>
+							)}
+						</div>
+					</div>
 				</div>
-			</div>
+			)}
 		</div>
 	);
 }

--- a/apps/dashboard/src/app/inbox/_components/MessageThread.test.tsx
+++ b/apps/dashboard/src/app/inbox/_components/MessageThread.test.tsx
@@ -44,7 +44,7 @@ describe("MessageThread", () => {
 		expect(screen.queryByText("Admin")).not.toBeInTheDocument();
 	});
 
-	it("puts the visitor on the left and the bot/admin on the right", () => {
+	it("puts the AI agent on the left and the visitor/you on the right", () => {
 		render(
 			<MessageThread
 				messages={[
@@ -54,8 +54,8 @@ describe("MessageThread", () => {
 				]}
 			/>,
 		);
-		expect(sideOf("I need help")).toBe("left");
-		expect(sideOf("Hi there")).toBe("right");
+		expect(sideOf("I need help")).toBe("right");
+		expect(sideOf("Hi there")).toBe("left");
 		expect(sideOf("On it!")).toBe("right");
 		// Role labels are shown for bubbles.
 		expect(screen.getByText("Visitor")).toBeInTheDocument();

--- a/apps/dashboard/src/app/inbox/_components/MessageThread.tsx
+++ b/apps/dashboard/src/app/inbox/_components/MessageThread.tsx
@@ -60,26 +60,28 @@ function RatingIndicator({ rating }: { rating: Message["rating"] }) {
 	);
 }
 
-// "Agent" (the AI support agent), never "Bot"; "You" for the human teammate's
-// own reply. `tone` maps to the ds Bubble variants.
+// Chatbase-style sides: the AI "Agent" sits on the LEFT (gray bubble + sparkle
+// avatar), the "Visitor" (the person being helped) on the RIGHT (black bubble),
+// and the human teammate's own reply ("You", never "Bot") on the right as a
+// bordered card. `tone` maps to the ds Bubble variants.
 const ROLE = {
 	user: {
-		side: "left",
+		side: "right",
 		tone: "visitor",
 		label: "Visitor",
 		labelClass: "text-ck-faint",
 	},
 	assistant: {
-		side: "right",
+		side: "left",
 		tone: "agent",
 		label: "Agent",
-		labelClass: "text-ck-muted",
+		labelClass: "text-ck-text",
 	},
 	admin: {
 		side: "right",
 		tone: "admin",
 		label: "You",
-		labelClass: "text-ck-accent",
+		labelClass: "text-ck-muted",
 	},
 } as const;
 
@@ -109,15 +111,21 @@ function MessageBubble({
 			data-search-hit={firstHit ? "true" : undefined}
 			className={cn("flex flex-col gap-1", right ? "items-end" : "items-start")}
 		>
-			<span
-				className={cn(
-					"inline-flex items-center gap-1 px-1 text-[11px] font-semibold",
-					labelClass,
-				)}
-			>
-				{message.role === "assistant" && <Sparkles className="size-3" />}
-				{label}
-			</span>
+			{message.role === "assistant" ? (
+				// Chatbase-style AI header: sparkle avatar + agent name.
+				<span className="inline-flex items-center gap-1.5 px-1">
+					<span className="flex size-5 items-center justify-center rounded-full bg-ck-chip text-ck-text">
+						<Sparkles className="size-3" />
+					</span>
+					<span className="text-[11px] font-semibold text-ck-text">
+						{label}
+					</span>
+				</span>
+			) : (
+				<span className={cn("px-1 text-[11px] font-semibold", labelClass)}>
+					{label}
+				</span>
+			)}
 			<Bubble side={side} tone={tone}>
 				<Highlighted text={message.content} query={search} />
 			</Bubble>

--- a/apps/dashboard/src/app/inbox/_components/MessageThread.tsx
+++ b/apps/dashboard/src/app/inbox/_components/MessageThread.tsx
@@ -1,7 +1,13 @@
 "use client";
 
 import { useStickToBottom } from "@llmchat/widget/chat";
-import { ArrowDown, Headset, ThumbsDown, ThumbsUp } from "lucide-react";
+import {
+	ArrowDown,
+	Headset,
+	Sparkles,
+	ThumbsDown,
+	ThumbsUp,
+} from "lucide-react";
 import { useEffect, useLayoutEffect, useMemo, useRef } from "react";
 
 import { Bubble, Button } from "@/components/ds";
@@ -103,7 +109,13 @@ function MessageBubble({
 			data-search-hit={firstHit ? "true" : undefined}
 			className={cn("flex flex-col gap-1", right ? "items-end" : "items-start")}
 		>
-			<span className={cn("px-1 text-[11px] font-semibold", labelClass)}>
+			<span
+				className={cn(
+					"inline-flex items-center gap-1 px-1 text-[11px] font-semibold",
+					labelClass,
+				)}
+			>
+				{message.role === "assistant" && <Sparkles className="size-3" />}
 				{label}
 			</span>
 			<Bubble side={side} tone={tone}>

--- a/apps/dashboard/src/app/inbox/_components/status.ts
+++ b/apps/dashboard/src/app/inbox/_components/status.ts
@@ -47,6 +47,6 @@ export const STATUS_PILL: Record<
 	},
 	resolved: {
 		label: "Resolved",
-		className: "bg-ck-accent/12 text-ck-accent",
+		className: "bg-ck-good/12 text-ck-good",
 	},
 };

--- a/apps/dashboard/src/app/inbox/page.test.tsx
+++ b/apps/dashboard/src/app/inbox/page.test.tsx
@@ -181,6 +181,9 @@ describe("InboxPage — deleting a filtered tag reconciles the filter", () => {
 		await screen.findByRole("heading", { name: "Inbox" });
 		await waitFor(() => expect(listCalls().length).toBeGreaterThan(0));
 
+		// Open the (collapsed) Filters panel — the tag/status chips live there now.
+		await user.click(screen.getByRole("button", { name: /filters/i }));
+
 		// Click the "Billing" tag chip → it becomes the active filter and the list
 		// refetches scoped to it.
 		await user.click(await screen.findByRole("button", { name: "Billing" }));

--- a/apps/dashboard/src/app/inbox/page.tsx
+++ b/apps/dashboard/src/app/inbox/page.tsx
@@ -41,6 +41,7 @@ import {
 } from "./_components/format";
 import { InboxPanes } from "./_components/InboxPanes";
 import { InboxSkeleton } from "./_components/InboxSkeleton";
+import { InboxStats } from "./_components/InboxStats";
 import { ListFilters } from "./_components/ListFilters";
 import { LoadMore } from "./_components/LoadMore";
 import { MessageThread } from "./_components/MessageThread";
@@ -625,6 +626,10 @@ export default function InboxPage() {
 							onManageTags={
 								canManage ? () => setManageTagsOpen(true) : undefined
 							}
+							onRefresh={() => {
+								void listQuery.refetch();
+								void statsQuery.refetch();
+							}}
 						/>
 						{listQuery.isLoading ? (
 							<ConversationListSkeleton />
@@ -736,8 +741,13 @@ export default function InboxPage() {
 					) : null
 				}
 				emptyState={
-					<div className="flex flex-1 items-center justify-center text-sm text-ck-faint">
-						Select a conversation
+					<div className="flex flex-1 flex-col items-center justify-center gap-6 px-6">
+						{statsQuery.data && (
+							<div className="w-full max-w-md">
+								<InboxStats stats={statsQuery.data} />
+							</div>
+						)}
+						<p className="text-sm text-ck-faint">Select a conversation</p>
 					</div>
 				}
 				detailsEmptyState={

--- a/apps/dashboard/src/app/layout.tsx
+++ b/apps/dashboard/src/app/layout.tsx
@@ -79,8 +79,7 @@ export default function RootLayout({
 				<PostHogProvider>
 					<ThemeProvider
 						attribute="class"
-						defaultTheme="light"
-						enableSystem
+						forcedTheme="light"
 						disableTransitionOnChange
 					>
 						<QueryProvider>

--- a/apps/dashboard/src/app/layout.tsx
+++ b/apps/dashboard/src/app/layout.tsx
@@ -79,7 +79,7 @@ export default function RootLayout({
 				<PostHogProvider>
 					<ThemeProvider
 						attribute="class"
-						defaultTheme="dark"
+						defaultTheme="light"
 						enableSystem
 						disableTransitionOnChange
 					>

--- a/apps/dashboard/src/components/ds/bubble.tsx
+++ b/apps/dashboard/src/components/ds/bubble.tsx
@@ -4,11 +4,12 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 /**
- * Design-system chat bubble for the Clanker restyle. Generic + token-driven:
- * a `side` (left/right) and a `tone` for who's speaking. Visitor messages read
- * as a neutral surface; the support agent + human teammate replies read as
- * accent/raised. The inbox composes per-message actions (Add-to-knowledge,
- * thumbs) around it; the bubble is just the speech container.
+ * Design-system chat bubble. Generic + token-driven: a `side` (left/right) and a
+ * `tone` for who's speaking. Chatbase-style mapping: the AI agent is a neutral
+ * gray bubble on the LEFT; the visitor (the person being helped) is the solid
+ * black bubble on the RIGHT; a human teammate's own reply ("You") is a bordered
+ * white card on the right, so it's distinct from the visitor. The inbox composes
+ * per-message actions (Add-to-knowledge, thumbs) around it.
  */
 const bubbleVariants = cva(
 	"max-w-[75%] rounded-2xl px-3.5 py-2 text-sm leading-relaxed whitespace-pre-wrap break-words",
@@ -16,12 +17,12 @@ const bubbleVariants = cva(
 		variants: {
 			side: { left: "rounded-bl-sm", right: "rounded-br-sm" },
 			tone: {
-				visitor: "bg-ck-chip text-ck-text",
-				agent: "border border-ck-border bg-ck-card text-ck-text",
-				admin: "bg-ck-accent text-white",
+				visitor: "bg-ck-accent text-white",
+				agent: "bg-ck-chip text-ck-text",
+				admin: "border border-ck-border bg-ck-card text-ck-text",
 			},
 		},
-		defaultVariants: { side: "left", tone: "visitor" },
+		defaultVariants: { side: "left", tone: "agent" },
 	},
 );
 

--- a/apps/dashboard/src/components/ds/nav-item.tsx
+++ b/apps/dashboard/src/components/ds/nav-item.tsx
@@ -15,7 +15,7 @@ export interface NavItemProps extends React.HTMLAttributes<HTMLElement> {
 /**
  * Design-system sidebar nav row for the Clanker restyle. Generic + token-driven:
  * icon · label · optional trailing slot, with active/inactive states from the ck
- * scale (active = solid accent; inactive = muted, hover surface). `asChild` lets
+ * scale (active = raised white card; inactive = muted, hover surface). `asChild` lets
  * a Next <Link> own the anchor while keeping the styling here. Shared by the
  * shell and any future nav.
  */
@@ -28,7 +28,7 @@ export const NavItem = React.forwardRef<HTMLElement, NavItemProps>(
 			"flex items-center gap-2.5 rounded-[10px] px-2.5 py-2 text-[13.5px] font-medium transition-colors",
 			"[&_svg]:size-[18px] [&_svg]:shrink-0",
 			active
-				? "bg-ck-accent text-white [&_svg]:text-white"
+				? "border border-ck-border bg-ck-card text-ck-text shadow-sm [&_svg]:text-ck-text"
 				: "text-ck-muted hover:bg-ck-navhover hover:text-ck-text [&_svg]:text-ck-muted",
 			className,
 		);

--- a/apps/dashboard/src/components/shell/account-menu.test.tsx
+++ b/apps/dashboard/src/components/shell/account-menu.test.tsx
@@ -9,11 +9,7 @@ import { useSignOut } from "@/lib/use-sign-out";
 import { AccountMenu } from "./account-menu";
 
 const signOut = vi.fn();
-const setTheme = vi.fn();
 vi.mock("@/lib/use-sign-out", () => ({ useSignOut: vi.fn() }));
-vi.mock("next-themes", () => ({
-	useTheme: () => ({ theme: "dark", setTheme }),
-}));
 vi.mock("@/lib/account", () => ({
 	ACCOUNT_KEY: ["account"],
 	fetchAccount: vi.fn(),
@@ -41,7 +37,7 @@ beforeEach(() => {
 });
 
 describe("AccountMenu", () => {
-	it("opens to Account / Billing / Appearance / Sign out and NO Settings entry", async () => {
+	it("opens to Account / Billing / Sign out and NO Settings or Appearance entry", async () => {
 		const user = userEvent.setup();
 		renderMenu();
 		await user.click(screen.getByRole("button", { name: /account menu/i }));
@@ -56,26 +52,14 @@ describe("AccountMenu", () => {
 		expect(
 			screen.getByRole("menuitem", { name: /sign out/i }),
 		).toBeInTheDocument();
-		// Appearance section keeps the theme switcher working.
-		expect(
-			screen.getByRole("menuitem", { name: /light/i }),
-		).toBeInTheDocument();
-		expect(
-			screen.getByRole("menuitem", { name: /system/i }),
-		).toBeInTheDocument();
+		// Light-only now (Chatbase-style): no appearance switcher.
+		expect(screen.queryByRole("menuitem", { name: /^light$/i })).toBeNull();
+		expect(screen.queryByRole("menuitem", { name: /^system$/i })).toBeNull();
 		// No dead "Settings" / workspace-management duplicate here.
 		expect(screen.queryByRole("menuitem", { name: /^settings$/i })).toBeNull();
 		expect(
 			screen.queryByRole("menuitem", { name: /manage workspaces/i }),
 		).toBeNull();
-	});
-
-	it("flips the theme from the Appearance section", async () => {
-		const user = userEvent.setup();
-		renderMenu();
-		await user.click(screen.getByRole("button", { name: /account menu/i }));
-		await user.click(await screen.findByRole("menuitem", { name: /light/i }));
-		expect(setTheme).toHaveBeenCalledWith("light");
 	});
 
 	it("signs out", async () => {

--- a/apps/dashboard/src/components/shell/account-menu.tsx
+++ b/apps/dashboard/src/components/shell/account-menu.tsx
@@ -1,32 +1,24 @@
 "use client";
 
 import { useQueryClient } from "@tanstack/react-query";
-import { CreditCard, LogOut, Monitor, Moon, Sun, UserCog } from "lucide-react";
+import { CreditCard, LogOut, UserCog } from "lucide-react";
 import Link from "next/link";
-import { useTheme } from "next-themes";
 
 import {
 	Menu,
 	MenuContent,
 	MenuItem,
-	MenuLabel,
 	MenuSeparator,
 	MenuTrigger,
 } from "@/components/ds";
 import { ACCOUNT_KEY, fetchAccount } from "@/lib/account";
 import { useSignOut } from "@/lib/use-sign-out";
 
-const THEMES = [
-	{ value: "light", label: "Light", icon: Sun },
-	{ value: "dark", label: "Dark", icon: Moon },
-	{ value: "system", label: "System", icon: Monitor },
-] as const;
-
 /**
- * Top-bar account menu: Account, Billing, an Appearance section (the Light/Dark/
- * System switcher — kept here so the top bar stays minimal), and Sign out. No
- * "Settings" entry: workspace management lives in the workspace switcher and
- * there's no global settings page, so it would be a dead/duplicate destination.
+ * Top-bar account menu: Account, Billing, and Sign out. No appearance switcher —
+ * the dashboard is light-only (Chatbase-style). No "Settings" entry: workspace
+ * management lives in the workspace switcher and there's no global settings page,
+ * so it would be a dead/duplicate destination.
  */
 export function AccountMenu({
 	userEmail,
@@ -37,7 +29,6 @@ export function AccountMenu({
 }) {
 	const handleSignOut = useSignOut();
 	const qc = useQueryClient();
-	const { theme, setTheme } = useTheme();
 	const initials = userEmail.slice(0, 2).toUpperCase();
 
 	// Warm the account page cache when the menu opens, so it renders with data.
@@ -80,22 +71,6 @@ export function AccountMenu({
 						Billing
 					</Link>
 				</MenuItem>
-				<MenuSeparator />
-				<MenuLabel>Appearance</MenuLabel>
-				{THEMES.map((t) => (
-					<MenuItem
-						key={t.value}
-						selected={theme === t.value}
-						// Keep the menu open while flipping theme so it's easy to compare.
-						onSelect={(e) => {
-							e.preventDefault();
-							setTheme(t.value);
-						}}
-					>
-						<t.icon />
-						{t.label}
-					</MenuItem>
-				))}
 				<MenuSeparator />
 				<MenuItem onSelect={handleSignOut}>
 					<LogOut />

--- a/apps/dashboard/src/components/shell/top-bar.tsx
+++ b/apps/dashboard/src/components/shell/top-bar.tsx
@@ -58,7 +58,7 @@ export function TopBar({
 					type="button"
 					onClick={onOpenSearch}
 					aria-label="Search conversations and projects"
-					className="hidden h-9 w-full max-w-md items-center gap-2 rounded-md border border-ck-border bg-ck-app px-3 text-sm text-ck-muted transition-colors hover:text-ck-text sm:flex"
+					className="hidden h-9 w-full max-w-md items-center gap-2 rounded-[10px] border border-transparent bg-ck-chip px-3 text-sm text-ck-muted transition-colors hover:bg-ck-navhover hover:text-ck-text sm:flex"
 				>
 					<Search className="size-4 shrink-0" />
 					<span className="flex-1 truncate text-left">
@@ -96,6 +96,9 @@ export function TopBar({
 					<HelpCircle className="size-4" />
 				</a>
 			</Button>
+
+			{/* Thin divider before the avatar (Chatbase top-right cluster). */}
+			<span className="mx-1 hidden h-5 w-px bg-ck-border sm:block" />
 
 			<AccountMenu userEmail={userEmail} roleLabel={roleLabel} />
 		</header>

--- a/apps/dashboard/src/components/shell/usage-meter.tsx
+++ b/apps/dashboard/src/components/shell/usage-meter.tsx
@@ -61,7 +61,7 @@ export function UsageMeter() {
 						Limits aren&apos;t enforced yet —{" "}
 						<Link
 							href="/settings/billing"
-							className="font-semibold text-ck-accent"
+							className="font-semibold text-ck-link"
 						>
 							Billing
 						</Link>

--- a/apps/dashboard/tailwind.config.ts
+++ b/apps/dashboard/tailwind.config.ts
@@ -44,6 +44,8 @@ const config: Config = {
 						DEFAULT: "rgb(var(--ck-accent) / <alpha-value>)",
 						hover: "rgb(var(--ck-accent-hover) / <alpha-value>)",
 					},
+					good: "rgb(var(--ck-good) / <alpha-value>)",
+					link: "rgb(var(--ck-link) / <alpha-value>)",
 					warn: "rgb(var(--ck-warn) / <alpha-value>)",
 				},
 				background: "hsl(var(--background))",


### PR DESCRIPTION
## Summary

Restyles the **operator dashboard** (`apps/dashboard`) to match the **Chatbase** UI — light, monochrome, clean — while keeping every real feature. **Design-only**: no routes, data, or business logic changed; features that were in the way were **relocated, not removed**.

Audit-driven (a parallel read of both token systems, the `ds/` primitives, the inbox tree, and every class-asserting test → a file-by-file plan), then two passes.

## Pass 1 — adopt the Chatbase visual language
- **Tokens**: light default; light `--ck-*` + shadcn tokens repointed to the Chatbase palette (warm `#F7F7F6` canvas, white cards, `#ECECEC` hairlines, **near-black primary** — Chatbase uses black buttons/bubbles, not a color brand). Added `--ck-good` (green) + `--ck-link` (blue).
- **Shell**: active nav → white raised pill; gray rounded search; divider before the avatar.
- **Inbox**: white panes; selected row = white card + shadow; list header "Inbox / N conversations"; green resolved/CSAT; label-left/value-right detail rows built from real fields only.

## Pass 2 — match the layout more exactly (per feedback)
- **Light-only**: `forcedTheme="light"` (a saved `dark` preference was overriding the new default). Removed the now-inert Appearance switcher.
- **Thread mirrors Chatbase**: the AI **"Agent" is on the left** (gray bubble + ✨ sparkle avatar), the **"Visitor" is on the right** (solid black bubble), and a teammate's own reply (**"You"**) is a bordered card on the right.
- **Decluttered list**: tag + status **filters collapse behind a Filters toggle**; the four **stat cards moved to the empty thread area**. The list is now header + count + toolbar (filter/refresh) + search + rows — Chatbase's clean "Chat logs" look.

## Feature mapping (Chatbase → ours)
| Chatbase | Ours |
|---|---|
| Left nav, active white pill | `sidebar-nav` (Conversations / Projects / Sources / Settings) |
| Sidebar usage card | `usage-meter` (real responses; no fake MB ring) |
| "Chat logs / N total items" + toolbar | "Inbox / N conversations" + filter/refresh |
| AI-left gray bubble + avatar / user-right black | Agent-left / Visitor-right-black / You-card |
| Details: Topics / Sentiment / Contact | tags / CSAT (green) / email·IP·device·started·messages |
| Confidence · AI-requests · Tickets · Phone · Location | **omitted** — no real data (never faked) |

## Honesty / scope
Design-only, every real feature preserved. Real data only — no fake tickets, confidence scores, phone, or location. Dark mode intentionally dropped (Chatbase is light-only).

## Gates ✅
`pnpm test` — all 6 packages green (**430 dashboard tests**, updated for the moved controls) · tsc + oxlint + prettier clean · `next build` clean.

Verified end-to-end against the running app with seeded data: inbox 3-pane (list / thread + detail panel), the decluttered empty state, billing, and projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
