### PR TITLE
feat(widget): explicit human request overrides the escalation threshold

### DIFF
--- a/packages/widget/src/escalation-intent.test.ts
+++ b/packages/widget/src/escalation-intent.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+
+import { requestsHuman } from "./escalation-intent";
+
+describe("requestsHuman", () => {
+	it.each([
+		// talk/speak/chat/connect + person
+		"Can I talk to a human?",
+		"I want to speak with a real person",
+		"can i chat with someone",
+		"Connect me to your support team",
+		"put me through to an agent",
+		"could you connect me with customer service",
+		"speaking to a representative would help",
+		// get/give me
+		"get me a human",
+		"Give me an agent",
+		// want/need/like
+		"I need a rep",
+		"I'd like a human",
+		"i wanna talk to a person",
+		"I would prefer an operator",
+		// is there…
+		"Is there a human I can talk to?",
+		"is there anyone who can help me",
+		// strong bigrams
+		"a real human would understand this",
+		"live agent",
+		"I need human support here",
+		// please / bare noun
+		"human please",
+		"Agent, please!",
+		"human",
+		"AGENT",
+		// escalate / transfer
+		"please escalate this",
+		"can you transfer me",
+		"hand me off to your team",
+		// bot frustration
+		"I don't want to talk to a bot",
+		"no bots please",
+		"stop, I did not ask for an AI",
+	])("matches %j", (text) => {
+		expect(requestsHuman(text)).toBe(true);
+	});
+
+	it.each([
+		// Ordinary support questions must never match.
+		"What exactly is Clanker Support?",
+		"How do I add the widget to my website?",
+		"My order hasn't arrived yet",
+		"Thanks, that answers my question!",
+		// Word-boundary traps: substrings of matched nouns/verbs.
+		"humanity is doomed",
+		"my personal email bounced",
+		"what's on the agenda for tomorrow",
+		"can you repeat that",
+		"the review said my zip was secretly a tar",
+		// Nouns in non-request contexts.
+		"my user agent string looks wrong",
+		"the person who emailed me was very nice",
+	])("does not match %j", (text) => {
+		expect(requestsHuman(text)).toBe(false);
+	});
+});

--- a/packages/widget/src/escalation-intent.ts
+++ b/packages/widget/src/escalation-intent.ts
@@ -1,0 +1,60 @@
+/**
+ * Detects a visitor explicitly asking for a human, so the "Talk to a human"
+ * CTA can surface immediately instead of waiting for the message-count
+ * threshold.
+ *
+ * Matching leans toward recall over precision: a match only REVEALS the
+ * escalate button (the visitor still has to click it), so a rare false
+ * positive costs one extra affordance while a false negative traps a
+ * frustrated visitor with the bot. Patterns stay word-boundary anchored so
+ * ordinary prose ("humanity", "agenda", "repeat", "personal") never matches.
+ */
+
+/** Nouns visitors use for "a human" (article/qualifier handled per pattern). */
+const PERSON =
+	"(?:human(?:\\s+being)?|person|agent|representative|rep|operator|advisor|somebody|someone|staff(?:\\s+member)?|team\\s?(?:mate|member)|customer\\s+(?:service|support|care)|support\\s+(?:team|staff|person))";
+
+/** Optional emphasis in front of the noun ("a REAL person", "a live agent"). */
+const QUALIFIER = "(?:real|actual|live|human|support)";
+
+const ARTICLE = "(?:an?\\s+|the\\s+|your\\s+)?";
+
+const PATTERNS: RegExp[] = [
+	// "talk to a human", "can I speak with a real person", "chat with someone",
+	// "connect me to your support team", "put me through to an agent"
+	new RegExp(
+		`\\b(?:talk(?:ing)?|speak(?:ing)?|chat(?:ting)?|connect(?:\\s+me)?|put\\s+me\\s+(?:through|in\\s+touch))\\s+(?:to|with)\\s+${ARTICLE}(?:${QUALIFIER}\\s+)?${PERSON}\\b`,
+	),
+	// "get me a human", "give me an agent"
+	new RegExp(
+		`\\b(?:get|give)\\s+me\\s+${ARTICLE}(?:${QUALIFIER}\\s+)?${PERSON}\\b`,
+	),
+	// "I want/need/would like a human/agent/rep" (with or without "to talk to")
+	new RegExp(
+		`\\bi\\s*(?:'d|would)?\\s*(?:want|need|like|prefer|wanna)\\s+${ARTICLE}(?:${QUALIFIER}\\s+)?(?:human|person|agent|representative|rep|operator)\\b`,
+	),
+	// "is there a human/anyone/someone (I can talk to)?"
+	new RegExp(
+		`\\bis\\s+there\\s+(?:a\\s+)?(?:${QUALIFIER}\\s+)?(?:human|person|agent|anyone|anybody|somebody|someone)\\b`,
+	),
+	// Strong bigrams anywhere: "real person", "live agent", "human support"…
+	/\b(?:real|actual|live)\s+(?:human|person|agent|representative)\b/,
+	/\bhuman\s+(?:agent|support|help|assistance|being)\b/,
+	// "human please", "agent, please" — or the message is just "human"/"agent".
+	/\b(?:human|agent|operator|representative),?\s+please\b/,
+	/^\s*(?:an?\s+)?(?:human|agent|operator|representative)\s*[.!?]*\s*$/,
+	// Explicit escalation / transfer verbs.
+	/\bescalat(?:e|ion|ing)\b/,
+	/\btransfer\s+me\b/,
+	/\bhand\s+(?:me\s+)?(?:off|over)\b/,
+	// Bot frustration: a negative word followed shortly (same clause) by a bot
+	// noun — "not a bot", "no bots please", "I don't want to talk to a robot",
+	// "stop, I did not ask for an AI", "tired of this chatbot".
+	/\b(?:no|not|don'?t|dont|stop|hate|quit|tired\s+of|sick\s+of|enough\s+of)\b[^.!?]{0,25}\b(?:bots?|robots?|ai|chatbots?|machines?|clankers?)\b/,
+];
+
+/** True when the message reads as an explicit request for a human. */
+export function requestsHuman(text: string): boolean {
+	const t = text.toLowerCase();
+	return PATTERNS.some((re) => re.test(t));
+}

--- a/packages/widget/src/widget.escalation-intent.test.tsx
+++ b/packages/widget/src/widget.escalation-intent.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// Keep the live widget off the network/model: stub the chat transport + hook and
+// the branding probe, and drive the server feed via a useServerMessages spy.
+vi.mock("ai", () => ({ DefaultChatTransport: class {} }));
+vi.mock("@ai-sdk/react", () => ({
+	Chat: class {},
+	useChat: () => ({
+		messages: [],
+		sendMessage: vi.fn(async () => {}),
+		status: "ready",
+		error: null,
+	}),
+}));
+vi.mock("./widget-config", () => ({
+	useWidgetConfig: () => ({ showBranding: false, privacyPolicyUrl: null }),
+}));
+
+import * as serverMessages from "./useServerMessages";
+import { Widget } from "./widget";
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+/** A feed with a SINGLE visitor message — below the default threshold of 3 —
+ * so the CTA can only appear via the explicit human-request override. */
+function mockFeed(content: string) {
+	vi.spyOn(serverMessages, "useServerMessages").mockReturnValue({
+		serverMessages: [
+			{ id: "s1", role: "user", content, sequence: 1, createdAt: 1 },
+		],
+		conversationId: "c1",
+		csatRating: null,
+		escalatedAt: null,
+		archivedAt: null,
+		refresh: vi.fn(),
+	});
+}
+
+async function mountIdentified(visitorMessage: string) {
+	mockFeed(visitorMessage);
+	render(
+		<Widget
+			widgetMode="live"
+			projectKey="pk"
+			apiUrl="http://x"
+			brandColor="#4f46e5"
+			mode="inline"
+		/>,
+	);
+	// Pass the pre-chat IdentifyForm gate so the conversation surface renders.
+	await userEvent.type(screen.getByPlaceholderText(/your name/i), "Test");
+	await userEvent.click(screen.getByRole("button", { name: /start chat/i }));
+}
+
+describe("LiveWidget — explicit human request overrides the threshold", () => {
+	it("shows the CTA on the first message when the visitor asks for a human", async () => {
+		await mountIdentified("Can I talk to a human please?");
+		expect(
+			screen.getByRole("button", { name: /talk to a human/i }),
+		).toBeInTheDocument();
+	});
+
+	it("keeps the CTA hidden below the threshold for an ordinary question", async () => {
+		await mountIdentified("How do I add the widget to my website?");
+		expect(
+			screen.queryByRole("button", { name: /talk to a human/i }),
+		).not.toBeInTheDocument();
+	});
+});

--- a/packages/widget/src/widget.tsx
+++ b/packages/widget/src/widget.tsx
@@ -15,6 +15,7 @@ import { ResolveSection } from "./components/ResolveSection";
 import { WidgetFrame } from "./components/WidgetFrame";
 import { rateConversation, shouldPromptCsat } from "./csat";
 import { requestEscalation } from "./escalation";
+import { requestsHuman } from "./escalation-intent";
 import { requestResolve } from "./resolve";
 import {
 	getOrCreateClientId,
@@ -261,9 +262,21 @@ function LiveWidget({
 		(m) => m.role === "user",
 	).length;
 	const threshold = resolveEscalationThreshold(escalationThreshold);
+	// An explicit "I want a human" from the visitor overrides the message-count
+	// threshold — the CTA surfaces immediately instead of making them rephrase
+	// until they hit it.
+	const requestedHuman = useMemo(
+		() =>
+			displayMessages.some(
+				(m) => m.role === "user" && requestsHuman(m.content),
+			),
+		[displayMessages],
+	);
 	// Hide the escalate CTA once escalated OR resolved (resolved wins — terminal).
 	const showEscalation =
-		!escalated && !resolved && userMessageCount >= threshold;
+		!escalated &&
+		!resolved &&
+		(userMessageCount >= threshold || requestedHuman);
 
 	// A "real exchange" = at least one persisted visitor message and one bot
 	// reply. Only then (and only when not already rated) do we prompt on close.


### PR DESCRIPTION
## What

The "Talk to a human" CTA now appears as soon as the visitor explicitly asks for a human — even before the project's escalation threshold (default 3 user messages) is reached.

## How

- New pure matcher `requestsHuman(text)` in `packages/widget/src/escalation-intent.ts`: word-boundary regex set covering the common phrasings — talk/speak/chat/connect me/put me through to a human/person/agent/rep/representative/operator/someone/customer service/support team; "get/give me a…"; "I want/need/'d like/wanna a…"; "is there a human/anyone…"; strong bigrams ("real person", "live agent", "human support"); bare "human"/"agent (please)"; escalate/transfer/hand-me-off; bot frustration ("I don't want to talk to a bot", "no bots please").
- Deliberately recall-over-precision: a match only **reveals** the CTA (the visitor still has to click), so a rare false positive costs one extra affordance while a false negative traps a frustrated visitor with the bot. Word-boundary anchored so "humanity", "agenda", "repeat", "user agent" never match.
- Widget CTA condition becomes `userMessageCount >= threshold || requestedHuman`, still gated by not-escalated / not-resolved.

## Testing

- ~40 unit cases for the matcher (positives + word-boundary traps).
- Component tests: CTA shows on a first-message human request; stays hidden for an ordinary first question.
- Full widget suite passes (158 tests); prettier/oxlint clean.
- Verified end-to-end on the seeded local stack: drove the real showcase widget with Playwright — CTA appears on message 1 for "Can I talk to a human please?", stays hidden for a shipping question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)