### PR TITLE
fix(dashboard): notification clicks open the linked thread when alrea…

### DIFF
--- a/apps/dashboard/src/app/inbox/page.test.tsx
+++ b/apps/dashboard/src/app/inbox/page.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen, waitFor, within } from "@testing-library/react";
+import { act, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -17,9 +17,31 @@ beforeAll(() => {
 // Stable router.replace spy (hoisted with the mock) so the onboarding-redirect
 // guard can be asserted at the real incident call site.
 const routerReplace = vi.hoisted(() => vi.fn());
-vi.mock("next/navigation", () => ({
-	useRouter: () => ({ replace: routerReplace, push: vi.fn() }),
-}));
+// router.push + useSearchParams mirror the real App Router contract the page
+// relies on: a push to the same route only changes the query string, and
+// useSearchParams re-renders subscribers with the new params (no remount).
+const navListeners = vi.hoisted(() => new Set<() => void>());
+const navigate = vi.hoisted(() => (url: string) => {
+	window.history.pushState(null, "", url);
+	for (const l of navListeners) l();
+});
+vi.mock("next/navigation", async () => {
+	const { useSyncExternalStore } = await import("react");
+	return {
+		useRouter: () => ({ replace: routerReplace, push: navigate }),
+		useSearchParams: () => {
+			const search = useSyncExternalStore(
+				(cb: () => void) => {
+					navListeners.add(cb);
+					return () => navListeners.delete(cb);
+				},
+				() => window.location.search,
+				() => "",
+			);
+			return new URLSearchParams(search);
+		},
+	};
+});
 
 // Admin in a workspace with a project, so the inbox renders (not onboarding) and
 // the "Manage tags" affordance is available.
@@ -264,6 +286,29 @@ describe("InboxPage — ⌘K deep link", () => {
 			).toBe(true),
 		);
 		// The open conversation's name shows in the thread header.
+		expect(await screen.findAllByText("Bob")).not.toHaveLength(0);
+	});
+
+	it("a later ?project=&c= push (notification bell click) opens that thread without a remount", async () => {
+		renderInbox();
+		await screen.findByRole("heading", { name: "Inbox" });
+		await waitFor(() => expect(listCalls().length).toBeGreaterThan(0));
+
+		// Simulate the bell's router.push while the inbox is already mounted: a
+		// same-route navigation that only changes the query string.
+		act(() => navigate("/inbox?project=p1&c=c1"));
+
+		// The changed params select c1 → its windowed thread is fetched and the
+		// visitor name shows in the thread header.
+		await waitFor(() =>
+			expect(
+				calls.some(
+					(c) =>
+						c.method === "GET" &&
+						/^\/api\/projects\/p1\/conversations\/c1(\?|$)/.test(c.path),
+				),
+			).toBe(true),
+		);
 		expect(await screen.findAllByText("Bob")).not.toHaveLength(0);
 	});
 

--- a/apps/dashboard/src/app/inbox/page.tsx
+++ b/apps/dashboard/src/app/inbox/page.tsx
@@ -6,8 +6,8 @@ import {
 	useQuery,
 	useQueryClient,
 } from "@tanstack/react-query";
-import { useRouter } from "next/navigation";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { Suspense, useCallback, useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 
 import { ApiError, api, describeApiError } from "@/lib/api";
@@ -60,7 +60,17 @@ import type { ProjectOption } from "./_components/ProjectSwitcher";
 
 const PAGE_SIZE = 30;
 
+// useSearchParams requires a Suspense boundary (same pattern as the billing
+// and onboarding pages); the inbox skeleton doubles as the fallback.
 export default function InboxPage() {
+	return (
+		<Suspense fallback={<InboxSkeleton />}>
+			<InboxPageInner />
+		</Suspense>
+	);
+}
+
+function InboxPageInner() {
 	const {
 		workspaces,
 		workspaceId,
@@ -69,6 +79,7 @@ export default function InboxPage() {
 	} = useWorkspace();
 	const qc = useQueryClient();
 	const router = useRouter();
+	const searchParams = useSearchParams();
 	const [projectId, setProjectId] = useState<string | null>(null);
 	const [selectedId, setSelectedId] = useState<string | null>(null);
 	const [reply, setReply] = useState("");
@@ -78,26 +89,6 @@ export default function InboxPage() {
 	const [manageTagsOpen, setManageTagsOpen] = useState(false);
 	// Contact-details sheet (mobile/tablet); on desktop details are a permanent aside.
 	const [detailsOpen, setDetailsOpen] = useState(false);
-
-	// One-time ?project=&c= deep link (from the ⌘K palette or a shared thread
-	// URL). Read once on mount; applied after projects load (below) so the
-	// project-resolver effect can't clobber it. The thread endpoint re-validates
-	// tenancy server-side, so a forged/foreign id just yields an empty thread —
-	// never a cross-tenant leak.
-	const deepLinkRef = useRef<{
-		project: string | null;
-		conversation: string | null;
-	}>(undefined as never);
-	if (deepLinkRef.current === undefined) {
-		deepLinkRef.current =
-			typeof window === "undefined"
-				? { project: null, conversation: null }
-				: {
-						project: new URLSearchParams(window.location.search).get("project"),
-						conversation: new URLSearchParams(window.location.search).get("c"),
-					};
-	}
-	const deepLinkConsumed = useRef(false);
 
 	const projects = useQuery({
 		queryKey: ["projects", workspaceId],
@@ -122,25 +113,36 @@ export default function InboxPage() {
 	useEffect(() => {
 		const available = projects.data?.projects ?? [];
 		if (available.length === 0) return;
-
-		// One-time: honor the ?project=&c= deep link before the normal resolver, if
-		// the project is one the caller can actually see in this workspace.
-		if (!deepLinkConsumed.current) {
-			deepLinkConsumed.current = true;
-			const dl = deepLinkRef.current!;
-			if (dl.project && available.some((p) => p.id === dl.project)) {
-				setProjectId(dl.project);
-				if (dl.conversation) setSelectedId(dl.conversation);
-				return;
-			}
-		}
-
 		const next = resolveSelectedId(projectId, available);
 		if (next !== projectId) {
 			setProjectId(next);
 			setSelectedId(null);
 		}
 	}, [projects.data, projectId]);
+
+	// ?project=&c= deep links (⌘K palette, notification bell, shared thread
+	// URLs). Applied whenever the search params change — not just on mount,
+	// because clicking a notification while already on /inbox is a same-route
+	// navigation that only changes the query string (the page never remounts).
+	// Declared AFTER the resolver above so on first load its selection wins the
+	// batch. The mirror effect below echoes the selection back into the URL;
+	// re-applying that echo sets the same values, so the two never fight. The
+	// thread endpoint re-validates tenancy server-side, so a forged/foreign id
+	// just yields an empty thread — never a cross-tenant leak.
+	const deepLinkSearch = searchParams.toString();
+	useEffect(() => {
+		const available = projects.data?.projects ?? [];
+		if (available.length === 0) return;
+		const params = new URLSearchParams(deepLinkSearch);
+		const project = params.get("project");
+		const conversationId = params.get("c");
+		// Only honor complete links to a project the caller can actually see in
+		// this workspace.
+		if (!project || !conversationId) return;
+		if (!available.some((p) => p.id === project)) return;
+		setProjectId(project);
+		setSelectedId(conversationId);
+	}, [deepLinkSearch, projects.data]);
 
 	// Mirror the open conversation into the URL (?project=&c=) so a thread is
 	// shareable and the ⌘K deep link round-trips. history.replaceState — not the


### PR DESCRIPTION
…dy on /inbox

- The inbox consumed the ?project=&c= deep link once at mount from window.location, so a bell/⌘K push while on /inbox (same-route navigation, no remount) never applied — and the URL mirror rewrote the params back to the old selection.
- Replace the one-shot read with useSearchParams + a sync effect keyed on the params string, applying project/conversation on every change; re-applying the mirror's echo is a no-op, so the two never fight.
- Wrap the page in Suspense (useSearchParams requirement — same pattern as billing/onboarding), skeleton as fallback.
- Test mock now models the App Router contract (push updates params and re-renders subscribers without remounting); add a regression test for the same-route notification navigation.