### PR TITLE
fix(widget): inline display:block !important on the shadow host

### DIFF
--- a/packages/widget/src/mount-host.test.ts
+++ b/packages/widget/src/mount-host.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { createWidgetHost } from "./mount-host";
+
+describe("createWidgetHost", () => {
+	it("creates the well-known root element", () => {
+		const host = createWidgetHost(document);
+		expect(host.tagName).toBe("DIV");
+		expect(host.id).toBe("llmchat-widget-root");
+	});
+
+	it("forces display with an important inline declaration — Dawn's div:empty{display:none} must not hide the shadow host", () => {
+		const host = createWidgetHost(document);
+		expect(host.style.getPropertyValue("display")).toBe("block");
+		expect(host.style.getPropertyPriority("display")).toBe("important");
+	});
+});

--- a/packages/widget/src/mount-host.ts
+++ b/packages/widget/src/mount-host.ts
@@ -1,0 +1,16 @@
+/**
+ * Creates the light-DOM host element the widget mounts its shadow root into.
+ *
+ * The inline `display: block !important` is load-bearing: all widget content
+ * lives in the shadow root, so in the light DOM the host is `:empty` — and
+ * theme CSS commonly hides empty containers (Shopify's Dawn ships
+ * `div:empty { display: none }` in base.css, which made the bubble invisible
+ * on every Dawn-based store). An important inline declaration outranks any
+ * stylesheet rule, important or not, in the cascade.
+ */
+export function createWidgetHost(doc: Document): HTMLDivElement {
+	const host = doc.createElement("div");
+	host.id = "llmchat-widget-root";
+	host.style.setProperty("display", "block", "important");
+	return host;
+}

--- a/packages/widget/src/mount.tsx
+++ b/packages/widget/src/mount.tsx
@@ -2,6 +2,7 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 
 import { resolveConfig } from "./config";
+import { createWidgetHost } from "./mount-host";
 import { Widget } from "./widget";
 import { widgetStyles } from "./styles";
 
@@ -12,8 +13,7 @@ const config = resolveConfig(
 );
 
 function mount() {
-	const host = document.createElement("div");
-	host.id = "llmchat-widget-root";
+	const host = createWidgetHost(document);
 	document.body.appendChild(host);
 	const shadow = host.attachShadow({ mode: "open" });
 


### PR DESCRIPTION
## What

One-property fix in the widget mount: the shadow host `#llmchat-widget-root` now sets inline `display: block !important` (`createWidgetHost()` in `packages/widget/src/mount-host.ts`, unit-tested).

## Why

Shopify's Dawn theme family ships `a:empty, ul:empty, div:empty, … { display: none }` in `base.css`. All widget content lives in the shadow root, so the light-DOM host is `:empty` — **the bubble was invisible on every Dawn-based store.** Found by the Shopify connector's §9 dev-store test; the entire embed chain worked, the host was simply hidden by theme CSS.

An important inline declaration outranks any stylesheet rule in the cascade, and the host has no layout footprint either way.

## Verification

- Headless repro: unfixed bundle + the Dawn rule → bubble hidden (host `computedDisplay: none`, rule fingered via CDP `CSS.getMatchedStylesForNode`); fixed bundle + same rule → bubble renders (56×56 rect) and completes a full live chat against prod.
- `@llmchat/widget`: 20 test files / 117 tests pass; repo lint + test green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)