### PR TITLE
[SCOUT — do not merge] Ploy preview bisect: c-no-nested-ws

### DIFF
--- a/apps/shopify/pnpm-workspace.yaml
+++ b/apps/shopify/pnpm-workspace.yaml
@@ -1,6 +1,0 @@
-# apps/shopify is a standalone pnpm workspace, deliberately outside the
-# monorepo's (see the root pnpm-workspace.yaml). Run pnpm from this directory.
-# Build-script approvals live in package.json ("pnpm.onlyBuiltDependencies") —
-# pnpm 10.0 does not read them from this file.
-packages:
-  - "."


### PR DESCRIPTION
Preview-pipeline bisect for the 5/5 Ploy preview failure (prod deploys are green on main). This branch isolates one component of apps/shopify. Will be closed and deleted after the Ploy check reports. 🤖 Generated with [Claude Code](https://claude.com/claude-code)