### PR TITLE
fix(marketing): regenerate llms.txt + fix false no-SDK claims sitewide

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ AI-first support widget + admin inbox. Standalone product built on LLM Gateway.
 - **Inference**: LLM Gateway (single backend, configured via `LLMGATEWAY_API_KEY`)
 - **Email**: Resend REST API (outbound) + inbound webhook
 - **Auth**: Better Auth (email + password)
-- **Billing**: Stripe (metered AI messages + seat-based)
+- **Billing**: Stripe (flat monthly tiers + metered overage; no per-seat fees)
 
 ## Layout
 

--- a/apps/marketing/content/blog/clanker-support-is-live-on-product-hunt.md
+++ b/apps/marketing/content/blog/clanker-support-is-live-on-product-hunt.md
@@ -14,7 +14,7 @@ So we built the opposite. Clanker Support answers from your docs, your help cent
 
 ## One script tag, then it's working
 
-Installation is one line of code before your closing `</body>` tag. No npm package, no build step, no framework to fight. The widget mounts in an isolated shadow DOM, so it inherits your brand color without your styles leaking in or out. Most teams are live in about five minutes.
+Installation is one line of code before your closing `</body>` tag. No build step, no framework to fight. (_Update, July 2026:_ prefer a package? There's now an official React SDK — `@clankersupport/widget-rsc` on npm.) The widget mounts in an isolated shadow DOM, so it inherits your brand color without your styles leaking in or out. Most teams are live in about five minutes.
 
 From there it reads from the knowledge you paste in and stays on topic. Ask it something off-script and it won't improvise — it raises its hand.
 

--- a/apps/marketing/content/competitors/chatbase.json
+++ b/apps/marketing/content/competitors/chatbase.json
@@ -8,7 +8,7 @@
 	"bestFor": "Teams that need multi-channel AI support and have enterprise security requirements.",
 	"notFor": "Teams wanting a simple drop-in widget, or the freedom to run a custom or self-hosted model.",
 	"pricing": "Free plan (1 agent, basic models); paid from $40/mo (Hobby) to ~$500/mo (Pro), credit-based; Enterprise custom",
-	"heroSubtext": "Clanker Support is a single script tag that goes live in minutes — no platform onboarding, no SDK. Chatbase lets you pick from its supported models on higher-priced plans; Clanker Support runs any model or provider — including custom and self-hosted endpoints — on every plan, and you can self-host the whole stack.",
+	"heroSubtext": "Clanker Support is a single script tag that goes live in minutes — no platform onboarding, no SDK required (an official React SDK exists when you want one). Chatbase lets you pick from its supported models on higher-priced plans; Clanker Support runs any model or provider — including custom and self-hosted endpoints — on every plan, and you can self-host the whole stack.",
 	"heroBadges": [
 		"One script tag",
 		"Model-agnostic",
@@ -111,7 +111,7 @@
 			]
 		}
 	],
-	"tldr": "Clanker Support is a single script tag that goes live in minutes and lets you swap underlying AI models without touching your code. Chatbase is a full platform with stronger multi-channel support. Choose Clanker Support if you want simplicity and model flexibility. Choose Chatbase if you need WhatsApp, Slack, or Messenger support today.",
+	"tldr": "Clanker Support installs with a single script tag — or one React Server Component — goes live in minutes, and lets you swap underlying AI models without touching your code. Chatbase is a full platform with stronger multi-channel support. Choose Clanker Support if you want simplicity and model flexibility. Choose Chatbase if you need WhatsApp, Slack, or Messenger support today.",
 	"llmchatWins": [
 		"One script tag setup — live in under 5 minutes",
 		"Shadow DOM isolation — widget styles never bleed into your page",

--- a/apps/marketing/content/migrations/chatbase.json
+++ b/apps/marketing/content/migrations/chatbase.json
@@ -4,7 +4,7 @@
 	"name": "Chatbase",
 	"tagline": "From the Chatbase embed to a single Clanker Support script tag",
 	"estimatedTime": "~20 minutes",
-	"intro": "Migrating from Chatbase to Clanker Support is mostly a knowledge-base re-import and a one-line embed swap. Your bot's brain lives in text you already have, and the Clanker Support widget drops in with a single script tag — no SDK, no platform onboarding.",
+	"intro": "Migrating from Chatbase to Clanker Support is mostly a knowledge-base re-import and a one-line embed swap. Your bot's brain lives in text you already have, and the Clanker Support widget drops in with a single script tag — no SDK required, no platform onboarding.",
 	"quickSummary": "Replace the Chatbase embed snippet with the Clanker Support script tag, then paste your knowledge base into your Clanker Support project. Everything else is configuration in the dashboard.",
 	"oldEmbedLabel": "Remove the Chatbase embed",
 	"oldEmbed": "<script>\n  window.embeddedChatbotConfig = {\n    chatbotId: \"XXXXXXXX\",\n    domain: \"www.chatbase.co\",\n  };\n</script>\n<script\n  src=\"https://www.chatbase.co/embed.min.js\"\n  chatbotId=\"XXXXXXXX\"\n  domain=\"www.chatbase.co\"\n  defer\n></script>",

--- a/apps/marketing/src/app/docs/page.tsx
+++ b/apps/marketing/src/app/docs/page.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import Link from "next/link";
 import { allMigrations, matrix } from "content-collections";
 import { SiteHeader } from "@/components/SiteHeader";
@@ -12,7 +13,15 @@ import {
 	pageMeta,
 	type Faq,
 } from "@/lib/seo";
-import { CANONICAL_SITE_URL } from "@/lib/site-urls";
+import { CANONICAL_SITE_URL, RSC_PACKAGE } from "@/lib/site-urls";
+
+function InlineCode({ children }: { children: ReactNode }) {
+	return (
+		<code className="rounded bg-paper-deep px-1.5 py-0.5 font-mono text-[0.8em]">
+			{children}
+		</code>
+	);
+}
 
 const dashboardUrl =
 	process.env.NEXT_PUBLIC_DASHBOARD_URL ?? "http://localhost:3001";
@@ -27,8 +36,7 @@ export const metadata = pageMeta({
 const faqs: Faq[] = [
 	{
 		question: "How do I install Clanker Support?",
-		answer:
-			"Create a project in the dashboard to get your public key, then add a single script tag to your site anywhere before the closing </body> tag. There's no build step or npm package, and most teams are live in under five minutes.",
+		answer: `Create a project in the dashboard to get your public key, then add a single script tag to your site anywhere before the closing </body> tag — no build step required. On Next.js or any React 19 app, install the official ${RSC_PACKAGE} npm package instead — one component in your layout. Most teams are live in under five minutes.`,
 	},
 	{
 		question: "How do I train the bot on my own docs?",
@@ -180,10 +188,18 @@ export default function DocsPage() {
 					<p className="mt-5 max-w-2xl text-base leading-relaxed text-ink-soft">
 						Create a project in the dashboard to get your public key, then add a
 						single script tag to your site — anywhere before the closing{" "}
-						<code className="rounded bg-paper-deep px-1.5 py-0.5 font-mono text-[0.8em]">
-							&lt;/body&gt;
-						</code>{" "}
-						tag. That&apos;s the whole integration.
+						<InlineCode>&lt;/body&gt;</InlineCode> tag. That&apos;s the whole
+						integration. Building with Next.js or another React Server
+						Components setup? Install the official{" "}
+						<InlineCode>{RSC_PACKAGE}</InlineCode> package instead — one Server
+						Component in your root layout, no script tag. See the{" "}
+						<Link
+							href="/blog/nextjs-ai-support-widget-server-component"
+							className="text-accent underline decoration-accent/40 underline-offset-2 hover:decoration-accent"
+						>
+							Next.js tutorial
+						</Link>
+						.
 					</p>
 					<div className="mt-6">
 						<CodeBlock code={matrix.llmchatEmbed} label="index.html" />

--- a/apps/marketing/src/app/page.tsx
+++ b/apps/marketing/src/app/page.tsx
@@ -8,7 +8,7 @@ import { FaqSection } from "@/components/FaqSection";
 import { FEATURES } from "@/lib/features";
 import { USE_CASES } from "@/lib/use-cases";
 import { faqPageLd, type Faq } from "@/lib/seo";
-import { CANONICAL_SITE_URL } from "@/lib/site-urls";
+import { CANONICAL_SITE_URL, RSC_PACKAGE } from "@/lib/site-urls";
 
 const dashboardUrl =
 	process.env.NEXT_PUBLIC_DASHBOARD_URL ?? "http://localhost:3001";
@@ -53,13 +53,11 @@ const orgJsonLd = {
 const faqs: Faq[] = [
 	{
 		question: "What is Clanker Support?",
-		answer:
-			"Clanker Support is an AI-powered support agent you embed on any site with one script tag. It answers from your docs and sources, then hands off to your team the moment it can't — routing every escalation into a single inbox with the full conversation intact.",
+		answer: `Clanker Support is an AI-powered support agent you embed on any site with one script tag — or one React Server Component via the ${RSC_PACKAGE} npm package. It answers from your docs and sources, then hands off to your team the moment it can't — routing every escalation into a single inbox with the full conversation intact.`,
 	},
 	{
 		question: "How do I add Clanker Support to my site?",
-		answer:
-			"Paste one script tag before the closing </body> tag. The widget mounts in an isolated shadow DOM, inherits your brand color, and needs no build step or npm package. Most teams are live in about five minutes.",
+		answer: `Paste one script tag before the closing </body> tag — the widget mounts in an isolated shadow DOM, inherits your brand color, and needs no build step. On Next.js or any React 19 app, install the official ${RSC_PACKAGE} npm package instead — one component in your layout. Most teams are live in about five minutes.`,
 	},
 	{
 		question: "Which AI models does Clanker Support support?",

--- a/apps/marketing/src/lib/features.ts
+++ b/apps/marketing/src/lib/features.ts
@@ -4,6 +4,8 @@
 // skill (benefit-led headlines, a problem hook, outcome-focused highlights) and
 // every claim stays faithful to what the product actually does (see AGENTS.md).
 
+import { RSC_PACKAGE } from "./site-urls";
+
 export type Feature = {
 	/** URL slug — `/features/<slug>`. */
 	slug: string;
@@ -47,7 +49,7 @@ export const FEATURES: Feature[] = [
 		points: [
 			{
 				heading: "Install in one line",
-				body: "Drop a single script tag on any page or framework. No build step, no npm package, no SDK to wire up.",
+				body: `Drop a single script tag on any page or framework — no build step, nothing to wire up. Prefer a package? The official ${RSC_PACKAGE} npm SDK covers React 19 and Next.js.`,
 			},
 			{
 				heading: "Never breaks your design",
@@ -66,8 +68,7 @@ export const FEATURES: Feature[] = [
 		faqs: [
 			{
 				question: "How do I add the Clanker Support widget to my site?",
-				answer:
-					"Paste one script tag before the closing </body> tag. It works the same on Webflow, WordPress, Next.js, or plain HTML — no build step, no npm package, and no SDK to wire up. Most teams are live in about five minutes.",
+				answer: `Paste one script tag before the closing </body> tag. It works the same on Webflow, WordPress, Next.js, or plain HTML — no build step and nothing to wire up. React 19 and Next.js teams can use the official npm package, ${RSC_PACKAGE}, instead. Most teams are live in about five minutes.`,
 			},
 			{
 				question: "Will the widget conflict with my site's styles?",

--- a/apps/marketing/src/lib/llms-txt.test.ts
+++ b/apps/marketing/src/lib/llms-txt.test.ts
@@ -1,6 +1,8 @@
+import { BILLING_TIERS } from "@llmchat/shared";
 import { describe, expect, it } from "vitest";
 
 import { buildLlmsTxt } from "./llms-txt";
+import { CANONICAL_SHOWCASE_URL } from "./site-urls";
 
 const BASE = "https://clankersupport.com";
 
@@ -62,6 +64,48 @@ describe("buildLlmsTxt", () => {
 	it("uses the 'support agent' positioning, never 'chatbot'", () => {
 		expect(out.toLowerCase()).toContain("support agent");
 		expect(out.toLowerCase()).not.toContain("chatbot");
+	});
+
+	it("presents both install paths: script tag AND the React SDK", () => {
+		expect(out).toContain("script tag");
+		expect(out).toContain("npm install @clankersupport/widget-rsc");
+		expect(out).toContain("Server Component");
+		expect(out).toContain("@clankersupport/widget-rsc/headless");
+		expect(out).toContain(".clanker-*");
+		expect(out).toContain(
+			"(https://www.npmjs.com/package/@clankersupport/widget-rsc)",
+		);
+	});
+
+	it("links the GitHub repo for the open-source / self-host story", () => {
+		expect(out).toContain("(https://github.com/theopenco/llmchat)");
+	});
+
+	it("links the live demo and the legal pages (Optional section)", () => {
+		expect(out).toContain(`(${CANONICAL_SHOWCASE_URL})`);
+		expect(out).toContain("## Optional");
+		expect(out).toContain(`(${BASE}/privacy-policy)`);
+		expect(out).toContain(`(${BASE}/terms-of-use)`);
+	});
+
+	it("derives prices from BILLING_TIERS so the summary can never drift", () => {
+		expect(out).toContain(`$${BILLING_TIERS.starter.priceUsdMonthly}/mo`);
+		expect(out).toContain(`$${BILLING_TIERS.growth.priceUsdMonthly}/mo`);
+		expect(out).toContain(`$${BILLING_TIERS.scale.priceUsdMonthly}/mo`);
+	});
+
+	// The WordPress plugin ships in-repo but is pending wordpress.org review —
+	// once the directory listing is live, drop that assertion and add the
+	// plugin as a third install path instead.
+	it("never mentions unshipped integrations in the static copy", () => {
+		const staticOnly = buildLlmsTxt(BASE, {
+			posts: [],
+			competitors: [],
+			migrations: [],
+			tools: [],
+		}).toLowerCase();
+		expect(staticOnly).not.toContain("wordpress");
+		expect(staticOnly).not.toContain("shopify");
 	});
 
 	it("ends with a single trailing newline and emits no empty links", () => {

--- a/apps/marketing/src/lib/llms-txt.ts
+++ b/apps/marketing/src/lib/llms-txt.ts
@@ -1,7 +1,24 @@
 // Builds the /llms.txt body — the llmstxt.org convention: an H1, a one-line
-// blockquote summary, then sections of markdown links so an AI system can grab
-// a map of the product and its key pages. Pure (data in, string out) so it's
-// unit-tested without the content-collections build or Next.
+// blockquote summary, an un-headed details block, then sections of markdown
+// links so an AI system can grab a map of the product and its key pages. Pure
+// (data in, string out) so it's unit-tested without the content-collections
+// build or Next.
+//
+// This file is load-bearing twice: external answer engines read it, AND our
+// own support agent ingests it as a URL knowledge source. Two rules follow:
+// every claim must describe shipped, live behavior (never roadmap — no
+// unreleased integrations), and after deploying a change an operator must hit
+// "Recrawl" on the llms.txt source in the dashboard — URL sources are stored
+// snapshots, not live fetches, so the agent stays stale until re-synced.
+
+import { BILLING_TIERS } from "@llmchat/shared";
+
+import {
+	CANONICAL_SHOWCASE_URL,
+	GITHUB_URL,
+	RSC_NPM_URL,
+	RSC_PACKAGE,
+} from "./site-urls";
 
 export interface LlmsTxtInput {
 	posts: { slug: string; title: string; description: string }[];
@@ -10,8 +27,25 @@ export interface LlmsTxtInput {
 	tools: { slug: string; name: string; tagline: string }[];
 }
 
-const SUMMARY =
-	"An AI-powered support agent you embed with one script tag — it answers from your docs and sources, then escalates to your team. Open and self-hostable (bring your own keys); the hosted version has flat monthly plans from $19/mo with no per-seat fees.";
+// Prices come from the shared entitlement table so this file can never
+// advertise a number the product doesn't charge.
+const STARTER = BILLING_TIERS.starter.priceUsdMonthly;
+const GROWTH = BILLING_TIERS.growth.priceUsdMonthly;
+const SCALE = BILLING_TIERS.scale.priceUsdMonthly;
+const TWO_MONTHS_FREE = (
+	[BILLING_TIERS.starter, BILLING_TIERS.growth, BILLING_TIERS.scale] as const
+).every((t) => t.priceUsdAnnual === t.priceUsdMonthly * 10);
+
+const SUMMARY = `An AI-powered support agent for your site — install it with one script tag or one React Server Component (${RSC_PACKAGE} on npm). It answers from your docs and sources, then escalates to your team. Open source (MIT) and self-hostable (bring your own keys); the hosted version has flat monthly plans from $${STARTER}/mo with no per-seat fees.`;
+
+const DETAILS = [
+	"Two official ways to install:",
+	"",
+	"- Script tag: paste one `<script>` before `</body>` — the widget mounts in an isolated shadow DOM, inherits your brand color, and needs no build step.",
+	`- React / Next.js SDK: \`npm install ${RSC_PACKAGE}\` (React 19 — Next.js 15+ App Router or any RSC framework), then render one \`<ClankerSupport apiKey="pk_…" />\` Server Component in your root layout; no script tag. Restyle the default UI with its \`.clanker-*\` classes and \`--clanker-*\` CSS variables, or build a fully custom UI with the headless primitives and \`useClankerSupport()\` hook from \`${RSC_PACKAGE}/headless\` — which also ships a client-rendered \`ClankerSupportWidget\` for non-RSC React apps.`,
+	"",
+	"The agent answers from a per-project knowledge base (page URLs, text snippets, and Q&A pairs) with your own system prompt and per-project model choice. Visitors introduce themselves by name (email optional). When the agent can't help, it escalates: your team is notified by email and optionally Slack, the visitor sees a recap of the handoff right in the chat, and the agent stands down — fully silent once a human replies. Replies from the team inbox appear in the widget and go out by email when the visitor shared an address; email replies from the visitor thread back into the same conversation, and visitors can mark their conversation resolved. Quality is tracked with per-message thumbs up/down ratings plus a 1–5 CSAT score.",
+];
 
 export function buildLlmsTxt(siteUrl: string, input: LlmsTxtInput): string {
 	const lines: string[] = [
@@ -19,11 +53,16 @@ export function buildLlmsTxt(siteUrl: string, input: LlmsTxtInput): string {
 		"",
 		`> ${SUMMARY}`,
 		"",
+		...DETAILS,
+		"",
 		"## Product",
 		`- [Overview](${siteUrl}/): What Clanker Support is and how the drop-in agent works.`,
-		`- [Docs](${siteUrl}/docs): Quickstart, training on your docs, escalation, and migration.`,
+		`- [Docs](${siteUrl}/docs): Quickstart (script tag or React SDK), training on your docs, escalation, and migration.`,
+		`- [React / Next.js SDK](${RSC_NPM_URL}): ${RSC_PACKAGE} on npm — the widget as one Server Component in your root layout, with a headless entry for custom UIs.`,
+		`- [GitHub](${GITHUB_URL}): The open-source (MIT) codebase — self-host the full stack with your own keys.`,
+		`- [Live demo](${CANONICAL_SHOWCASE_URL}): The real widget running on a first-party demo page — try it before installing.`,
 		`- [Compare](${siteUrl}/compare): How Clanker Support compares to other AI support tools.`,
-		`- [Pricing](${siteUrl}/pricing.md): Self-host (free) and hosted plans — Starter, Growth, and Scale.`,
+		`- [Pricing](${siteUrl}/pricing.md): Machine-readable plans — self-host free; hosted Starter $${STARTER}/mo, Growth $${GROWTH}/mo, Scale $${SCALE}/mo${TWO_MONTHS_FREE ? " (annual = two months free)" : ""}.`,
 	];
 
 	if (input.tools.length) {
@@ -57,6 +96,14 @@ export function buildLlmsTxt(siteUrl: string, input: LlmsTxtInput): string {
 			lines.push(`- [${p.title}](${siteUrl}/blog/${p.slug}): ${p.description}`);
 		}
 	}
+
+	// "Optional" is the llmstxt.org name for skippable, lower-priority links.
+	lines.push(
+		"",
+		"## Optional",
+		`- [Privacy policy](${siteUrl}/privacy-policy): How visitor and customer data is handled.`,
+		`- [Terms of use](${siteUrl}/terms-of-use): The terms for the hosted service.`,
+	);
 
 	return `${lines.join("\n").trimEnd()}\n`;
 }

--- a/apps/marketing/src/lib/site-urls.ts
+++ b/apps/marketing/src/lib/site-urls.ts
@@ -25,5 +25,7 @@ export const SALES_EMAIL =
  * GitHub repo doubles as the source for the live star count in the navbar. */
 export const GITHUB_REPO = "theopenco/llmchat";
 export const GITHUB_URL = `https://github.com/${GITHUB_REPO}`;
+export const RSC_PACKAGE = "@clankersupport/widget-rsc";
+export const RSC_NPM_URL = `https://www.npmjs.com/package/${RSC_PACKAGE}`;
 export const DISCORD_URL = "https://discord.gg/RnyjHWuTKP";
 export const X_URL = "https://x.com/ClankrSupport";


### PR DESCRIPTION
## Why

A prospect asked the live widget "Is there a React SDK I can use?" and the agent answered **no**, citing the homepage and llms.txt. Reproduced on prod before this change — the agent literally quotes the homepage FAQ: *"no npm package or build step"*. But `@clankersupport/widget-rsc@1.0.1` is live on npm (published 2026-07-02).

llms.txt is load-bearing twice: it's a knowledge source for our own support agent AND the file external LLMs/crawlers read about us.

## What

**llms.txt generator (`src/lib/llms-txt.ts`)** — rewritten, verified-claims-only:
- Summary + new details block lead with **both install paths**: script tag and the RSC SDK (`npm install @clankersupport/widget-rsc`, one Server Component in the root layout, `.clanker-*` / `--clanker-*` theming, `/headless` primitives + `useClankerSupport()`, client-rendered `ClankerSupportWidget` for non-RSC React apps) — all quoted from the shipped README / verified against `packages/widget-rsc` src.
- New Product links: npm package page, GitHub repo, live demo; new `## Optional` section with privacy/terms.
- Shipped escalation semantics, phrased exactly to what the code does: visitor identity (name required, email optional), visitor-facing recap, email + optional Slack notify, bot fully silent after human takeover, email threading both ways (email delivery qualified on the visitor having shared an address), visitor resolve, thumbs + 1–5 CSAT.
- **Prices derived from `BILLING_TIERS`** ($19/$89/$299); "annual = two months free" is now computed from the table, so the file can never advertise numbers the product doesn't charge.

**False-claim fixes sitewide** (the agent ingests the homepage too — llms.txt alone wasn't enough):
- Homepage FAQ + JSON-LD, docs FAQ + quickstart, drop-in-widget feature page, Chatbase comparison/migration content, and the Product Hunt launch post (as a dated update note) no longer deny the npm package/SDK exists.
- SDK claims scoped to **React 19 / RSC frameworks** (avoids the React-18 peer-dep trap).
- `RSC_PACKAGE` / `RSC_NPM_URL` centralized in `site-urls.ts`; README's stale "seat-based" billing line corrected.

**Deliberately excluded** (LIVE-only rail): WordPress plugin (on main but pending wordpress.org review — verified unpublished), Shopify (not on main), any roadmap items.

## Verification

- Baseline probe on prod reproduced the wrong answer (conversation `llmstxt-verify-baseline-27a5f5b1` in the inbox).
- 7-agent evidence audit of main + 10-agent adversarial verify of every claim (3 must-fix findings applied) + workflow code review at high effort (6 findings applied).
- `pnpm test` 7/7 packages green (api 464, marketing 27 incl. new assertions), `pnpm lint` clean, marketing `next build` green; emitted `llms.txt.body` inspected.

## After merge (required — deploying is NOT enough)

URL sources are stored snapshots; there is no auto-recrawl. After deploy:
1. Dashboard → project → **Sources** → hit **Recrawl** on the `https://clankersupport.com/llms.txt` row **and** the homepage row.
2. Acceptance test: ask the live widget "Is there a React SDK I can use?" — it should describe `@clankersupport/widget-rsc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)