### PR TITLE
docs(dashboard): commit the canonical restyle plan + feature inventory

### DIFF
--- a/docs/dashboard-inventory.md
+++ b/docs/dashboard-inventory.md
@@ -1,0 +1,237 @@
+# Dashboard product inventory — what actually exists today
+
+Read-only audit (2026-06-21). Scope: `packages/db`, `apps/api`, `apps/dashboard`,
+`packages/widget`. Everything below is what the code **literally does today** —
+stubs, placeholders, and unwired columns are called out explicitly.
+
+---
+
+## 1. Data model (Drizzle — `packages/db/src/schema.ts`)
+
+### Better Auth tables
+- **`user`** — `id, name, email (unique), emailVerified, image, createdAt, updatedAt`.
+- **`session`** — `id, userId, token (unique), expiresAt, ipAddress, userAgent, …`.
+- **`account`** — OAuth/password credentials (`providerId, accessToken, refreshToken, idToken, password, …`).
+- **`verification`** — email-verification tokens.
+- **`passkey`** — present in schema but the Better Auth passkey plugin is **removed at runtime** (workerd-bundle constraint). Dead table; no code writes it.
+
+### `workspace` (billing entity)
+- `id, name, ownerId, stripeCustomerId, stripeSubscriptionId, createdAt`.
+- **`plan`** enum: `none | starter | growth | scale`, default **`none`**. There is **no `free`/`pro`** anymore (legacy values resolve to `none`/blocked). This is the only billing-tier field.
+
+### `member` (RBAC)
+- `id, workspaceId, userId, role, createdAt`. **`role`** enum: `owner | admin | agent` (default `agent`). Unique on `(workspaceId, userId)`.
+
+### `project` (the embed unit)
+Config columns that exist:
+- `name`, `publicKey` (unique, widget bootstrap), `inboundEmailLocal` (unique, reply email).
+- `systemPrompt` (text, default ""), `activeSystemPromptId` (points into `system_prompt`).
+- `knowledgeText` (text, default "") — plain-text KB.
+- `model` (default `gpt-5.4-mini`), `brandColor` (default **`#000000`**), `welcomeMessage` (default "Hi! How can I help you today?").
+- `escalationThreshold` (int, default 3), `notifyEmail`, `slackWebhookUrl`.
+- `favorite` (bool), `pinned` (bool).
+- **No status column** (no live/paused/draft). **No per-project counters** (no stored message/conversation count on the project; totals are aggregated on demand — see §2 stats).
+
+### `conversation`
+- `id, projectId, clientId, name, email, ipAddress, userAgent, messageCount, createdAt, updatedAt`.
+- **`escalatedAt`** (timestamp, null = not escalated) — this is the only "AI-handled vs human-requested" signal.
+- **`archivedAt`** (timestamp, null = active) — the **only** closed/resolved state.
+- **`csatRating`** (int 1–5, null = unrated) — end-of-conversation CSAT.
+- **No `status` enum** (no open/pending/closed/resolved — "resolved" in the UI just means `archivedAt is not null`). **No `assignee`/owner field** — conversations are not assigned to a human agent. **No AI-vs-human handling flag** beyond `escalatedAt`.
+
+### `system_prompt`
+- `id, projectId, name, content, favorite, createdAt, updatedAt`. Multiple saved prompts per project; one is "active" via `project.activeSystemPromptId`.
+
+### `source`
+- `id, projectId, url, title, content, active (bool, default true), lastFetchedAt, lastError, createdAt, updatedAt`.
+- **URL-only.** No type column — there is no file/PDF/Q&A-pair/text-snippet source kind. `content` is the fetched page text stored inline.
+- Sync state is just `lastFetchedAt` + `lastError` (success/error). **No "crawling/in-progress" status, no page-count, no chunk/embedding tracking.**
+
+### `message`
+- `id, conversationId, role, content, sequence, createdAt`.
+- **`role`** enum: `user | assistant | admin | system` (admin = human reply, system = e.g. escalation marker).
+- **`rating`** enum `up | down` (null = unrated) — per-message thumbs, assistant messages only.
+- `authorUserId` (admin author), `emailMessageId` (email threading).
+
+### `read_status`
+- Per-viewer unread tracking: `(conversationId, userId, lastReadMessageCount, readAt)`, unique per pair.
+
+### `usage_event` (metering source of truth)
+- `workspaceId, projectId, conversationId, messageId, model, promptTokens, completionTokens, costUsd, createdAt`. One row per assistant reply. **`costUsd` is always written as `0` today** (token counts are real; cost is not computed).
+
+**Ratings — two distinct systems, both real:** per-message thumbs (`message.rating`) and per-conversation CSAT stars (`conversation.csatRating`). They are kept separate.
+
+---
+
+## 2. API routes (`apps/api/src/routes/`, mounted in `index.ts`)
+
+### Public widget (`/v1/*`, CORS `*`, unauthenticated, rate-limited by public key + IP)
+- **`POST /v1/chat`** — streams the assistant reply (UI message stream). Body: `projectKey, clientId, name?, email?, messages[]`. Enforces paywall + monthly-quota + model-access, persists user+assistant messages, writes a `usage_event`.
+- **`POST /v1/escalate`** — flips `conversation.escalatedAt`, writes a `system` message, emails `notifyEmail` + posts Slack (both best-effort). Body adds a transcript.
+- **`GET /v1/messages`** — poll feed for the widget (`projectKey, clientId` query). Returns `conversationId, csatRating, messages[]`.
+- **`POST /v1/rating`** — set/clear a message thumbs rating.
+- **`POST /v1/csat`** — set conversation CSAT (1–5).
+- **`GET /v1/config/:key`** — server-authoritative branding flag (`showBranding`) so the "Powered by" badge can't be stripped client-side.
+
+### Dashboard API (`/api/*`, CORS pinned to dashboard origin, session + workspace required)
+- **Conversations** (`/api/projects/:projectId/conversations`):
+  - **`GET` list** — filters: `search` (matches visitor name/email/**message body**, project-scoped + bounded), `archived` (`true|false`, default active), keyset pagination (`cursor`, `limit` ≤100 default 30, ordered `updatedAt DESC, id DESC`). Each row carries `firstMessage` preview, `unread` flag, and a search `match` snippet. **The only sort is `updatedAt DESC`** — no other sort options server-side.
+  - **`GET …/stats`** — true project-wide aggregate: `total, escalated, resolved (=archived), avgRating`. Independent of search/archive filter.
+  - **`GET …/:id`** — paginated message thread (keyset on `sequence`: latest page, `before` = older page, `after` = newest-only poll; `search` returns `firstHitSequence` for scroll-to-hit). Returns `conversation, messages, hasOlder, firstHitSequence`.
+  - **`POST …/:id/reply`** — human (admin) reply; emails the visitor if `email` is set.
+  - **`PATCH …/:id`** — `archived?` and/or `read?` only.
+  - **`DELETE …/:id`** — admin+ only.
+- **Projects** (`/api/projects`): `GET` list, `POST` create (admin+, paywall + project-cap + model gate), `PATCH :id` (admin+, partial — only provided fields written), `DELETE :id` (admin+).
+- **Sources** (`/api/projects/:projectId/sources`): `GET`, `POST` (admin+, fetches URL on add), `PATCH :id` (re-fetch if URL changes), `POST :id/refresh` (re-crawl), `DELETE :id`.
+- **System prompts** (`/api/projects/:projectId/system-prompts`): `GET`, `POST` (first auto-activates), `PATCH :id`, `POST :id/activate`, `DELETE :id` (falls back to another active).
+- **Workspaces** (`/api/workspaces`): `GET` (memberships + role), `POST` (provision a new workspace).
+- **OAuth providers** (`/api/oauth-providers`): reports which social providers are configured (Google/GitHub) so the sign-in UI can show buttons.
+
+### Billing (mounted at root)
+- **`POST /billing/checkout`** (owner-only) — Stripe Checkout for `starter|growth|scale`. Returns `{id, url}`. 503 `billing_not_configured` if Stripe keys/prices unset.
+- **`POST /billing/portal`** (owner-only) — Stripe Billing Portal.
+- **`GET /billing/usage`** — current `plan, exempt, entitlements, usage {projects, members, responsesThisMonth}, availablePlans, monthStartUnix`. Real numbers only.
+- **`POST /billing/webhook`** — Stripe webhook (signature-verified); maps `checkout.session.completed` / `subscription.updated` / `subscription.deleted` to `workspace.plan`.
+
+### Auth & misc
+- **`/api/auth/*`** — Better Auth (email+password; OAuth Google/GitHub when configured).
+- **`/embed/:key`** — full-page iframe embed HTML shell (locked-down CSP, `frame-ancestors *`).
+- **`/widget.js`** — the widget bundle (`cache-control: max-age=300`).
+- **inbound-email** — Resend webhook for email replies → matched back to a conversation via `emailMessageId`.
+
+---
+
+## 3. Widget visitor/session capture (what's actually collected per conversation)
+
+The widget is deliberately minimal. It collects **four** things; IP and user-agent
+are derived **server-side** from request headers, not sent by the widget.
+
+| Field | Captured? | Source | Stored on `conversation` |
+|---|---|---|---|
+| `clientId` (anon id) | ✅ | `crypto.randomUUID()`, persisted in **`sessionStorage`** (per-tab) | `clientId` |
+| Visitor **name** | ✅ | IdentifyForm (user types it) | `name` |
+| Visitor **email** | ✅ (optional) | IdentifyForm | `email` |
+| **IP address** | ✅ server-derived | request header (`cf-connecting-ip`/`x-forwarded-for`) | `ipAddress` |
+| **User-agent** | ✅ server-derived | `user-agent` header | `userAgent` |
+| First-seen | ✅ implicit | row creation | `createdAt` |
+| Current page **URL** | ❌ | not read | — |
+| Page **title** | ❌ | — | — |
+| **Referrer** | ❌ | — | — |
+| Device/OS/browser (structured) | ❌ | only raw UA stored; dashboard parses UA for display | — |
+| Screen/viewport size | ❌ | — | — |
+| **Geo / country** | ❌ | — | — |
+| Locale / timezone | ❌ | — | — |
+| Pages-viewed history | ❌ | — | — |
+
+**Implication for a contact/session panel:** the only real visitor fields are
+**name, email, IP, raw user-agent (→ "Chrome on macOS" parsed client-side),
+started-at, message count, escalated-at, CSAT**. There is **no page URL,
+referrer, geo, device-type, or browsing history** to render — none of it is
+collected. `clientId` is per-tab (sessionStorage), so it is **not** a stable
+cross-visit identity.
+
+---
+
+## 4. Dashboard surfaces (`apps/dashboard/src/app`)
+
+Sidebar nav (`components/app-sidebar.tsx`) exposes exactly three top-level items:
+**Conversations** (`/inbox`), **Projects** (`/settings/projects`), **Billing**
+(`/settings/billing`), plus a user/workspace menu, theme toggle, and a "Need
+help?" docs link. When inside a project, a contextual "Current project" switcher
++ "Setup" step list appear.
+
+- **`/` (root)** — redirect only (→ `/inbox` or `/sign-in`).
+- **`/sign-in`, `/sign-up`** — email + password, show/hide toggle, "Remember me", and OAuth buttons (Google/GitHub). Sign-up auto-provisions a workspace and routes to `/onboarding`.
+- **`/onboarding`** — single-screen builder (agent name, welcome message, brand-color swatch, optional source URL) with a **live widget preview**, then "Create my agent". A **hard paywall** (`OnboardingPaywall` → reused tier grid) blocks unpaid workspaces before any project is created. `?new=1` skips the paywall for already-paid workspaces.
+- **`/inbox`** — three panes:
+  - **List**: project switcher, conversation rows (initials, unread dot, name/"Anonymous", time-ago, escalated badge, search-match snippet), Load-more (keyset). Toolbar has a **status filter (All/Archived)** and a **debounced search**. ⚠️ The **"Filters" and "Sort" selects in the toolbar are disabled placeholders** — not wired.
+  - **Thread**: header (initials, name, email + parsed device, escalated badge), message list (per-message thumbs on assistant replies, "Load older" at top), reply composer (notes whether the reply also emails the visitor).
+  - **Details panel** (`DetailPanel`): avatar, name, email, **Started** (timestamp), **Messages** (count), **Device** (parsed from UA), **IP address**, **CSAT** stars, and Archive/Unarchive + Delete actions. Every field shown maps to a real `conversation` column — nothing fabricated.
+  - Header **InboxStats**: Conversations / Escalated / Resolved / Avg rating (from the server `/stats` aggregate).
+- **`/settings/projects`** — project grid with Pinned + All sections, per-card favorite/pin toggles, brand-color bar, create dialog, delete dialog, search + "favorites only" + "Recent" sort (client-side).
+- **`/settings/projects/[id]`** — config cards: **Bot basics** (name, welcome message, brand color), **AI model** (picker, web-search models only, metadata badges, handles "model no longer available"), **Instructions** (system prompt textarea + templates), **Sources** (add URL / status badge / recrawl / delete), **Install widget** (embed snippet). Sidebar: setup-progress checklist, live chat preview, configuration summary, danger zone (delete). ⚠️ **`escalationThreshold`, `notifyEmail`, `slackWebhookUrl` exist in the data model and PATCH schema but have NO input in this UI** (only present in `types.ts`). Escalation threshold is consumed by the embed/widget; notify-email and Slack-webhook are used by the escalation route but can't be set from the dashboard.
+- **`/settings/billing`** — current-plan card, usage meters (responses/projects/members with progress bars + overage note), 3-tier grid (Starter/Growth/Scale, with "Coming soon" for tiers lacking a configured Stripe price, "Current plan" for the active one), manage-billing (portal) button, internal-account banner when exempt. Stripe-return success/cancel banners.
+
+---
+
+## 5. Sources behavior (retrieval reality)
+
+- **Ingestion** = on add/edit/refresh, the API does a server-side `fetchUrlContent(url)` and stores the extracted **text** inline in `source.content` (plus `title`, `lastFetchedAt`, `lastError`). One fetch, synchronous, at write time. No background crawler, no scheduled re-crawl, no multi-page spidering.
+- **Retrieval** = there is **no RAG / embeddings / vector search**. At chat time (`lib/llm.ts → buildSystem`), the active project's system prompt + `knowledgeText` + **all active sources' full text** are concatenated into the system prompt, capped at **~80k chars total** (budget split evenly across sources, each truncated). The model also has web-search capability (web-search models only), but project sources are plain prompt-stuffing.
+- **Source types** = **website/URL only.** No PDF, file upload, Q&A pairs, or text-snippet source kinds exist.
+- **Sync status** = binary success/error via `lastError` + a `lastFetchedAt` timestamp. No "crawling/queued" state, no page or chunk counts.
+
+---
+
+## 6. Plan limits & gating (what's actually enforced, and where)
+
+Policy lives in `@llmchat/shared` (`BILLING_TIERS`); enforcement in `apps/api`.
+
+| Tier | maxProjects | maxMembers | responses/mo | overage | models | branding | price |
+|---|---|---|---|---|---|---|---|
+| none (unpaid) | 0 | 1 | 0 | no | basic | badge | $0 |
+| starter | 2 | 3 | 2,000 | **hard stop** | basic | badge | $19 |
+| growth | 5 | 8 | 8,000 | meter | all | off | $89 |
+| scale | 15 | 20 | 25,000 | meter | all | custom | $299 |
+| internal (exempt) | ∞ | ∞ | ∞ | no | all | custom | — |
+
+Enforced server-side:
+- **Hard paywall before building** — `POST /api/projects` returns `402 subscription_required` if the workspace has no active paid plan (`isPaidPlan` false), then `project_limit_reached` at the project cap, then `model_not_allowed` if the chosen model exceeds tier access. (`routes/projects.ts`)
+- **Live-agent gating** — `POST /v1/chat`: unpaid → `402 subscription_required`; fixed-tier monthly quota reached → `402 message_limit_reached`; overage tiers never hard-block (Stripe meters each response). The monthly counter is `usage_event` rows since start-of-UTC-month, and the quota check **fails open** (DB error ⇒ allow). (`routes/chat.ts`, `lib/plan.ts`)
+- **Model access** — Starter/unpaid = basic models only; Growth/Scale/exempt = all web-search models. Also degraded gracefully at chat time if a saved model is no longer allowed.
+- **"Powered by" badge** — server-authoritative via `GET /v1/config/:key` (`branding === "badge"` ⇒ Starter/unpaid show it; Growth/Scale/internal suppress it). Customer can't strip it from the embed markup.
+- **Member cap** — `canAddMember` / `memberCount` helpers exist and are correct, **but** there is no member-invite route or team-management UI yet, so the seat cap isn't reachable in practice.
+- **Internal/founder exemption** — owner email in `INTERNAL_ACCOUNT_EMAILS` ⇒ unlimited, unmetered, resolved server-side (non-spoofable). Empty allowlist ⇒ nobody exempt.
+
+> Note: actual purchasability depends on `STRIPE_SECRET_KEY` + `STRIPE_PRICE_*`
+> being set; unconfigured tiers render "Coming soon" and checkout returns
+> `billing_not_configured`/503.
+
+---
+
+## Feature inventory
+
+| Feature | Status |
+|---|---|
+| Email+password auth | **Built** |
+| OAuth sign-in (Google/GitHub) | **Built** (code-complete; live only when provider secrets are set) |
+| Passkeys | **Not present** (schema table only; runtime plugin removed) |
+| Workspaces + provisioning | **Built** |
+| RBAC roles (owner/admin/agent) enforced | **Built** |
+| Team-member invite / seat management UI | **Not present** (cap helpers exist, no route/UI) |
+| Projects CRUD + favorite/pin | **Built** |
+| Project status (live/paused/draft) | **Not present** |
+| System prompts (multiple, activatable) | **Built** |
+| Sources — website/URL ingestion | **Built** |
+| Sources — PDF/file/Q&A/text-snippet types | **Not present** |
+| Retrieval via embeddings / RAG / vector search | **Not present** (prompt-stuffing, ~80k-char cap) |
+| Source crawl/sync status + page counts | **Partial** (success/error + lastFetched only; no progress/counts) |
+| Model picker (web-search models, badges) | **Built** |
+| Embed snippet + iframe full-page embed | **Built** |
+| React/RSC SDK embed | **Not present** (backlog) |
+| Inbox list (keyset pagination, polling) | **Built** |
+| Inbox search (name/email/message body) | **Built** |
+| Inbox status filter (active/archived) | **Built** |
+| Inbox "Filters" / "Sort" controls | **Not present** (disabled placeholders) |
+| Conversation status (open/pending/resolved enum) | **Not present** (only `archivedAt` + `escalatedAt`) |
+| Conversation assignee / human assignment | **Not present** |
+| Conversation details/contact panel | **Built** (name, email, IP, device-from-UA, started, msg count, CSAT) |
+| Richer visitor context (page URL, referrer, geo, device type) | **Not present** (not captured by the widget) |
+| Human reply (with visitor email) | **Built** |
+| Per-message thumbs rating | **Built** |
+| Per-conversation CSAT (stars) | **Built** |
+| Escalate to human + email/Slack notify | **Built** |
+| Escalation-threshold / notify-email / Slack-webhook config UI | **Not present** (columns + PATCH schema exist; no inputs) |
+| Per-viewer unread tracking | **Built** |
+| Plan tiers + entitlements (none/starter/growth/scale) | **Built** |
+| Hard paywall before building | **Built** |
+| Live-agent monthly quota / overage metering | **Built** (cost in `usage_event` is always 0) |
+| Model-access gating by tier | **Built** |
+| "Powered by" badge gating | **Built** |
+| Stripe checkout / portal / webhook | **Built** (live only when Stripe env configured) |
+| Internal/founder exemption | **Built** |
+| Billing screen + usage meters | **Built** |
+| Onboarding flow + live preview | **Built** |
+| Dark/light theming | **Built** |
+
+_Saved to `docs/dashboard-inventory.md` (uncommitted, per request)._

--- a/docs/dashboard-restyle-plan.md
+++ b/docs/dashboard-restyle-plan.md
@@ -1,0 +1,292 @@
+# Dashboard restyle — staged build plan (read-only pass)
+
+Source of truth: the **`llmchat`** Claude Design project
+(`claude.ai/design/p/2369a16d-…`), file **`Clanker App.dc.html`** — the
+"reconciled to what's real" spec. It carries an explicit in-canvas legend:
+
+- **LIVE** = renders real data only, safe to build now.
+- **ROADMAP** = designed but not yet wired; must ship as an honest
+  empty/disabled/"Not captured yet" state, never wired to fabricated data.
+
+This is a **frontend reskin of working screens**, not a backend rewrite.
+Preserve all working logic: API, data layer, auth, billing, retrieval,
+escalation, migrations. **Do not touch schema or the data layer.** The design's
+sample data (Jordan Reese, lordapparel.com, "Dev Workspace", the model list) is
+placeholder — wire every value to real workspace/project/visitor data.
+
+Cross-checked against `docs/dashboard-inventory.md` (what the code literally does
+today). Classification key per surface element:
+
+- **(a) Pure reskin** — element exists and is wired today; restyle only. Low risk.
+- **(b) New LIVE behavior** — backend already supports the data, but the current
+  UI doesn't expose it. Net-new UI over an existing endpoint/column. Medium risk.
+- **(c) ROADMAP scaffold** — defer. Build later, only when taken on explicitly,
+  and only as honest empty/disabled state.
+
+---
+
+## 0. Design system (applies to every surface)
+
+- **Fonts:** Hanken Grotesk (UI) + JetBrains Mono (numerals/IDs/code). New webfonts.
+- **Theme:** full Light / Dark / **System** token sets defined in the spec
+  (`themeTokens()`), accent indigo `#6366f1` dark / `#4f46e5` light. The existing
+  Light/Dark/System switcher must keep working — both themes ship. (a)
+- **Badges:** the LIVE/ROADMAP chips are a *design-canvas* affordance to show what's
+  wired. **Do not ship the literal LIVE/ROADMAP pills into production.** They are
+  the build contract, not UI. (The "Soon" pill on a disabled nav item is real UI.)
+- **Copy rule:** "support agent", never "chatbot"/"bot". The spec already says
+  "support agent" everywhere — preserve it. Sweep stray "bot" copy ([[feature-map]]).
+
+---
+
+## 1. Shell / nav + top bar  — "Command Bar"  *(maps to RESTYLE PR1, task #89)*
+
+**Top bar (left→right):** logo · **workspace switcher** ▸ **project switcher** ·
+[optional inbox-search shortcut] · help · account avatar menu. **No ⌘K, no
+notifications bell, no Analytics** (see rows below — all dropped, not stubbed).
+
+| Element | Class | Notes |
+|---|---|---|
+| Workspace switcher (dropdown, list + check) | **(a)** | `GET /api/workspaces` + `setWorkspaceId` already exist (shipped #64). |
+| Project switcher (dropdown) in the top bar | **(b)** | **LOCKED decision (do not build a global current-project context):** the switcher holds **lightweight display/navigation state only** — which project is selected, for its label and as the target of navigation. **Data scoping comes from the route `[id]`**, not a shared context. Sources/Settings read their project from the route. **The inbox stays workspace-scoped with its own project filter and does NOT read the switcher's selection.** Net-new UI is just the top-bar control + nav wiring; no global-context plumbing. (See §IA #1.) |
+| Grouped sidebar nav: **WORKSPACE** {Conversations[unread badge], Projects} / **PROJECT** {Sources, Settings} | **(a/b)** | Regroup of existing nav. **Analytics is dropped from the sidebar entirely** (not "Soon", not a roadmap item). Conversations/Projects are workspace-scoped (a); Sources/Settings become project-scoped (b, see §IA). |
+| Conversations unread badge | **(a)** | `read_status` unread tracking exists. |
+| **Analytics** nav item | **DROPPED** | Removed from the sidebar entirely — not a "Soon" pill, not a roadmap nav item, no empty-state screen. It returns only as a real feature with real data if ever wanted. (Drop the spec's Analytics nav row *and* its roadmap screen.) |
+| Centered global search + **⌘K** | **DROPPED / conditional** | **Drop ⌘K entirely.** Include the top-bar search box **only if it cleanly routes to the existing inbox search**; if that isn't clean, **omit the search bar** rather than ship a dead/placeholder box. No-dead-stub rule. Real global search (conversations + projects) stays backlog (#101). |
+| Notifications bell | **DROPPED** | No notifications backend → **omit it**, don't render it inert. Same no-dead-stub logic. |
+| Help link, account avatar menu | **(a)** | Account menu → existing `/settings/account`, sign-out, workspaces (#64). |
+| **Bottom-left usage meter** | **(a) + (c)** | **Response count is LIVE** — wire to `GET /billing/usage` `usage.responsesThisMonth` + `periodLabel`. The **plan-limit bar / quota is ROADMAP** — the spec itself says "Limits aren't enforced yet — shown for reference." Keep the honest "not enforced yet" caption; do **not** render a hard cap as if enforced. |
+
+**PR1 scope discipline:** build the chrome and render the *existing* pages
+unchanged inside it. Defer the project-scoped reshuffle of Sources/Settings (§IA)
+to their own PRs so PR1 stays a low-risk shell swap.
+
+---
+
+## 2. Inbox / Conversations  *(RESTYLE PR2, task #90)*
+
+The most-used surface and almost entirely LIVE. Three-pane: list · thread · details.
+
+| Element | Class | Notes |
+|---|---|---|
+| List: search, conversation rows (avatar, unread dot, name/Anonymous, time, preview) | **(a)** | All wired today. |
+| **Tag filter chips** | **(a)** | Tags shipped (#58/#59). |
+| Per-conversation **tags** in details pane + "+ Add tag" | **(a)** | Shipped. |
+| **Status filter: Open / Resolved / Escalated / All** | **(b)** | Spec tags the *status tabs* ROADMAP, but the columns exist: **Open** = `archivedAt null`, **Resolved** = `archivedAt set`, **Escalated** = `escalatedAt set`. Today's UI only has active/archived. The user's PR2 brief explicitly wants "real Open/Resolved/Escalated filters" — **achievable as LIVE with no schema change**, just map to existing columns + the `archived` query param (+ a new `escalated` filter on the list endpoint). This is the one place to *promote* the design's ROADMAP tag to LIVE because the data is real. |
+| Thread header **"Open" status pill** | **(b)** | Same mapping — derive from `escalatedAt`/`archivedAt`. Don't invent a status enum. |
+| **Resolve / Reopen** action (single control over `archivedAt`) + **Delete** | **(a) reskin + rename** | **Confirmed semantics:** `archivedAt` **is** the resolved state — it's "the app's only closed state" (`conversations.ts:322` maps `resolved == archived`; `InboxStats` already labels the archived count "Resolved"). So **archive and resolve are the same column** — collapse to one concept: **rename Archive → Resolve and Unarchive → Reopen** over the existing `PATCH …/:id {archived}` toggle. No second button, no new column. `DELETE …/:id` stays distinct. |
+| Message bubbles, system escalation marker | **(a)** | `message.role` incl. system; escalation is real. |
+| **"Add to knowledge"** on assistant messages | **(a)** | Promote-reply-to-source shipped (#57/#81). |
+| Per-message **thumbs** | **(a)** | `message.rating`. |
+| **CSAT** stars (details) | **(a)** | `conversation.csatRating`. |
+| Contact fields (name, email, IP, device-from-UA, started, msg count) | **(a)** | All real `conversation` columns. Copy-email is trivial. |
+| Composer **Reply** tab + Send | **(a)** | `POST …/:id/reply`. |
+| **Assign** button (header) | **(c)** | No `assignee` column. Roadmap (#96). (The spec groups Resolve + Assign under one ROADMAP chip — split them: Resolve is the real rename above; Assign is roadmap.) |
+| Composer **Internal note** tab | **(c)** | `message.role` has no "note"; needs schema. Roadmap (#97). |
+| Composer **Attach** + **Suggest with AI** | **(c)** | No upload, no suggest endpoint. Roadmap (#98). |
+| Details **"Visitor context"** card (page, referrer, device-type, geo…) | **(c)** | **Not captured by the widget.** Keep the design's exact honest state: heading + "Not captured yet — never show a guessed value" + `—` rows. Roadmap (#99). |
+
+**Data honesty flags:** the visitor-context block and Assign/Internal-note/Suggest
+must ship disabled/empty, never seeded. Preserve `—` and "Not captured yet" verbatim.
+
+---
+
+## 3. Projects  *(RESTYLE PR3, task #91)*
+
+Grid of agent cards → "New project" routes into first-run setup.
+
+| Element | Class | Notes |
+|---|---|---|
+| Card: name, favorite star, public-key copy, model badge, config button, search | **(a)** | All wired (favorite/pin, publicKey, model). |
+| "New project" / create tile → first-run setup | **(a)** | Existing onboarding flow. |
+| **Real model badge** | **(a)** | `project.model`; keep gateway-snapshot-driven, no hardcoded names. |
+| Card **domain** line (`lordapparel.com`) | **(c)** | **No `domain`/website column on `project`.** Spec tags it ROADMAP. Defer — or drop from the card. *Data-shape gap.* |
+| Card **status pill** (Live/Paused) | **(c)** | No project `status` column. Roadmap (#101). *Data-shape gap.* |
+| Card **"responses · 30d"** counter | **(b, deferred)** | No per-project counter column, **but** `usage_event` rows are per-`projectId` — a 30-day count is *computable* with a new aggregate endpoint. Spec conservatively marks it ROADMAP; it's LIVE-able later via a `GET /api/projects/:id/usage` rollup. No schema change needed when taken on. |
+
+---
+
+## 4. Sources  *(RESTYLE PR4, task #92)*
+
+Becomes a **project-scoped page** (today it's a card inside the project config page).
+
+| Element | Class | Notes |
+|---|---|---|
+| Add **URL** source + list table (Source, Type, Added) | **(a)** | URL ingestion is real (`POST …/sources`, fetch-on-add). |
+| "**Promoted from a reply**" badge on a source row | **(a)** | Reply→knowledge shipped (#57). |
+| Source **status** (ok/error/last-fetched) | **(b)** | `lastError`/`lastFetchedAt` exist → a basic ok/error/last-synced cell is LIVE-able (spec marks the rich "Status" column ROADMAP). Ship minimal-honest: success/error only, no fake "crawling/queued". |
+| Add-source **types** other than URL (PDF, file, Q&A, text) | **(c)** | URL-only today; no `type` column. Roadmap (#100). Render dimmed/disabled. |
+| **Typed-source dashboard** (per-type rollups) + "Items" column (page/chunk counts) | **(c)** | No counts, no RAG. Roadmap (#100). Honest empty. *Data-shape gap:* design implies multi-type + chunk counts the backend doesn't model. |
+
+---
+
+## 5. Settings (project-scoped: General / Widget / Behavior / Members)  *(RESTYLE PR5, task #93)*
+
+Left subnav with four tabs. Decomposes today's single `/settings/projects/[id]` config page.
+
+**General**
+| Element | Class | Notes |
+|---|---|---|
+| **Agent name** | **(a)** | `project.name`. |
+| Display name / support-email-for-handoffs / default language / require-email-before-chat / Powered-by toggle | **(c)** | No columns for these. Powered-by is **server-authoritative + plan-gated** (`branding`), not a per-project toggle — keep it server-side; don't fake a switch. Roadmap. Spec already groups them under "NOT WIRED YET". |
+
+**Widget**
+| Element | Class | Notes |
+|---|---|---|
+| **Brand color** | **(a)** | `project.brandColor`. |
+| **Welcome message** | **(a)** | `project.welcomeMessage`. |
+| **Install snippet** (copy) | **(a)** | Existing embed snippet; `publicKey` public-safe. |
+| **Launcher position** (bottom-left/right) | **(c)** | No column. Roadmap. |
+
+**Behavior**
+| Element | Class | Notes |
+|---|---|---|
+| **Model** picker (opens overlay) | **(a)** | `project.model` + model overlay. **Keep gateway-snapshot-driven** (`@llmchat/shared` web-search list) — the design's "live from `…/v1/models`" is aspirational; there is **no models endpoint**, the picker reads the committed snapshot. Don't hardcode the design's sample model names. |
+| **Instructions** (system prompt) | **(a)** | `systemPrompt` + saved templates. |
+| **escalationThreshold / notifyEmail / slackWebhookUrl** | **(b)** | **Columns + PATCH schema exist and are consumed by the escalation route today, but have no UI.** The user's PR3/PR5 brief explicitly wants these exposed. **LIVE-able now** as real inputs — likely a "Escalation & handoff" section on Behavior. *Note: the design's Behavior page doesn't surface these explicitly — it needs an added LIVE section beyond what the canvas shows.* |
+| Tone of voice / fallback message / auto-escalate toggle | **(c)** | No columns (escalation *works*, but as a threshold, not a toggle). Roadmap. |
+
+**Members** — **entirely (c).** No invite route, no team-management UI (cap helpers
+exist server-side but are unreachable). Ship the spec's honest layout: owner is the
+real account, "Roles & invitations aren't wired yet", Invite button disabled.
+Roadmap (#96).
+
+---
+
+## 6. Billing / usage  *(part of the existing Billing surface; mostly LIVE)*
+
+| Element | Class | Notes |
+|---|---|---|
+| Current plan + price, "Manage in Stripe" (portal) | **(a)** | `GET /billing/usage`, `POST /billing/portal`. |
+| **Responses this period** | **(a)** | `usage.responsesThisMonth` + `monthStartUnix`. |
+| Plan-limit progress bar / overage | **(c)** | Spec: "Hard limits & overage aren't enforced yet — reference only." Keep honest caption; don't render as enforced. |
+| Payment method ("Visa ···· 4242") | **(a)** | From Stripe; wire to real card, don't hardcode 4242. |
+| Plan tiers grid (Starter/Growth/Scale, Current pill, purchasable vs roadmap) | **(a)** | Wire purchasability to `availablePlans` from `/billing/usage`. **Discrepancy:** spec copy says "only **Starter** is purchasable today" but reality is **Growth** is the live tier ([[billing-tiers-pro-only-live]], [[product-roadmap]]). Drive from `availablePlans`, ignore the hardcoded copy. Revenue task #95 wires the other two. |
+
+---
+
+## 7. First-run setup wizard
+
+5 steps: **Basics** (agent name + website) → **Choose model** (gateway snapshot,
+web-search only) → **Instructions** (templates) → **Add first source** (URL) →
+**Install widget**. Plus "Skip to dashboard". All steps map to existing onboarding +
+the hard paywall before project creation.
+
+- Classification: **(a)** reskin of the existing `/onboarding` flow. The "website"
+  field is a *source suggestion* convenience (it pre-fills the first source URL),
+  **not** a persisted `project.domain` — so it doesn't resurrect the domain gap.
+- **(c)** caveat: the model step lists Anthropic/Google/etc. as samples — feed it
+  the real shared snapshot, not the canvas list.
+
+---
+
+## IA change — call it out explicitly
+
+This is the biggest structural delta and the main source of risk.
+
+1. **Project becomes a top-level *navigational* anchor — not a global data context.**
+   Today the only nav is workspace-level (Conversations `/inbox`, Projects
+   `/settings/projects`, Billing). The new top bar adds a **workspace ▸ project
+   switcher**, and the sidebar splits into **WORKSPACE** (Conversations, Projects,
+   Analytics) vs **PROJECT** (Sources, Settings). **LOCKED:** the project switcher
+   holds **lightweight display/navigation state only** (selected project → its label
+   + where it navigates). **Data scoping comes from the route `[id]`**, not a shared
+   "current project" the way the workspace context works. **Do NOT build global
+   current-project plumbing.** The **inbox stays workspace-scoped** with its own
+   project filter and does **not** read the switcher's selection.
+
+2. **Sources + Settings become project-scoped pages.** Today both live as **cards
+   inside one page**, `/settings/projects/[id]` (Bot basics, AI model, Instructions,
+   Sources, Install widget). The redesign explodes that single page into:
+   - a standalone **Sources** page, and
+   - a **Settings** page with **General / Widget / Behavior / Members** subtabs.
+   **LOCKED routing:** project pages are **`[id]`-routed** —
+   `…/projects/[id]/sources` and
+   `…/projects/[id]/settings/{general|widget|behavior|members}` — and the top-bar
+   switcher simply **navigates** to the selected project's page. No global current-
+   project context, no flat `/sources` + `/settings/*` fed by shared state. This
+   avoids a global-context refactor mid-restyle.
+
+3. **The Configure wizard reconciles, doesn't disappear.** The existing
+   `/settings/projects/[id]` config cards are **decomposed**, not deleted:
+   - Bot basics → **Settings/General** (agent name) + **Settings/Widget** (brand
+     color, welcome message, install snippet),
+   - AI model + Instructions → **Settings/Behavior**,
+   - Sources card → the standalone **Sources** page,
+   - the per-project **danger zone / delete** lands on Settings (likely General).
+   The **first-run setup wizard stays** as the create-a-project flow (`/onboarding`);
+   the new Settings pages are the *persistent edit* surface for the same fields. No
+   duplicate source of truth — both write the same `project` columns.
+
+---
+
+## Data-shape / behavior gaps the backend doesn't support today
+
+(All correctly tagged ROADMAP in the spec — listing so they don't get "fixed" by
+inventing data.)
+
+- `project.domain` / website (Projects card line, Sources header) — **no column.**
+- `project.status` Live/Paused (Projects card pill) — **no column.**
+- Per-project "responses · 30d" — no counter column (computable from `usage_event`
+  via a new rollup endpoint; not exposed today).
+- Conversation **status enum** / **assignee** — only `archivedAt`+`escalatedAt`+
+  `csatRating` exist (the 3-way Open/Resolved/Escalated filter is still LIVE-able
+  off those columns; a true *enum* and *assignment* are not).
+- **Internal notes** — `message.role` has no note kind.
+- **Suggest-with-AI**, **attach** — no endpoints.
+- **Visitor enrichment** (page URL, referrer, device-type, geo) — not captured by
+  the widget at all.
+- **Members/invite** — no invite route; cap helpers exist but unreachable.
+- Source **types** beyond URL, **page/chunk counts**, **RAG** — URL-only,
+  prompt-stuffing (~80k cap), binary success/error sync.
+- Settings toggles (powered-by, require-email, launcher position, tone, default
+  language, fallback, auto-escalate toggle) — no columns; powered-by is plan-gated
+  server-side, not a per-project switch.
+- **No `/v1/models` endpoint** — picker is a build-time snapshot, not a live gateway
+  call (functionally fine; just isn't what the label implies).
+
+---
+
+## Recommended sequencing — where to start
+
+The PR1–PR5 arc in the task list ([[product-roadmap]] #89–#93) is the right
+spine. Refinements:
+
+1. **Start with PR1 (Shell/chrome) — #89.** Safest *and* highest-leverage: it's the
+   frame every other surface renders inside, and it can land as a near-pure reskin
+   if scoped to **chrome only** (top-bar switchers wired to existing workspace/
+   project data, grouped sidebar, usage meter on real `/billing/usage`; **no ⌘K, no
+   notifications bell, no Analytics** — all dropped, not stubbed) while existing
+   pages render unchanged inside it.
+   **De-risk by deferring the project-scoped IA reshuffle to PR4/PR5.** Project
+   context is already **locked** (§IA #1/#2: `[id]`-routed pages + a switcher that
+   only navigates; no global current-project state), so PR1 wires the switcher as
+   navigation and nothing more.
+
+2. **Then PR2 (Inbox) — #90.** Highest day-to-day value, ~90% LIVE, and the place
+   to *promote* the design's ROADMAP status tabs to a real Open/Resolved/Escalated
+   filter (the only LIVE-able promotion in the set). Self-contained.
+
+3. **PR3 Projects → PR4 Sources → PR5 Settings.** PR4/PR5 carry the IA split
+   (project-scoped pages) and should follow once the shell's project context is
+   settled. Settings is last because it's the most decomposition-heavy and depends
+   on the project-scoped routing chosen in PR1.
+
+4. **Out of band:** Billing reskin is small, almost fully LIVE, and independent —
+   good low-risk warm-up or filler PR if a quick win is wanted, but not on the
+   critical path. Conversation summary (#94) and the revenue/backlog tasks remain
+   after the arc.
+
+**If a single safest leaf to pilot the visual language first is wanted** before
+touching global nav: **Billing** (self-contained, mostly LIVE) is the lowest-blast-
+radius proof-of-concept. But for value, lead with PR1→PR2 as above.
+
+---
+
+## Standing rules for the build phase (not this pass)
+
+Feature branch + conventional commits; gate on lint+format+typecheck+test+secret-scan;
+hand-author any migration (never `drizzle-kit generate`); explicit ordered deletes;
+never merge without explicit word. **This pass is plan-only — no code, no PRs.**
+
+_Saved to `docs/dashboard-restyle-plan.md` (uncommitted, read-only pass)._


### PR DESCRIPTION
These two docs are referenced as canonical by the roadmap but existed only as untracked files on Omar's machine — one `git clean` from gone. Docs-only, no code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)