### PR TITLE
feat(dashboard): bring back dark mode — Light/Dark/System preference

### DIFF
--- a/apps/dashboard/src/app/layout.tsx
+++ b/apps/dashboard/src/app/layout.tsx
@@ -77,9 +77,16 @@ export default function RootLayout({
 					}}
 				/>
 				<PostHogProvider>
+					{/*
+					 * Light stays the default (Chatbase-style), but the theme is a
+					 * PREFERENCE again: enableSystem + the account-menu Appearance
+					 * switcher (Light/Dark/System) — both .dark token sets (shadcn +
+					 * --ck-*) shipped with the restyle and stay maintained.
+					 */}
 					<ThemeProvider
 						attribute="class"
-						forcedTheme="light"
+						defaultTheme="light"
+						enableSystem
 						disableTransitionOnChange
 					>
 						<QueryProvider>

--- a/apps/dashboard/src/components/shell/account-menu.test.tsx
+++ b/apps/dashboard/src/components/shell/account-menu.test.tsx
@@ -9,7 +9,11 @@ import { useSignOut } from "@/lib/use-sign-out";
 import { AccountMenu } from "./account-menu";
 
 const signOut = vi.fn();
+const setTheme = vi.fn();
 vi.mock("@/lib/use-sign-out", () => ({ useSignOut: vi.fn() }));
+vi.mock("next-themes", () => ({
+	useTheme: () => ({ theme: "dark", setTheme }),
+}));
 vi.mock("@/lib/account", () => ({
 	ACCOUNT_KEY: ["account"],
 	fetchAccount: vi.fn(),
@@ -37,7 +41,7 @@ beforeEach(() => {
 });
 
 describe("AccountMenu", () => {
-	it("opens to Account / Billing / Sign out and NO Settings or Appearance entry", async () => {
+	it("opens to Account / Billing / Appearance / Sign out and NO Settings entry", async () => {
 		const user = userEvent.setup();
 		renderMenu();
 		await user.click(screen.getByRole("button", { name: /account menu/i }));
@@ -52,14 +56,26 @@ describe("AccountMenu", () => {
 		expect(
 			screen.getByRole("menuitem", { name: /sign out/i }),
 		).toBeInTheDocument();
-		// Light-only now (Chatbase-style): no appearance switcher.
-		expect(screen.queryByRole("menuitem", { name: /^light$/i })).toBeNull();
-		expect(screen.queryByRole("menuitem", { name: /^system$/i })).toBeNull();
+		// Appearance section keeps the theme switcher working.
+		expect(
+			screen.getByRole("menuitem", { name: /light/i }),
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole("menuitem", { name: /system/i }),
+		).toBeInTheDocument();
 		// No dead "Settings" / workspace-management duplicate here.
 		expect(screen.queryByRole("menuitem", { name: /^settings$/i })).toBeNull();
 		expect(
 			screen.queryByRole("menuitem", { name: /manage workspaces/i }),
 		).toBeNull();
+	});
+
+	it("flips the theme from the Appearance section", async () => {
+		const user = userEvent.setup();
+		renderMenu();
+		await user.click(screen.getByRole("button", { name: /account menu/i }));
+		await user.click(await screen.findByRole("menuitem", { name: /light/i }));
+		expect(setTheme).toHaveBeenCalledWith("light");
 	});
 
 	it("signs out", async () => {

--- a/apps/dashboard/src/components/shell/account-menu.tsx
+++ b/apps/dashboard/src/components/shell/account-menu.tsx
@@ -1,24 +1,32 @@
 "use client";
 
 import { useQueryClient } from "@tanstack/react-query";
-import { CreditCard, LogOut, UserCog } from "lucide-react";
+import { CreditCard, LogOut, Monitor, Moon, Sun, UserCog } from "lucide-react";
 import Link from "next/link";
+import { useTheme } from "next-themes";
 
 import {
 	Menu,
 	MenuContent,
 	MenuItem,
+	MenuLabel,
 	MenuSeparator,
 	MenuTrigger,
 } from "@/components/ds";
 import { ACCOUNT_KEY, fetchAccount } from "@/lib/account";
 import { useSignOut } from "@/lib/use-sign-out";
 
+const THEMES = [
+	{ value: "light", label: "Light", icon: Sun },
+	{ value: "dark", label: "Dark", icon: Moon },
+	{ value: "system", label: "System", icon: Monitor },
+] as const;
+
 /**
- * Top-bar account menu: Account, Billing, and Sign out. No appearance switcher —
- * the dashboard is light-only (Chatbase-style). No "Settings" entry: workspace
- * management lives in the workspace switcher and there's no global settings page,
- * so it would be a dead/duplicate destination.
+ * Top-bar account menu: Account, Billing, an Appearance section (the Light/Dark/
+ * System switcher — kept here so the top bar stays minimal), and Sign out. No
+ * "Settings" entry: workspace management lives in the workspace switcher and
+ * there's no global settings page, so it would be a dead/duplicate destination.
  */
 export function AccountMenu({
 	userEmail,
@@ -29,6 +37,7 @@ export function AccountMenu({
 }) {
 	const handleSignOut = useSignOut();
 	const qc = useQueryClient();
+	const { theme, setTheme } = useTheme();
 	const initials = userEmail.slice(0, 2).toUpperCase();
 
 	// Warm the account page cache when the menu opens, so it renders with data.
@@ -71,6 +80,22 @@ export function AccountMenu({
 						Billing
 					</Link>
 				</MenuItem>
+				<MenuSeparator />
+				<MenuLabel>Appearance</MenuLabel>
+				{THEMES.map((t) => (
+					<MenuItem
+						key={t.value}
+						selected={theme === t.value}
+						// Keep the menu open while flipping theme so it's easy to compare.
+						onSelect={(e) => {
+							e.preventDefault();
+							setTheme(t.value);
+						}}
+					>
+						<t.icon />
+						{t.label}
+					</MenuItem>
+				))}
 				<MenuSeparator />
 				<MenuItem onSelect={handleSignOut}>
 					<LogOut />


### PR DESCRIPTION
## What

Restores the dashboard's theme switcher, which the Chatbase-adoption pass (`c0ac44c`) forced off:

- `ThemeProvider` back to `defaultTheme="light"` + `enableSystem` (was `forcedTheme="light"`). **Light remains the default** — dark is a preference again, and previously-saved choices are honored.
- The account-menu **Appearance** section (Light / Dark / System) restored exactly as it shipped pre-force, with its tests (including "flips the theme from the Appearance section").

## Why no token work

Both `.dark` token sets (shadcn vars + the restyle's `--ck-*` scale) shipped with the restyle and stayed maintained — the restyle plan explicitly contracted "both themes ship" (`docs/dashboard-restyle-plan.md` §Theme). This PR is pure re-wiring; zero visual change for anyone who never picks Dark.

## Verification

- 431 dashboard tests pass (68 files; +1 restored switcher test)
- `next build` + bundle-size guard green; prettier/oxlint/tsc clean
- Headless screenshots of `/sign-in` in both themes: `.dark`/`.light` class flips, dark renders the slate+indigo set, light unchanged
- Worth a quick eyeball on auth-gated pages (inbox/settings) in dark after merge — the dark tokens predate the force and shipped through the restyle PRs, but they haven't been looked at in a few days

🤖 Generated with [Claude Code](https://claude.com/claude-code)