### PR TITLE
feat(dashboard): notification bell for new conversations, escalations…

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -11,6 +11,7 @@ import { chat } from "@/routes/chat";
 import { conversations } from "@/routes/conversations";
 import { embed } from "@/routes/embed";
 import { inboundEmail } from "@/routes/inbound-email";
+import { notifications } from "@/routes/notifications";
 import { oauthProviders } from "@/routes/oauth-providers";
 import { projects } from "@/routes/projects";
 import { search } from "@/routes/search";
@@ -112,6 +113,7 @@ app.route("/api", systemPrompts);
 app.route("/api", sources);
 app.route("/api", tags);
 app.route("/api", conversations);
+app.route("/api", notifications);
 app.route("/", admin);
 app.route("/", inboundEmail);
 // Billing mounts at root so the webhook is reachable at /billing/webhook

--- a/apps/api/src/lib/notifications.test.ts
+++ b/apps/api/src/lib/notifications.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+
+import { buildNotificationFeed, messagePreview } from "./notifications";
+
+const d = (iso: string) => new Date(iso);
+
+describe("messagePreview", () => {
+	it("collapses whitespace and trims", () => {
+		expect(messagePreview("  hello \n  world  ")).toBe("hello world");
+	});
+
+	it("truncates long bodies with an ellipsis", () => {
+		expect(messagePreview("x".repeat(200), 10)).toBe(`${"x".repeat(9)}…`);
+	});
+});
+
+describe("buildNotificationFeed", () => {
+	it("merges all three sources, newest first", () => {
+		const feed = buildNotificationFeed({
+			conversations: [
+				{
+					id: "c1",
+					projectId: "p1",
+					name: "Ann",
+					createdAt: d("2026-01-01T10:00:00Z"),
+				},
+			],
+			escalations: [
+				{
+					id: "c1",
+					projectId: "p1",
+					name: "Ann",
+					escalatedAt: d("2026-01-01T12:00:00Z"),
+				},
+			],
+			messages: [
+				{
+					id: "m1",
+					conversationId: "c1",
+					projectId: "p1",
+					name: "Ann",
+					content: "help me",
+					createdAt: d("2026-01-01T11:00:00Z"),
+				},
+			],
+			limit: 30,
+		});
+		expect(feed.map((n) => n.id)).toEqual([
+			"escalation:c1",
+			"message:m1",
+			"conversation:c1",
+		]);
+		expect(feed[1].preview).toBe("help me");
+	});
+
+	it("gives each source a stable, type-prefixed id", () => {
+		const feed = buildNotificationFeed({
+			conversations: [
+				{
+					id: "c1",
+					projectId: "p1",
+					name: null,
+					createdAt: d("2026-01-01T10:00:00Z"),
+				},
+			],
+			escalations: [],
+			messages: [],
+			limit: 30,
+		});
+		expect(feed[0].id).toBe("conversation:c1");
+		expect(feed[0].title).toBeNull();
+	});
+
+	it("caps the feed at the limit", () => {
+		const messages = Array.from({ length: 40 }, (_, i) => ({
+			id: `m${i}`,
+			conversationId: "c1",
+			projectId: "p1",
+			name: "Ann",
+			content: `msg ${i}`,
+			createdAt: d(`2026-01-01T10:${String(i).padStart(2, "0")}:00Z`),
+		}));
+		const feed = buildNotificationFeed({
+			conversations: [],
+			escalations: [],
+			messages,
+			limit: 30,
+		});
+		expect(feed).toHaveLength(30);
+		// Newest first: m39 leads.
+		expect(feed[0].id).toBe("message:m39");
+	});
+});

--- a/apps/api/src/lib/notifications.ts
+++ b/apps/api/src/lib/notifications.ts
@@ -1,0 +1,109 @@
+/**
+ * Notification feed — pure shaping/merge logic, split from the route so it can be
+ * unit-tested without a DB. The route runs three bounded, workspace-scoped queries
+ * (new conversations, escalations, new visitor messages) and hands the rows here to
+ * be normalized into one time-sorted, deduped, capped feed for the dashboard bell.
+ */
+
+export type NotificationType = "conversation" | "escalation" | "message";
+
+export interface NotificationItem {
+	/** Stable id (`<type>:<sourceId>`) so the client can dedupe across polls and
+	 * compute the unread count against a stored "last seen" timestamp. */
+	id: string;
+	type: NotificationType;
+	conversationId: string;
+	projectId: string;
+	/** Visitor name; null when anonymous (the client renders "Anonymous"). */
+	title: string | null;
+	/** Short human-readable line for the row. */
+	preview: string;
+	/** ISO timestamp of the underlying event. */
+	createdAt: string;
+}
+
+/** Row shapes as selected by the route (timestamps are Drizzle `Date`s). */
+export interface ConversationStartRow {
+	id: string;
+	projectId: string;
+	name: string | null;
+	createdAt: Date;
+}
+export interface EscalationRow {
+	id: string;
+	projectId: string;
+	name: string | null;
+	escalatedAt: Date;
+}
+export interface VisitorMessageRow {
+	id: string;
+	conversationId: string;
+	projectId: string;
+	name: string | null;
+	content: string;
+	createdAt: Date;
+}
+
+/** Clamp a message body to a single readable preview line. */
+export function messagePreview(content: string, max = 120): string {
+	const oneLine = content.replace(/\s+/g, " ").trim();
+	return oneLine.length > max ? `${oneLine.slice(0, max - 1)}…` : oneLine;
+}
+
+/**
+ * Merge the three event sources into one feed: newest first, capped at `limit`.
+ * Ids are stable per source row, so re-polling never produces duplicate entries
+ * even as the same conversation surfaces across multiple event types.
+ */
+export function buildNotificationFeed(inputs: {
+	conversations: ConversationStartRow[];
+	escalations: EscalationRow[];
+	messages: VisitorMessageRow[];
+	limit: number;
+}): NotificationItem[] {
+	const items: NotificationItem[] = [];
+
+	for (const c of inputs.conversations) {
+		items.push({
+			id: `conversation:${c.id}`,
+			type: "conversation",
+			conversationId: c.id,
+			projectId: c.projectId,
+			title: c.name,
+			preview: "Started a new conversation",
+			createdAt: c.createdAt.toISOString(),
+		});
+	}
+
+	for (const e of inputs.escalations) {
+		items.push({
+			id: `escalation:${e.id}`,
+			type: "escalation",
+			conversationId: e.id,
+			projectId: e.projectId,
+			title: e.name,
+			preview: "Asked to talk to a human",
+			createdAt: e.escalatedAt.toISOString(),
+		});
+	}
+
+	for (const m of inputs.messages) {
+		items.push({
+			id: `message:${m.id}`,
+			type: "message",
+			conversationId: m.conversationId,
+			projectId: m.projectId,
+			title: m.name,
+			preview: messagePreview(m.content),
+			createdAt: m.createdAt.toISOString(),
+		});
+	}
+
+	// Newest first; tie-break on id for a stable, deterministic order.
+	items.sort(
+		(a, b) =>
+			b.createdAt.localeCompare(a.createdAt) || b.id.localeCompare(a.id),
+	);
+
+	return items.slice(0, inputs.limit);
+}

--- a/apps/api/src/routes/notifications.ts
+++ b/apps/api/src/routes/notifications.ts
@@ -1,0 +1,138 @@
+import { Hono } from "hono";
+
+import { db } from "@/lib/db";
+import { buildNotificationFeed } from "@/lib/notifications";
+import { requireSession, requireWorkspace } from "@/middleware/session";
+
+import {
+	and,
+	conversation,
+	desc,
+	eq,
+	gte,
+	inArray,
+	isNotNull,
+	message as messageTable,
+	project as projectTable,
+	sql,
+} from "@llmchat/db";
+
+import type { AppContext } from "@/env";
+
+/** How far back the feed looks, and how many rows to keep. Bounds every scan so
+ * the endpoint stays O(window) regardless of total history. */
+const WINDOW_MS = 14 * 24 * 60 * 60 * 1000; // 14 days
+const FEED_LIMIT = 30;
+/** Per-source fetch cap before the merge — a little headroom over FEED_LIMIT so a
+ * burst of one event type can't starve the others out of the final feed. */
+const PER_SOURCE_LIMIT = 50;
+
+/**
+ * Workspace-wide notification feed for the dashboard bell: new conversation
+ * starts, escalations, and new visitor messages across every project the caller's
+ * workspace owns. Read-only; "unread" is tracked client-side against a stored
+ * last-seen timestamp (no per-user write path here — keeps it a pure read that can
+ * poll cheaply, like the inbox head query).
+ */
+export const notifications = new Hono<AppContext>()
+	.use("*", requireSession, requireWorkspace)
+	.get("/notifications", async (c) => {
+		const workspaceId = c.get("workspaceId");
+		const database = db(c.env);
+
+		// Scope to this workspace's projects. No projects ⇒ empty feed (skip the
+		// event scans entirely).
+		const projects = await database
+			.select({ id: projectTable.id })
+			.from(projectTable)
+			.where(eq(projectTable.workspaceId, workspaceId));
+		const projectIds = projects.map((p) => p.id);
+		if (projectIds.length === 0) {
+			return c.json({ notifications: [] });
+		}
+
+		const sinceUnix = Math.floor((Date.now() - WINDOW_MS) / 1000);
+
+		// Three bounded, project-scoped scans, merged in-app. Kept as separate
+		// queries (not one UNION) so each stays a plain indexed lookup and the
+		// shaping/merge is the unit-tested pure function in lib/notifications.
+		const [starts, escalations, messages] = await Promise.all([
+			database
+				.select({
+					id: conversation.id,
+					projectId: conversation.projectId,
+					name: conversation.name,
+					createdAt: conversation.createdAt,
+				})
+				.from(conversation)
+				.where(
+					and(
+						inArray(conversation.projectId, projectIds),
+						gte(conversation.createdAt, new Date(sinceUnix * 1000)),
+					),
+				)
+				.orderBy(desc(conversation.createdAt))
+				.limit(PER_SOURCE_LIMIT),
+
+			database
+				.select({
+					id: conversation.id,
+					projectId: conversation.projectId,
+					name: conversation.name,
+					escalatedAt: conversation.escalatedAt,
+				})
+				.from(conversation)
+				.where(
+					and(
+						inArray(conversation.projectId, projectIds),
+						isNotNull(conversation.escalatedAt),
+						gte(conversation.escalatedAt, new Date(sinceUnix * 1000)),
+					),
+				)
+				.orderBy(desc(conversation.escalatedAt))
+				.limit(PER_SOURCE_LIMIT),
+
+			// New visitor messages: role='user' and sequence > 1 so the opening
+			// message (already surfaced as a "new conversation" event) isn't counted
+			// twice. Joined to conversation for the project scope + visitor name.
+			database
+				.select({
+					id: messageTable.id,
+					conversationId: messageTable.conversationId,
+					projectId: conversation.projectId,
+					name: conversation.name,
+					content: messageTable.content,
+					createdAt: messageTable.createdAt,
+				})
+				.from(messageTable)
+				.innerJoin(
+					conversation,
+					eq(messageTable.conversationId, conversation.id),
+				)
+				.where(
+					and(
+						inArray(conversation.projectId, projectIds),
+						eq(messageTable.role, "user"),
+						sql`${messageTable.sequence} > 1`,
+						gte(messageTable.createdAt, new Date(sinceUnix * 1000)),
+					),
+				)
+				.orderBy(desc(messageTable.createdAt))
+				.limit(PER_SOURCE_LIMIT),
+		]);
+
+		const feed = buildNotificationFeed({
+			conversations: starts,
+			escalations: escalations.map((e) => ({
+				id: e.id,
+				projectId: e.projectId,
+				name: e.name,
+				// escalatedAt is non-null here (isNotNull predicate above).
+				escalatedAt: e.escalatedAt as Date,
+			})),
+			messages,
+			limit: FEED_LIMIT,
+		});
+
+		return c.json({ notifications: feed });
+	});

--- a/apps/dashboard/src/components/shell/notification-bell.tsx
+++ b/apps/dashboard/src/components/shell/notification-bell.tsx
@@ -1,0 +1,187 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { Bell, LifeBuoy, MessageSquare, MessageSquarePlus } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useEffect, useMemo, useState } from "react";
+
+import { Button } from "@/components/ds";
+import {
+	Popover,
+	PopoverContent,
+	PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+	countUnread,
+	fetchNotifications,
+	getLastSeen,
+	newestTimestamp,
+	NOTIFICATIONS_KEY,
+	setLastSeen,
+	type NotificationItem,
+} from "@/lib/notifications";
+import { cn } from "@/lib/utils";
+import { useWorkspace } from "@/lib/workspace";
+
+const TYPE_META: Record<
+	NotificationItem["type"],
+	{ Icon: typeof Bell; label: string; className: string }
+> = {
+	conversation: {
+		Icon: MessageSquarePlus,
+		label: "New conversation",
+		className: "text-ck-accent",
+	},
+	escalation: {
+		Icon: LifeBuoy,
+		label: "Escalated",
+		className: "text-ck-warn",
+	},
+	message: {
+		Icon: MessageSquare,
+		label: "New message",
+		className: "text-ck-muted",
+	},
+};
+
+/** Compact relative time for feed rows ("just now", "5m", "3h", "2d"). */
+function relativeTime(iso: string): string {
+	const diff = Date.now() - new Date(iso).getTime();
+	const s = Math.max(0, Math.floor(diff / 1000));
+	if (s < 60) return "just now";
+	const m = Math.floor(s / 60);
+	if (m < 60) return `${m}m`;
+	const h = Math.floor(m / 60);
+	if (h < 24) return `${h}h`;
+	return `${Math.floor(h / 24)}d`;
+}
+
+/**
+ * Top-bar notification bell: workspace-wide feed of new conversations,
+ * escalations, and new visitor messages. Polls `/api/notifications` on a slow
+ * cadence (notifications are less latency-critical than the inbox itself); the
+ * unread badge is derived against a per-workspace "last seen" watermark in
+ * localStorage, so opening the panel clears the count without any server write.
+ */
+export function NotificationBell() {
+	const { workspaceId } = useWorkspace();
+	const router = useRouter();
+	const [open, setOpen] = useState(false);
+	// The watermark lives in state (seeded from storage) so clearing it on open
+	// re-renders the badge immediately.
+	const [lastSeen, setLastSeenState] = useState<string>(() =>
+		new Date(0).toISOString(),
+	);
+
+	// Re-seed from storage whenever the active workspace changes.
+	useEffect(() => {
+		if (workspaceId) setLastSeenState(getLastSeen(workspaceId));
+	}, [workspaceId]);
+
+	const query = useQuery({
+		queryKey: workspaceId ? NOTIFICATIONS_KEY(workspaceId) : ["notifications"],
+		enabled: !!workspaceId,
+		refetchInterval: 20_000,
+		queryFn: () => fetchNotifications(workspaceId!),
+	});
+
+	const items = useMemo(() => query.data?.notifications ?? [], [query.data]);
+	const unread = countUnread(items, lastSeen);
+
+	function markSeen() {
+		if (!workspaceId) return;
+		// Watermark at the newest event we've actually loaded (or now, if empty) so
+		// items arriving after this open still count as unread next poll.
+		const watermark = newestTimestamp(items) ?? new Date().toISOString();
+		setLastSeen(workspaceId, watermark);
+		setLastSeenState(watermark);
+	}
+
+	function handleOpenChange(next: boolean) {
+		setOpen(next);
+		if (next) markSeen();
+	}
+
+	function handleSelect(n: NotificationItem) {
+		setOpen(false);
+		router.push(`/inbox?project=${n.projectId}&c=${n.conversationId}`);
+	}
+
+	const badge = unread > 9 ? "9+" : String(unread);
+
+	return (
+		<Popover open={open} onOpenChange={handleOpenChange}>
+			<PopoverTrigger asChild>
+				<Button
+					variant="outline"
+					size="icon"
+					className="relative"
+					aria-label={
+						unread > 0 ? `Notifications (${unread} unread)` : "Notifications"
+					}
+				>
+					<Bell className="size-4" />
+					{unread > 0 && (
+						<span className="absolute -right-1 -top-1 flex min-w-4 items-center justify-center rounded-full bg-ck-accent px-1 text-[10px] font-bold leading-4 text-white">
+							{badge}
+						</span>
+					)}
+				</Button>
+			</PopoverTrigger>
+			<PopoverContent
+				align="end"
+				className="w-80 border-ck-border bg-ck-card p-0 text-ck-text"
+			>
+				<div className="flex items-center justify-between border-b border-ck-border px-3 py-2">
+					<span className="text-sm font-semibold">Notifications</span>
+					{unread > 0 && (
+						<span className="text-[11px] text-ck-faint">{unread} new</span>
+					)}
+				</div>
+				<div className="max-h-96 overflow-y-auto">
+					{items.length === 0 ? (
+						<p className="px-3 py-8 text-center text-xs text-ck-faint">
+							{query.isLoading ? "Loading…" : "You're all caught up"}
+						</p>
+					) : (
+						<ul className="divide-y divide-ck-border">
+							{items.map((n) => {
+								const meta = TYPE_META[n.type];
+								const unseen = n.createdAt > lastSeen;
+								return (
+									<li key={n.id}>
+										<button
+											type="button"
+											onClick={() => handleSelect(n)}
+											className="flex w-full items-start gap-2.5 px-3 py-2.5 text-left transition-colors hover:bg-ck-navhover"
+										>
+											<meta.Icon
+												className={cn("mt-0.5 size-4 shrink-0", meta.className)}
+											/>
+											<span className="min-w-0 flex-1">
+												<span className="flex items-center gap-1.5">
+													<span className="truncate text-[13px] font-semibold text-ck-text">
+														{n.title ?? "Anonymous"}
+													</span>
+													{unseen && (
+														<span className="size-1.5 shrink-0 rounded-full bg-ck-accent" />
+													)}
+												</span>
+												<span className="block truncate text-xs text-ck-muted">
+													{n.preview}
+												</span>
+												<span className="mt-0.5 block text-[11px] text-ck-faint">
+													{meta.label} · {relativeTime(n.createdAt)}
+												</span>
+											</span>
+										</button>
+									</li>
+								);
+							})}
+						</ul>
+					)}
+				</div>
+			</PopoverContent>
+		</Popover>
+	);
+}

--- a/apps/dashboard/src/components/shell/top-bar.test.tsx
+++ b/apps/dashboard/src/components/shell/top-bar.test.tsx
@@ -18,6 +18,9 @@ vi.mock("@/components/shell/project-switcher", () => ({
 vi.mock("@/components/shell/account-menu", () => ({
 	AccountMenu: () => <div data-testid="acct" />,
 }));
+vi.mock("@/components/shell/notification-bell", () => ({
+	NotificationBell: () => <div data-testid="bell" />,
+}));
 
 describe("TopBar — centered search trigger", () => {
 	it("renders the wide centered search box with the ⌘K hint and the design placeholder", () => {

--- a/apps/dashboard/src/components/shell/top-bar.tsx
+++ b/apps/dashboard/src/components/shell/top-bar.tsx
@@ -10,6 +10,7 @@ import {
 import { BrandLogo } from "@/components/brand-logo";
 import { Button } from "@/components/ds";
 import { AccountMenu } from "@/components/shell/account-menu";
+import { NotificationBell } from "@/components/shell/notification-bell";
 import { ProjectSwitcher } from "@/components/shell/project-switcher";
 import { WorkspaceSwitcher } from "@/components/shell/workspace-switcher";
 
@@ -80,6 +81,8 @@ export function TopBar({
 			>
 				<Search className="size-5" />
 			</Button>
+
+			<NotificationBell />
 
 			<Button
 				variant="outline"

--- a/apps/dashboard/src/lib/notifications.test.ts
+++ b/apps/dashboard/src/lib/notifications.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+	countUnread,
+	getLastSeen,
+	newestTimestamp,
+	setLastSeen,
+	type NotificationItem,
+} from "./notifications";
+
+const item = (id: string, createdAt: string): NotificationItem => ({
+	id,
+	type: "message",
+	conversationId: "c1",
+	projectId: "p1",
+	title: "Ann",
+	preview: "hi",
+	createdAt,
+});
+
+describe("countUnread", () => {
+	it("counts only items strictly newer than the watermark", () => {
+		const items = [
+			item("a", "2026-01-01T10:00:00.000Z"),
+			item("b", "2026-01-01T12:00:00.000Z"),
+			item("c", "2026-01-01T14:00:00.000Z"),
+		];
+		expect(countUnread(items, "2026-01-01T11:00:00.000Z")).toBe(2);
+		expect(countUnread(items, "2026-01-01T14:00:00.000Z")).toBe(0);
+		expect(countUnread(items, new Date(0).toISOString())).toBe(3);
+	});
+});
+
+describe("newestTimestamp", () => {
+	it("returns the max createdAt", () => {
+		expect(
+			newestTimestamp([
+				item("a", "2026-01-01T10:00:00.000Z"),
+				item("b", "2026-01-01T14:00:00.000Z"),
+				item("c", "2026-01-01T12:00:00.000Z"),
+			]),
+		).toBe("2026-01-01T14:00:00.000Z");
+	});
+
+	it("returns null for an empty feed", () => {
+		expect(newestTimestamp([])).toBeNull();
+	});
+});
+
+describe("last-seen storage", () => {
+	beforeEach(() => window.localStorage.clear());
+
+	it("defaults to epoch when unset", () => {
+		expect(getLastSeen("ws1")).toBe(new Date(0).toISOString());
+	});
+
+	it("round-trips per workspace", () => {
+		setLastSeen("ws1", "2026-01-01T10:00:00.000Z");
+		expect(getLastSeen("ws1")).toBe("2026-01-01T10:00:00.000Z");
+		// A different workspace keeps its own watermark.
+		expect(getLastSeen("ws2")).toBe(new Date(0).toISOString());
+	});
+});

--- a/apps/dashboard/src/lib/notifications.ts
+++ b/apps/dashboard/src/lib/notifications.ts
@@ -1,0 +1,71 @@
+import { api } from "./api";
+
+/** One feed entry from `GET /api/notifications` (mirrors the api's
+ * NotificationItem). `title` is the visitor name, null when anonymous. */
+export interface NotificationItem {
+	id: string;
+	type: "conversation" | "escalation" | "message";
+	conversationId: string;
+	projectId: string;
+	title: string | null;
+	preview: string;
+	createdAt: string;
+}
+
+export interface NotificationsResponse {
+	notifications: NotificationItem[];
+}
+
+export const NOTIFICATIONS_KEY = (workspaceId: string) =>
+	["notifications", workspaceId] as const;
+
+export function fetchNotifications(workspaceId: string) {
+	return api<NotificationsResponse>("/api/notifications", { workspaceId });
+}
+
+/** localStorage key for the per-workspace "last seen" watermark. Scoped by
+ * workspace so switching workspaces reads the right badge count. */
+function lastSeenKey(workspaceId: string) {
+	return `ck:notifications:lastSeen:${workspaceId}`;
+}
+
+/** Read the stored watermark (ISO string). Missing / SSR ⇒ epoch, so a
+ * first-time user sees everything in the window as unread. */
+export function getLastSeen(workspaceId: string): string {
+	if (typeof window === "undefined") return new Date(0).toISOString();
+	try {
+		return (
+			window.localStorage.getItem(lastSeenKey(workspaceId)) ??
+			new Date(0).toISOString()
+		);
+	} catch {
+		return new Date(0).toISOString();
+	}
+}
+
+export function setLastSeen(workspaceId: string, iso: string): void {
+	if (typeof window === "undefined") return;
+	try {
+		window.localStorage.setItem(lastSeenKey(workspaceId), iso);
+	} catch {
+		/* storage blocked (private mode) — badge just won't persist. */
+	}
+}
+
+/** How many feed items are newer than the watermark. Pure so it's unit-tested. */
+export function countUnread(
+	items: NotificationItem[],
+	lastSeenIso: string,
+): number {
+	return items.filter((n) => n.createdAt > lastSeenIso).length;
+}
+
+/** The newest event time in the feed, or null when empty — used as the new
+ * watermark when the panel is opened. */
+export function newestTimestamp(items: NotificationItem[]): string | null {
+	let newest: string | null = null;
+	for (const n of items) {
+		if (newest === null || n.createdAt > newest) newest = n.createdAt;
+	}
+	return newest;
+}


### PR DESCRIPTION
… & messages

- Add workspace-wide GET /api/notifications feed (new conversation starts, escalations, and new visitor messages across all workspace projects), bounded to a 14-day window and capped at 30 items over three project-scoped scans.
- Split the feed shaping/merge into a pure, unit-tested lib/notifications helper.
- Add a top-bar NotificationBell: polls every 20s, unread badge derived against a per-workspace localStorage watermark (no server write), popover feed rows that deep-link into the inbox thread.
- Stub NotificationBell in the TopBar test.