### PR TITLE
fix(analytics): ship PostHog keys in marketing + dashboard prod env

### DIFF
--- a/apps/dashboard/ploy.yaml
+++ b/apps/dashboard/ploy.yaml
@@ -8,6 +8,11 @@ env:
   # browser — used by @stripe/stripe-js to redirect to Checkout. The SECRET key
   # lives only in the api worker's env, never here.
   NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: $NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY
+  # Analytics (PostHog EU). Public/write-only project key — safe to commit,
+  # same convention as apps/showcase/.env.production. Without these the prod
+  # build ships with analytics disabled (no key = provider no-ops).
+  NEXT_PUBLIC_POSTHOG_KEY: phc_ySVKqGDizuGXPiHXYLVnUXMnR28FNZu8PccWLt6BdbfH
+  NEXT_PUBLIC_POSTHOG_HOST: https://eu.i.posthog.com
 
 dev:
   port: 3001

--- a/apps/marketing/ploy.yaml
+++ b/apps/marketing/ploy.yaml
@@ -6,6 +6,11 @@ env:
   NEXT_PUBLIC_API_URL: https://api.clankersupport.com
   NEXT_PUBLIC_DASHBOARD_URL: https://app.clankersupport.com
   NEXT_PUBLIC_SHOWCASE_URL: https://showcase.clankersupport.com
+  # Analytics (PostHog EU). Public/write-only project key — safe to commit,
+  # same convention as apps/showcase/.env.production. Without these the prod
+  # build ships with analytics disabled (no key = provider no-ops).
+  NEXT_PUBLIC_POSTHOG_KEY: phc_ySVKqGDizuGXPiHXYLVnUXMnR28FNZu8PccWLt6BdbfH
+  NEXT_PUBLIC_POSTHOG_HOST: https://eu.i.posthog.com
 
 dev:
   port: 3002


### PR DESCRIPTION
## Problem

The prod builds of **marketing** (`clankersupport.com`) and **dashboard** (`app.clankersupport.com`) have never sent a single PostHog event — their `ploy.yaml` env blocks carried no `NEXT_PUBLIC_POSTHOG_KEY`, and the PostHog providers deliberately no-op without one. Only the showcase tracks in prod, because its committed `.env.production` bakes the key into the build.

Without this, the visitor→signup and signup→paid funnels are unmeasurable: no traffic sources, no signup attribution, no checkout events.

## Fix

Add the public `phc_` project key + EU ingest host to both apps' `ploy.yaml` `env:` blocks. This is the same public/write-only token already committed in `apps/showcase/.env.production`, so committing it follows the established convention. Local dev stays clean — both providers skip capture on dev hosts unless `NEXT_PUBLIC_POSTHOG_CAPTURE_DEV=true`.

## Verification

- `pnpm lint` ✅ (prettier + oxlint, exit 0)
- `pnpm test` ✅ (7 tasks, all passing)
- Config-only change; takes effect on next Ploy deploy. From the first post-deploy visitor, the three PostHog dashboards (Acquisition 800092, Visitor→Signup 800094, Signup→Paid 800095 on EU project 205250) start filling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HXvS5AGNN3eke6USb3Bupw