### PR TITLE
feat(docs): new IA (Pricing/Features/Integrations) + llms.txt routes

### DIFF
--- a/apps/docs/app/llms-full.txt/route.ts
+++ b/apps/docs/app/llms-full.txt/route.ts
@@ -1,0 +1,24 @@
+import { getLLMText } from "@/lib/get-llm-text";
+import { source } from "@/lib/source";
+
+// cached forever
+export const revalidate = false;
+
+const HEADER = `# Clanker Support — Full Documentation
+
+> An AI-powered support agent for your site — install it with one script tag or one React Server Component (@clankersupport/widget-rsc on npm). It answers from your docs and sources, then escalates to your team. Open source (MIT) and self-hostable (bring your own keys).
+
+Site: https://clankersupport.com · Docs: https://docs.clankersupport.com · Dashboard: https://app.clankersupport.com
+
+This file concatenates the full text of every documentation page below.`;
+
+export async function GET() {
+	const scan = source.getPages().map(getLLMText);
+	const scanned = await Promise.all(scan);
+
+	return new Response([HEADER, ...scanned].join("\n\n"), {
+		headers: {
+			"Content-Type": "text/plain; charset=utf-8",
+		},
+	});
+}

--- a/apps/docs/app/llms.mdx/[[...slug]]/route.ts
+++ b/apps/docs/app/llms.mdx/[[...slug]]/route.ts
@@ -1,0 +1,27 @@
+import { notFound } from "next/navigation";
+
+import { getLLMText } from "@/lib/get-llm-text";
+import { source } from "@/lib/source";
+
+export const revalidate = false;
+
+export async function GET(
+	_req: Request,
+	{ params }: { params: Promise<{ slug?: string[] }> },
+) {
+	const { slug } = await params;
+	const page = source.getPage(slug);
+	if (!page) {
+		notFound();
+	}
+
+	return new Response(await getLLMText(page), {
+		headers: {
+			"Content-Type": "text/markdown",
+		},
+	});
+}
+
+export function generateStaticParams() {
+	return source.generateParams();
+}

--- a/apps/docs/app/llms.txt/route.ts
+++ b/apps/docs/app/llms.txt/route.ts
@@ -1,0 +1,88 @@
+import { BILLING_TIERS } from "@llmchat/shared";
+
+import { source } from "@/lib/source";
+
+import type { InferPageType } from "fumadocs-core/source";
+
+// cached forever
+export const revalidate = false;
+
+const SITE_URL = "https://clankersupport.com";
+const DOCS_URL = "https://docs.clankersupport.com";
+const DASHBOARD_URL = "https://app.clankersupport.com";
+const SHOWCASE_URL = "https://showcase.clankersupport.com";
+const GITHUB_URL = "https://github.com/theopenco/llmchat";
+const RSC_PACKAGE = "@clankersupport/widget-rsc";
+const RSC_NPM_URL = `https://www.npmjs.com/package/${RSC_PACKAGE}`;
+
+const STARTER = BILLING_TIERS.starter.priceUsdMonthly;
+const GROWTH = BILLING_TIERS.growth.priceUsdMonthly;
+const SCALE = BILLING_TIERS.scale.priceUsdMonthly;
+
+type Page = InferPageType<typeof source>;
+
+// Section headings keyed by the first URL segment, in the order they should
+// appear. Pages whose first segment isn't listed fall back to "Getting started".
+const SECTIONS: { key: string; title: string }[] = [
+	{ key: "", title: "Getting started" },
+	{ key: "features", title: "Features" },
+	{ key: "integrations", title: "Integrations" },
+	{ key: "learn", title: "Dashboard knowledge base" },
+];
+
+function sectionKey(page: Page): string {
+	const first = page.url.split("/").filter(Boolean)[0] ?? "";
+	return SECTIONS.some((s) => s.key === first) ? first : "";
+}
+
+export async function GET() {
+	const pages = source.getPages();
+
+	const grouped = new Map<string, string[]>();
+	for (const page of pages) {
+		const key = sectionKey(page);
+		const line = `- [${page.data.title}](${DOCS_URL}${page.url})${page.data.description ? `: ${page.data.description}` : ""}`;
+		const existing = grouped.get(key);
+		if (existing) {
+			existing.push(line);
+		} else {
+			grouped.set(key, [line]);
+		}
+	}
+
+	const docSections = SECTIONS.filter((s) => grouped.has(s.key))
+		.map((s) => `## ${s.title}\n\n${grouped.get(s.key)!.join("\n")}`)
+		.join("\n\n");
+
+	const content = `# Clanker Support
+
+> An AI-powered support agent for your site — install it with one script tag or one React Server Component (${RSC_PACKAGE} on npm). It answers from your docs and sources, then escalates to your team. Open source (MIT) and self-hostable (bring your own keys); the hosted version has flat monthly plans from $${STARTER}/mo with no per-seat fees.
+
+## Key facts
+
+- Install via one \`<script>\` tag (isolated shadow DOM, no build step), the React/Next.js SDK (\`${RSC_PACKAGE}\`, React 19), a WordPress plugin, or a Shopify theme app extension.
+- Answers from a per-project knowledge base — page URLs, text snippets, and Q&A pairs — with your own instructions and model choice.
+- Escalates to your team when it can't help: email + optional Slack notification, a handoff recap for the visitor, and the agent stands down once a human replies.
+- Replies from the team inbox reach the visitor in the widget and by email; visitor email replies thread back into the same conversation.
+- Quality signals: per-message thumbs up/down plus a 1–5 CSAT rating.
+- Open source (MIT): ${GITHUB_URL} — self-host free with your own LLM Gateway key.
+- Hosted plans: Starter $${STARTER}/mo, Growth $${GROWTH}/mo, Scale $${SCALE}/mo — metered by AI responses, no per-seat fees, annual = two months free.
+- Site: ${SITE_URL} · Docs: ${DOCS_URL} · Dashboard: ${DASHBOARD_URL}
+
+## Product pages
+
+- [Home](${SITE_URL}): What Clanker Support is and how the drop-in agent works.
+- [Pricing](${SITE_URL}/pricing): Hosted plans and what each includes.
+- [Machine-readable pricing](${SITE_URL}/pricing.md): Plans in plain markdown.
+- [Live demo](${SHOWCASE_URL}): The real widget running on a first-party demo page.
+- [React / Next.js SDK](${RSC_NPM_URL}): ${RSC_PACKAGE} on npm.
+- [GitHub](${GITHUB_URL}): The open-source (MIT) codebase.
+
+${docSections}`;
+
+	return new Response(content, {
+		headers: {
+			"Content-Type": "text/plain; charset=utf-8",
+		},
+	});
+}

--- a/apps/docs/content/features/ai-responses.mdx
+++ b/apps/docs/content/features/ai-responses.mdx
@@ -1,0 +1,50 @@
+---
+title: "AI responses"
+description: Streamed answers grounded in your knowledge base, with a per-project AI model and instructions you control
+icon: MessageSquareText
+---
+
+When a visitor asks a question, the support agent answers directly in the widget — the reply streams in word by word, so the visitor starts reading immediately instead of watching a spinner. Every answer is grounded in what you've taught that project: its active knowledge sources plus your instructions.
+
+## Grounded in your knowledge
+
+Each response is built from the project's active [knowledge sources](/features/knowledge-sources) — website pages, text snippets, and Q&A pairs — together with the project's instructions. Sources you deactivate stop informing answers right away, and new sources apply to the next response as soon as they're ready.
+
+The models the agent runs are all web-search-capable, so it can also search the web when a question calls for it — but your own sources are what anchor its answers about your product.
+
+## Choosing a model
+
+Every project picks its own AI model from a curated set of web-search-capable models. The default is `gpt-5.4-mini`, and you can change it per project — so a high-traffic marketing site can run a lighter model while your flagship product runs a stronger one.
+
+Model access follows your plan:
+
+- **Starter** — the lighter "basic" model class (mini, nano, haiku, flash, lite, and small-class models).
+- **Growth and Scale** — the full catalog.
+
+See [Pricing](/pricing) for the full plan comparison. If a plan change ever leaves a project saved on a model its plan no longer includes, the agent quietly falls back to the default model instead of going offline — your widget keeps answering.
+
+## Instructions
+
+Instructions are the project's system prompt: the agent's tone, focus, and boundaries. The agent answers from your sources first; instructions shape _how_ it answers.
+
+<ThemedImage
+	alt="Project settings — Behavior tab with model and instructions"
+	basePath="/learn/project-behavior"
+/>
+
+## Making it yours
+
+Two widget settings shape the first impression of every conversation:
+
+- **Welcome message** — the greeting the visitor sees when they open the widget.
+- **Brand color** — applied to the widget so it matches your site.
+
+Both are set per project, alongside the install snippet and a live preview.
+
+## When the agent can't help
+
+The agent doesn't answer forever. After a configurable number of visitor messages — or immediately, when the visitor asks for a person — the widget offers **Talk to a human**. From there the conversation hands off to your team and the agent stands down. See [Escalation](/features/escalation) for how the handoff works.
+
+## Where to configure it
+
+Model, instructions, welcome message, and brand color all live in the project's settings tabs in the dashboard — see [Project settings](/learn/project-settings) for a walkthrough.

--- a/apps/docs/content/features/email-threading.mdx
+++ b/apps/docs/content/features/email-threading.mdx
@@ -1,0 +1,47 @@
+---
+title: Email threading
+description: How team replies reach the visitor by email, and how their email replies thread back into the same conversation
+icon: Mail
+---
+
+Visitors don't always stay on your site waiting for an answer. When a visitor shares their email address, Clanker Support keeps the conversation alive over email: your replies go out to their inbox, and their replies come back into the same thread — chat and email stay one conversation, with no separate ticket to reconcile.
+
+## Replies reach the visitor both ways
+
+Reply from the inbox composer and your message always appears in the visitor's widget — it polls for new messages, so the reply shows up even mid-session. If the visitor shared an email address, the same reply also goes out by email, so they see your answer whether they're still on your site or long gone. The composer's placeholder tells you when a reply will also be emailed.
+
+<ThemedImage
+	alt="Conversation thread with the reply composer"
+	basePath="/learn/conversation-thread"
+/>
+
+## Visitor replies thread back automatically
+
+When the visitor answers your email instead of returning to the widget, their reply lands back in the same conversation in your inbox — appended as a new visitor message, right where the thread left off.
+
+Two mechanisms make the match:
+
+- **Reply address.** Every project has its own reply address, and every outgoing email sets it as the Reply-To. When the visitor hits reply, their email routes straight back to the right project.
+- **Message-ID matching.** Each outgoing reply carries a unique email Message-ID tied to the message it came from. When the visitor's reply references it (standard email threading, which mail clients do automatically), it's matched to the exact conversation. If that reference is missing, the sender's address is used as a fallback: the reply is threaded into their most recent conversation on that project.
+
+The result: the visitor just replies to an email like they would to any other, and your team sees it in the inbox thread — no forwarding, no copy-pasting.
+
+## Escalation email keeps the thread alive
+
+[Escalation](/features/escalation) emails both sides, with different jobs:
+
+- **Your team's notification** — sent to the project's notify address so a human knows to step in. Answer from the dashboard inbox (see [Conversations](/learn/conversations)) — your reply reaches the visitor in the widget and by email, with proper threading.
+- **The visitor's acknowledgement** — a visitor who has shared an email address gets a confirmation that a human will follow up, and it seeds the email thread. Their reply to it threads back into the conversation automatically.
+
+So a visitor who escalates and closes the tab loses nothing: your team's answer reaches them by email, and the back-and-forth continues in one thread.
+
+## Zero setup on hosted
+
+On the hosted service there is nothing to configure — every project gets its reply address automatically, and outgoing email works out of the box. The only thing that gates email delivery is the visitor: replies go out by email only when they've shared an address (the widget asks for a name and an optional email before the conversation starts).
+
+If you [self-host](/features/self-hosting), email threading needs a Resend account with an inbound domain configured — that powers both escalation notifications and reply threading.
+
+## Where to go next
+
+- [Conversations](/learn/conversations) — reading a thread, replying, and how emailed replies appear in the dashboard.
+- [Escalation & human handoff](/features/escalation) — when and how a conversation reaches your team in the first place.

--- a/apps/docs/content/features/escalation.mdx
+++ b/apps/docs/content/features/escalation.mdx
@@ -1,0 +1,42 @@
+---
+title: Escalation & human handoff
+description: When the agent can't help, a human takes over — with the full conversation already in front of them
+icon: LifeBuoy
+---
+
+The support agent handles the questions your knowledge base can answer. For everything else, the visitor hands the conversation to your team — and the agent gets out of the way. No ticket form, no starting over: your team picks up the same thread, with everything the visitor already said.
+
+## When the widget offers a human
+
+Each project sets its own threshold: after a number of visitor messages (default **3**), the widget shows a **Talk to a human** option. Set it low to route visitors to your team quickly; set it higher to let the agent try more answers first.
+
+A visitor who explicitly asks for a person doesn't wait for the threshold. When a message reads as a request for a human — "talk to a real person", "get me an agent", "escalate this" — the widget surfaces **Talk to a human** immediately, however early in the conversation it happens. Nobody has to argue with the agent to reach your team.
+
+Either way, escalating stays the visitor's choice: the option appears, and the visitor clicks it.
+
+## What the visitor sees
+
+When the visitor chooses **Talk to a human**, a short recap appears in the chat — a sentence or two summarizing what they asked about and what's been covered, so they know the handoff carries their context and they won't have to repeat themselves. The **Talk to a human** option then disappears; a conversation escalates once.
+
+## How your team finds out
+
+An escalation notifies your team through every channel the project has configured, plus the dashboard itself:
+
+- **Email** — sent to the project's notify address, when one is set.
+- **Slack** — posted via an incoming webhook to a channel of your choice, when one is set.
+- **Notification bell** — the escalation always appears in the dashboard's notification feed, and the conversation is flagged **Escalated** in the [team inbox](/features/team-inbox) so it stands out while triaging.
+
+## The agent stands down
+
+Escalation isn't just a notification — it changes who's answering:
+
+1. **While your team is on the way**, if the visitor sends another message, the agent replies only with a brief holding note saying a human will follow up. It doesn't attempt an answer.
+2. **Once a human replies**, the agent goes fully silent. Every later visitor message reaches only your team.
+
+The handoff is one-way by design: a conversation a human has taken over stays with humans. A visitor who asked for a person is never bounced back to the agent mid-conversation.
+
+From there it's a normal team conversation — replies from the inbox reach the visitor in the widget, and by email when they shared an address. See [Email threading](/features/email-threading) for how those replies stay in one thread.
+
+## Configuration
+
+The threshold, notify email, and Slack webhook all live on the project's **Behavior** tab. [Escalation in the dashboard](/learn/escalation) walks through each setting and how escalated conversations look in the inbox.

--- a/apps/docs/content/features/index.mdx
+++ b/apps/docs/content/features/index.mdx
@@ -1,0 +1,44 @@
+---
+title: Features
+description: What the support agent can do, at a glance
+icon: Sparkles
+---
+
+Clanker Support puts an AI-powered support agent on your site: it answers visitor questions from a knowledge base you control, hands off to your team when a person is needed, and keeps every conversation — chat and email — in one shared inbox. This page is the map; each feature page below covers one capability in depth, and the matching [Learn](/learn) pages show where everything lives in the dashboard.
+
+## The features
+
+### [AI responses](/features/ai-responses)
+
+Streamed answers grounded in your knowledge sources and per-project instructions. Every project picks its model from a curated set of web-search-capable models, so the agent can search the web when answering.
+
+### [Knowledge sources](/features/knowledge-sources)
+
+Teach the agent with three kinds of source per project: website URLs (fetched as snapshots you refresh with **Recrawl**), text snippets, and Q&A pairs. Operators can also promote a good inbox reply into a Q&A source.
+
+### [Escalation](/features/escalation)
+
+The widget offers **Talk to a human** after a configurable number of messages — or immediately when the visitor asks for one. Your team is notified by email — plus Slack, if configured — and the dashboard bell; the agent posts a holding note and stands down for good once a human replies.
+
+### [Email threading](/features/email-threading)
+
+Inbox replies appear in the visitor's widget, and go out by email when the visitor shared an address. When they answer that email instead of returning to the chat, their reply threads back into the same conversation — no separate ticket to reconcile.
+
+### [Team inbox](/features/team-inbox)
+
+A shared inbox per workspace: filters, full-text search with a ⌘K command palette, colored tags, per-user unread state, AI-generated triage summaries in the list, and resolve and reopen. Roles (owner, admin, agent) are enforced server-side.
+
+### [Ratings & CSAT](/features/ratings-csat)
+
+Two distinct quality signals, never merged: per-message thumbs up/down on individual agent answers, and a separate 1–5 rating the visitor can leave for the whole conversation when they close it.
+
+### [Self-hosting](/features/self-hosting)
+
+The entire stack is open source ([theopenco/llmchat](https://github.com/theopenco/llmchat), MIT). Run it yourself for free with your own LLM Gateway key — you pay your model provider directly.
+
+## Where to go next
+
+- **[Getting started](/getting-started)** — from sign-up to a live widget on your site.
+- **[Integrations](/integrations)** — install paths beyond the script tag: the React SDK, Shopify, WordPress, and the iframe embed.
+- **[Pricing](/pricing)** — plans, included response quotas, and what's metered.
+- **[Learn](/learn)** — the dashboard, page by page: inbox, projects, sources, workspaces, and billing.

--- a/apps/docs/content/features/knowledge-sources.mdx
+++ b/apps/docs/content/features/knowledge-sources.mdx
@@ -1,0 +1,58 @@
+---
+title: "Knowledge sources"
+description: Teach the agent from your website pages, text snippets, and Q&A pairs — per project, refreshed on your terms
+icon: Database
+---
+
+The agent answers from a knowledge base you build per project. Add the pages, policies, and answers that matter, and every reply the agent gives is grounded in that material — not just what the model happens to know.
+
+## Three kinds of sources
+
+| Kind             | You provide               | Good for                                              |
+| ---------------- | ------------------------- | ----------------------------------------------------- |
+| **Website URL**  | A page URL                | Docs, FAQs, pricing or shipping pages you already run |
+| **Text snippet** | Free-form text, any title | Policies or facts that don't live on a public page    |
+| **Q&A pair**     | A question and its answer | Precise answers to questions visitors ask often       |
+
+A fourth kind, file upload, is coming soon.
+
+Each project has its own knowledge base, so separate sites or products get separately trained agents.
+
+## How grounding works
+
+Every **active** source in the project feeds every answer, alongside the project's instructions (its system prompt). There's no separate indexing or training step — add a source and the very next conversation can draw on it; deactivate or delete one and the agent stops using it immediately.
+
+The agent's answers, model choice, and instructions are covered in [AI responses](/features/ai-responses).
+
+## Website sources are snapshots
+
+A website source is fetched **once, when you add it**. It does not track your live site — publishing changes to a page does not change what the agent knows.
+
+To update the agent after you edit a page, press **Recrawl** on that source in the dashboard. Recrawl re-fetches the URL and replaces the stored snapshot with the current page. It's also the fix for a failed fetch: correct whatever blocked it, then recrawl.
+
+## Status at a glance
+
+Every source carries a status chip in the dashboard:
+
+- **Ready** — a website source fetched successfully; the snapshot is in use.
+- **Pending** — a website source that hasn't completed its first fetch.
+- **Failed** — the last fetch errored; fix the page or URL and recrawl.
+- **Saved** — a text snippet or Q&A pair, stored exactly as you wrote it.
+- **Off** — a deactivated source; it stops informing answers until you switch it back on.
+
+Only website sources have a fetch lifecycle.
+
+## Turn good replies into knowledge
+
+When a teammate answers a visitor in the [team inbox](/features/team-inbox), that reply is often worth teaching the agent. Every teammate reply has an **Add to knowledge** action: it pre-fills a Q&A pair — the visitor's question and your answer, both editable — and saves it as a source in the project.
+
+Promoting the same reply twice never creates a duplicate, and sources created this way are labeled in the list so you can tell curated answers apart from hand-written ones. Any workspace member can promote a reply; adding and editing other sources is for admins and owners.
+
+## Manage sources in the dashboard
+
+The full walkthrough — adding each source type, the source list, Recrawl, and deletion — is in [Knowledge sources in the dashboard](/learn/sources), and the promote flow is part of the [inbox](/learn/inbox) workflow.
+
+<ThemedImage
+	alt="Knowledge sources in the dashboard"
+	basePath="/learn/sources"
+/>

--- a/apps/docs/content/features/meta.json
+++ b/apps/docs/content/features/meta.json
@@ -1,0 +1,15 @@
+{
+	"title": "Features",
+	"description": "What the support agent can do",
+	"icon": "Sparkles",
+	"pages": [
+		"index",
+		"ai-responses",
+		"knowledge-sources",
+		"escalation",
+		"email-threading",
+		"team-inbox",
+		"ratings-csat",
+		"self-hosting"
+	]
+}

--- a/apps/docs/content/features/ratings-csat.mdx
+++ b/apps/docs/content/features/ratings-csat.mdx
@@ -1,0 +1,51 @@
+---
+title: Ratings & CSAT
+icon: Star
+description: Two separate quality signals — thumbs on each answer, and a 1–5 CSAT score for the whole conversation
+---
+
+Clanker Support gives visitors two ways to tell you how it's going, and deliberately keeps them apart: a **thumbs up/down on each individual answer** the agent gives, and a **separate 1–5 CSAT rating for the whole conversation**. One measures answer quality, the other measures the overall experience — and neither is ever folded into the other.
+
+## Per-message thumbs: answer quality
+
+Every answer the agent streams into the widget carries small thumbs up/down controls. Visitors rate individual answers as they read them — no form, no interruption. They can change their mind: tapping the other thumb switches the rating, and tapping the same one again clears it.
+
+A few properties of this signal:
+
+- **It's per answer, not per conversation.** A visitor can mark one reply helpful and the next one not — which is exactly the granularity you want when deciding which answers to fix.
+- **Only the agent's answers are rateable.** Visitor messages and teammate replies don't take thumbs.
+- **It's actionable at the knowledge level.** A downvoted answer usually points at a gap or a stale entry in your [knowledge sources](/features/knowledge-sources); an upvoted one is worth capturing as a Q&A pair in your sources.
+
+In the dashboard, thumbs show up inside the conversation thread: each agent reply displays **Helpful**, **Not helpful**, or "Not rated" beneath its bubble. The rating is read-only for your team — it's the visitor's verdict, not something operators edit.
+
+<ThemedImage alt="Conversation thread" basePath="/learn/conversation-thread" />
+
+## Conversation CSAT: experience quality
+
+When a visitor closes the chat, the widget asks them to rate the conversation from **1 to 5**. This is a single score for the whole exchange — did they get what they came for? — and it's stored on the conversation, not on any message.
+
+A visitor can only rate their own conversation, and the widget only asks once — a rated conversation is never re-prompted. CSAT applies to the conversation regardless of who handled it: a thread the agent resolved alone and a thread your team took over after [escalation](/features/escalation) are both eligible.
+
+## Where each shows up in the dashboard
+
+| Signal          | Where you see it                                                                                      |
+| --------------- | ----------------------------------------------------------------------------------------------------- |
+| Thumbs          | In the thread view, under each agent answer — **Helpful**, **Not helpful**, or "Not rated"            |
+| CSAT            | In the conversation's details panel, as 1–5 stars (or "Not rated")                                    |
+| CSAT, aggregate | The inbox stats cards show **Avg rating** — the average CSAT across rated conversations, project-wide |
+
+The inbox average counts only conversation-level CSAT scores. Thumbs are never averaged into it.
+
+## Why they're kept separate
+
+Merging the two would destroy both signals. A visitor can rate three answers "not helpful" and still leave a 5-star CSAT because a teammate stepped in and fixed everything — that tells you the _handoff_ works but the _knowledge base_ has a gap. The reverse happens too: every answer was technically correct, but the visitor left a low CSAT because the experience was slow or frustrating.
+
+So use them for what they each measure:
+
+- **Thumbs** → tune the agent. Chase down the downvoted answers, fix or add sources, refine your instructions.
+- **CSAT** → track the outcome. Watch the inbox average as the health metric for the whole support experience.
+
+## Learn more
+
+- [Conversations](/learn/conversations) — reading thumbs in a thread and the CSAT stars in the details panel.
+- [Inbox](/learn/inbox) — the stats cards, including the project-wide average rating.

--- a/apps/docs/content/features/self-hosting.mdx
+++ b/apps/docs/content/features/self-hosting.mdx
@@ -1,0 +1,46 @@
+---
+title: Self-hosting
+description: Run the whole Clanker Support stack yourself — free, MIT-licensed, with your own keys
+icon: Server
+---
+
+Clanker Support is open source under the MIT license, and the entire product lives in one repository: [theopenco/llmchat](https://github.com/theopenco/llmchat). Self-hosting is free forever — you run the infrastructure, bring your own API keys, and pay your model provider directly. There is no feature-gated "community edition"; the code you deploy is the same code behind the hosted service.
+
+## What's in the box
+
+The monorepo contains everything the hosted service runs:
+
+- **API** — a Hono worker that serves the public chat endpoints, the dashboard API, webhooks, and the widget bundle itself at `/widget.js`.
+- **Dashboard** — the Next.js operator console: the shared inbox, project settings, knowledge sources, and billing.
+- **Marketing site** — the Next.js site behind [clankersupport.com](https://clankersupport.com), if you want it.
+- **Widget** — the embeddable script-tag bundle, built once and served by the API, so a self-hosted install still works with a one-line `<script>` tag pointed at your own API origin.
+- **Database** — a SQLite-compatible database (D1-style) with SQL migrations included; the deploy platform applies them automatically.
+
+One honest note on the runtime: the API is built to run on **workerd** via the [Ploy platform](https://docs.meetploy.com), not on a plain Node.js server. That's the deployment target the repo is set up for out of the box.
+
+## What you bring
+
+Three external services, only one of which is required:
+
+| Service         | Needed for                                           | Required?                        |
+| --------------- | ---------------------------------------------------- | -------------------------------- |
+| **LLM Gateway** | Inference — the API key the agent answers with       | Yes                              |
+| **Resend**      | Email — escalation notifications and reply threading | Only if you want email           |
+| **Stripe**      | Billing — metering and subscriptions                 | Only if you want to charge users |
+
+Inference goes through [LLM Gateway](https://llmgateway.io), so a single key gives your projects access to the model catalog, and usage is billed to your own account — Clanker Support takes no cut on a self-hosted install. Without Resend, chat and the inbox work fine; you just lose [escalation emails](/features/escalation) and [email threading](/features/email-threading). Stripe is entirely optional and only matters if you're running the stack as a service for others.
+
+## Self-host or hosted?
+
+Both run the same code; the difference is who operates it.
+
+- **Self-host** — free, MIT. You deploy and operate the stack, apply updates, and pay your model provider directly through your LLM Gateway key. Best when you want full control over data and infrastructure.
+- **Hosted** — we run everything at [app.clankersupport.com](https://app.clankersupport.com); you create a project and paste one script tag. Metered by AI responses, with unlimited human replies and no per-seat fees — see [Pricing](/pricing).
+
+Enterprise plans include a self-host support contract if you want the control of self-hosting with someone to call.
+
+## Setting it up
+
+The [GitHub README](https://github.com/theopenco/llmchat) is the canonical setup guide and stays current with the code — follow it rather than any copy of the steps here. In short, it walks you through installing dependencies, copying the example env file and filling in your keys, and starting the full stack with a single dev command; migrations apply automatically.
+
+Once your stack is up, everything in these docs applies unchanged — point the widget's `data-api` attribute (or the SDK's `apiUrl` prop) at your own API origin and continue with [Getting started](/getting-started) and the [dashboard guide](/learn).

--- a/apps/docs/content/features/team-inbox.mdx
+++ b/apps/docs/content/features/team-inbox.mdx
@@ -1,0 +1,55 @@
+---
+title: Team inbox
+description: Every conversation from every widget, in one shared inbox your whole team works from
+icon: Inbox
+---
+
+Every conversation your support agents handle — across every project in your workspace — lands in one shared inbox at [app.clankersupport.com](https://app.clankersupport.com). Your team triages, replies, and closes conversations from a single place; nothing lives in a visitor's browser tab or a teammate's private queue.
+
+<ThemedImage alt="The team inbox" basePath="/learn/inbox" />
+
+## Triage without opening threads
+
+The conversation list is built for scanning. Each row carries an **AI-generated triage summary** — a short recap of what the conversation is about, generated automatically (until one exists, the row shows the visitor's first message) — plus status badges (**Escalated**, **Resolved**), tag chips, and a message count. Open a thread and the same summary sits in the header, alongside a details panel with the visitor's contact info, CSAT rating, and tags.
+
+The full triage workflow is covered in [Inbox](/learn/inbox) and [Conversations](/learn/conversations).
+
+## Find anything
+
+Three ways to get to the right conversation:
+
+- **Filters** — narrow the list by status (Open, Resolved, Escalated) and by workspace tags; active filters show as a badge so a narrowed list is never a surprise.
+- **Full-text search** — the inbox search box matches visitor names, emails, and message text across the whole project, live as you type.
+- **⌘K command palette** — press **⌘K** (or **Ctrl+K**) anywhere in the dashboard to search every project in the workspace at once, and jump straight to a conversation or a project's settings.
+
+See [Search & command palette](/learn/search) for the details.
+
+## Organize with tags
+
+Tags are colored, workspace-level labels — "billing", "bug report", "VIP" — shared by every member. Any member can create and apply them; admins and owners can rename, recolor, or delete them for the whole workspace. Tags show as chips on inbox rows and double as a filter.
+
+See [Tags](/learn/tags).
+
+## Stay on top of new activity
+
+- **Per-user unread state** — each teammate has their own unread indicators: an unread conversation shows a dot and bold preview until _you_ open it, independent of whether a colleague already read it.
+- **Notification bell** — a workspace-wide feed of new conversations, escalations, and visitor replies, refreshed automatically while the dashboard is open. Click an entry to jump straight to the thread, whatever project it happened in.
+
+See [Notifications](/learn/notifications).
+
+## Close the loop
+
+From the thread header you can **Resolve** a conversation once it's handled and **Reopen** it if the visitor comes back — visitors can also mark their own conversation resolved from the widget, and the inbox tells you which side closed it. Conversations can also be deleted entirely (with confirmation) — deleting requires the admin or owner role.
+
+## Roles
+
+Every member has one role per workspace — **owner** > **admin** > **agent** — and the API enforces it server-side, deny by default. Agents work the inbox (read, reply, resolve, tag); admins additionally manage projects, knowledge, and tags; owners additionally control billing and the workspace itself. Permissions can't be bypassed by the UI.
+
+See [Workspaces & members](/learn/workspaces) for the full role table.
+
+## Learn more
+
+- [Inbox](/learn/inbox) — the list, filters, search, and stats cards
+- [Conversations](/learn/conversations) — the thread, replying, and promoting replies into knowledge
+- [Tags](/learn/tags) · [Search & command palette](/learn/search) · [Notifications](/learn/notifications)
+- [Escalation](/features/escalation) — how a conversation reaches the inbox as a human handoff

--- a/apps/docs/content/index.mdx
+++ b/apps/docs/content/index.mdx
@@ -1,12 +1,12 @@
 ---
-title: Welcome
+title: Introduction
 description: What Clanker Support is, how it fits together, and where to start in these docs
 icon: BookOpen
 ---
 
 Clanker Support is an AI-powered support agent for your site. You install it with a single script tag (or the React SDK), point it at your knowledge base — website pages, text snippets, Q&A pairs — and it answers visitor questions in a chat widget on your site. When a visitor needs a person, the agent hands the conversation off to your team, and every conversation lands in a shared inbox at [app.clankersupport.com](https://app.clankersupport.com).
 
-Clanker Support is open source ([theopenco/llmchat](https://github.com/theopenco/llmchat), MIT). You can self-host the whole stack, or use the hosted service — see [pricing](https://clankersupport.com/pricing) for plans.
+Clanker Support is open source ([theopenco/llmchat](https://github.com/theopenco/llmchat), MIT). You can self-host the whole stack for free with your own LLM Gateway key, or use the hosted service — see [Pricing](/pricing) for plans.
 
 ## What you get
 
@@ -14,7 +14,7 @@ Clanker Support is open source ([theopenco/llmchat](https://github.com/theopenco
 - **Escalation to humans** — the agent offers a handoff when it can't help; your team is notified by email (and Slack, if you add a webhook) and the agent stands down.
 - **A shared inbox** — search, filters, tags, and a reply composer; replies reach the visitor in the widget, and by email when they shared an address.
 - **Quality signals** — per-message thumbs up/down on answers, plus a separate 1–5 rating the visitor can leave for the conversation.
-- **Two install paths** — a one-line script tag, or the `@clankersupport/widget-rsc` React/Next.js SDK.
+- **Your choice of install path** — a one-line script tag, a React/Next.js SDK, and connectors for Shopify and WordPress.
 
 ## How it fits together
 
@@ -32,12 +32,21 @@ Once you've created a project, the whole install is one script tag with your pro
 ></script>
 ```
 
-Using React or Next.js? The `@clankersupport/widget-rsc` package gives you a `<ClankerSupport apiKey="pk_…" />` Server Component instead, restylable with CSS variables. Both paths — plus an inline iframe embed — are covered in [Getting started](/getting-started).
+Using React or Next.js? The `@clankersupport/widget-rsc` package gives you a `<ClankerSupport apiKey="pk_…" />` Server Component instead, restylable with CSS variables — see the [React SDK](/integrations/react-sdk).
+
+## Four ways to install
+
+- **[Script tag](/integrations/widget)** — one line, works on any site, no build step.
+- **[React SDK](/integrations/react-sdk)** — `@clankersupport/widget-rsc` on npm; a Server Component for the drop-in path, plus headless primitives when you want full control.
+- **[Shopify](/integrations/shopify)** — a theme app extension, coming soon to the Shopify App Store. Until then, Shopify merchants can paste the script tag into their theme.
+- **[WordPress](/integrations/wordpress)** — a plugin with a settings page and a `[clanker_support]` shortcode. The wordpress.org listing is on its way; today it installs as a manual plugin upload.
 
 ## How these docs are organized
 
 - **[Getting started](/getting-started)** — create your account and workspace, build your first agent, and install the widget on your site.
-- **[Learn](/learn)** — working in the dashboard: the inbox, escalation, tags and search, projects and widget settings, workspaces, and billing.
-- **[Knowledge sources](/learn/sources)** — teach the agent: add website, text, and Q&A sources, keep them fresh with Recrawl, and promote inbox replies into knowledge.
+- **[Pricing](/pricing)** — plans, included AI responses, overage, and what self-hosting costs (nothing).
+- **[Features](/features)** — what the product does: AI responses, knowledge sources, escalation, email threading, the team inbox, ratings, and self-hosting.
+- **[Integrations](/integrations)** — the four install paths in detail: script tag, React SDK, Shopify, and WordPress.
+- **[Dashboard](/learn)** — working in the dashboard: the inbox, escalation, tags and search, projects and widget settings, workspaces, and billing.
 
-If you get stuck, the **Help** button in the dashboard's top bar brings you back here.
+If you get stuck, use the **Help** button in the dashboard's top bar.

--- a/apps/docs/content/integrations/index.mdx
+++ b/apps/docs/content/integrations/index.mdx
@@ -1,0 +1,41 @@
+---
+title: Integrations
+description: Every way to put the support agent on your site
+icon: Blocks
+---
+
+Every integration is a different way to install the same support agent. Whatever the path, the widget talks to the same project — the same knowledge base, instructions, and AI model — and every conversation lands in the same shared [inbox](/learn/inbox). Pick the path that matches your stack; you can switch later without losing anything, because the project key is all any of them need.
+
+## The four paths
+
+| Integration                                   | Best for                                                                                | Status                                         |
+| --------------------------------------------- | --------------------------------------------------------------------------------------- | ---------------------------------------------- |
+| [Widget & iframe embed](/integrations/widget) | Any website — one script tag, no build step; iframe for site builders                   | Live                                           |
+| [React SDK](/integrations/react-sdk)          | React 19 / Next.js App Router apps that want a typed component and CSS-variable styling | Live on npm                                    |
+| [Shopify](/integrations/shopify)              | Shopify stores — app-embed block toggled on in the theme editor, zero permission scopes | Coming soon to the Shopify App Store           |
+| [WordPress](/integrations/wordpress)          | WordPress sites — settings-page install plus a shortcode for an inline chat             | Plugin ready; wordpress.org listing on its way |
+
+## Choosing a path
+
+- **Not sure? Start with the [script tag](/integrations/widget).** It works on any site that lets you add HTML, loads asynchronously, and renders in a shadow DOM so your site's CSS and the widget's never collide.
+- **On React or Next.js**, the [`@clankersupport/widget-rsc` SDK](/integrations/react-sdk) gives you a `<ClankerSupport apiKey="pk_…" />` Server Component for the root layout, plus headless primitives when you want to build your own chat UI.
+- **Can't add script tags at all?** The [iframe embed](/integrations/widget) serves the full chat as a page you can frame anywhere.
+- **On Shopify today**, paste the script tag into your theme — the app-embed install takes over once the App Store listing is live.
+- **On WordPress today**, install the plugin as a manual zip upload; the wordpress.org listing will make that one click.
+
+## The same agent, whichever path you pick
+
+The install path only changes how the widget gets onto the page. Everything the agent does is identical across all four:
+
+- **Answers** stream from the project's knowledge base and instructions — see [AI responses](/features/ai-responses) and [Knowledge sources](/features/knowledge-sources).
+- **Escalation** offers "Talk to a human" after the project's message threshold (or immediately when the visitor asks), notifies your team, and stands the agent down — see [Escalation](/features/escalation).
+- **Replies** from your team reach the visitor in the widget, and by email when they shared an address, with email replies threading back into the same conversation — see [Email threading](/features/email-threading).
+- **Quality signals** — per-message thumbs on answers and a separate 1–5 rating on the conversation — flow into the inbox either way; see [Ratings & CSAT](/features/ratings-csat).
+
+Branding follows the project too: brand color and welcome message are project settings. The script tag can override the brand color per page, and the React SDK can override both — the individual integration pages list the options.
+
+## What every path needs
+
+One thing: your project's **public key** (`pk_…`). You get it when you create a project, and it's always available under **Projects → your project → Widget** in the dashboard — see [Widget & embed settings](/learn/widget). The key is safe to expose in page source; it identifies the project, it doesn't grant dashboard access.
+
+Before installing, make sure the agent has something to answer from — add [knowledge sources](/learn/sources) and set the project's instructions. The [Getting started](/getting-started) guide walks through the whole flow from account to first conversation.

--- a/apps/docs/content/integrations/meta.json
+++ b/apps/docs/content/integrations/meta.json
@@ -1,0 +1,6 @@
+{
+	"title": "Integrations",
+	"description": "Every way to put Clanker Support on your site",
+	"icon": "Blocks",
+	"pages": ["index", "widget", "react-sdk", "shopify", "wordpress"]
+}

--- a/apps/docs/content/integrations/react-sdk.mdx
+++ b/apps/docs/content/integrations/react-sdk.mdx
@@ -1,0 +1,97 @@
+---
+title: React SDK
+description: Embed the support agent as a single React Server Component, or build your own UI with the headless entry
+icon: Atom
+---
+
+`@clankersupport/widget-rsc` is the Clanker Support widget as an npm package for React and Next.js apps. It's MIT-licensed, has zero runtime dependencies (React 19 is the only peer), and ships two entries: a batteries-included Server Component, and a headless entry with primitives and a hook for building your own UI.
+
+```sh
+npm install @clankersupport/widget-rsc
+```
+
+## One line in your root layout
+
+Add the component once — every page gets the widget. Grab your project's public key from the dashboard (**Project → Embed**):
+
+```tsx
+import { ClankerSupport } from "@clankersupport/widget-rsc";
+
+export default function RootLayout({ children }) {
+	return (
+		<html lang="en">
+			<body>
+				{children}
+				<ClankerSupport apiKey="pk_your_project_key" />
+			</body>
+		</html>
+	);
+}
+```
+
+`ClankerSupport` is an async Server Component: it prefetches your widget config on the server (cached, revalidated every 5 minutes), so the client saves a round-trip and branding never flashes. The fetch is wrapped in Suspense and fails soft — a slow or unreachable API never blocks or breaks your page. The public key is safe to expose; it's the same key the script tag uses.
+
+Mounting from a Client Component instead? Import `ClankerSupportWidget` from the `/headless` entry — the identical widget, with the config fetched client-side.
+
+## Props
+
+| Prop                  | Type                              | Default                          | What it does                                                         |
+| --------------------- | --------------------------------- | -------------------------------- | -------------------------------------------------------------------- |
+| `apiKey`              | `string` (required)               | —                                | Your project's public widget key.                                    |
+| `apiUrl`              | `string`                          | `https://api.clankersupport.com` | API origin. Point at your own deployment when self-hosting.          |
+| `brandColor`          | `string`                          | `#111827`                        | Accent color for the launcher, header, and visitor bubbles.          |
+| `position`            | `"bottom-right" \| "bottom-left"` | `"bottom-right"`                 | Which corner the widget docks to.                                    |
+| `title`               | `string`                          | `"Support"`                      | Panel header title.                                                  |
+| `greeting`            | `string \| null`                  | `"Hi! How can I help?"`          | Greeting bubble copy. Pass `null` to hide it.                        |
+| `escalationThreshold` | `number`                          | `3`                              | Visitor messages before **Talk to a human** appears.                 |
+| `defaultOpen`         | `boolean`                         | `false`                          | Open the panel on mount.                                             |
+| `className`           | `string`                          | —                                | Extra class on the fixed container — handy for CSS-variable theming. |
+
+## Styling
+
+Unlike the script tag, the SDK does **not** use a shadow DOM. Everything is plain, namespaced CSS — `.clanker-*` classes driven by `--clanker-*` custom properties — so your stylesheet wins:
+
+```css
+.clanker-root {
+	--clanker-brand: #16a34a;
+	--clanker-surface: #0b0f14;
+	--clanker-text: #e5e7eb;
+}
+.clanker-panel {
+	border-radius: 8px;
+}
+```
+
+If re-theming isn't enough, go headless.
+
+## Headless: bring your own UI
+
+`@clankersupport/widget-rsc/headless` exports `ClankerSupportProvider` (aliased as `Root`), the `useClankerSupport()` hook, and unstyled primitives: `Trigger`, `Panel`, `Messages`, `Composer`, `Input`, `Submit`, `EscalateButton`, `ResolveButton`, and `Branding`. Primitives render semantic elements with `data-*` state attributes, forward native props, and interactive ones support `asChild` (Radix-style) so you can swap in your own components. The client-rendered `ClankerSupportWidget` lives here too.
+
+```tsx
+"use client";
+
+import * as SupportChat from "@clankersupport/widget-rsc/headless";
+
+export function HelpButton() {
+	return (
+		<SupportChat.Root apiKey="pk_your_project_key">
+			<SupportChat.Trigger>Need help?</SupportChat.Trigger>
+			<SupportChat.Panel>
+				<SupportChat.Messages />
+				<SupportChat.Composer>
+					<SupportChat.Input placeholder="Ask anything…" />
+					<SupportChat.Submit>Send</SupportChat.Submit>
+				</SupportChat.Composer>
+				<SupportChat.Branding />
+			</SupportChat.Panel>
+		</SupportChat.Root>
+	);
+}
+```
+
+Prefer no components at all? `useClankerSupport()` exposes the full surface — `messages`, `status`, `send()`, draft state, `escalate()` / `resolve()` with their eligibility flags, `rate()` for per-message thumbs, CSAT submission, visitor `identify()`, and panel open state — so you can drive everything yourself.
+
+## SDK or script tag?
+
+Use the SDK when your site is React or Next.js and you want server-side config prefetch, CSS-level restyling, or a fully custom UI. Use the [script tag](/integrations/widget) everywhere else — it's one line of HTML, needs no build step, and its shadow DOM keeps host-page CSS out. The two share storage keys, so switching from the script tag to the SDK keeps existing visitor conversations and identities.

--- a/apps/docs/content/integrations/shopify.mdx
+++ b/apps/docs/content/integrations/shopify.mdx
@@ -1,0 +1,46 @@
+---
+title: Shopify
+description: Add the support agent to your storefront with a zero-permission theme app extension
+icon: ShoppingBag
+---
+
+The Clanker Support Shopify app is **coming soon to the Shopify App Store**. Until the listing is live, you can put the agent on any Shopify store today with the one-line script tag — see [Install today](#install-today-with-the-script-tag) below.
+
+## What the app does
+
+The app is a theme app extension: an **app embed** block that loads the widget on your storefront. Once it's available and installed, setup is two steps — no code, no theme edits.
+
+- **Zero permission scopes.** The app requests no access to your orders, customers, products, or anything else in your store. The only thing it stores is its own settings.
+- **Paste your project key.** Open the app in your Shopify admin and paste your project's public key on its settings page. That's the whole connection.
+- **Enable the app embed.** In the theme editor, open **App embeds**, switch on **Clanker Support**, and hit **Save**. App embeds are per theme, so enabling it on your live theme is one Save.
+- **The bubble appears on your storefront.** The widget script loads after the page has finished loading, so it never competes with your storefront's own resources or slows down what shoppers see first.
+- **Optional bubble color.** The embed block includes a bubble-color setting; leave it unset to use your project's default. (There's also an advanced project-key override, filled automatically when you connect the app.)
+- **Clean uninstall.** Removing the app removes the embed from your theme and clears the data the app stored.
+
+If you're already using the manual script tag when you switch to the app, the embed detects the existing snippet and won't mount a second bubble — one widget, never two.
+
+## Install today with the script tag
+
+Until the App Store listing is live, add the agent the same way as any other site: paste the script tag into your theme layout.
+
+1. In your Shopify admin, go to **Online Store → Themes**, open the **…** menu on your current theme, and choose **Edit code**.
+2. Open `layout/theme.liquid`.
+3. Paste the snippet just before the closing `</body>` tag, with your project's public key:
+
+```html
+<script
+	src="https://api.clankersupport.com/widget.js"
+	data-project="pk_…"
+	async
+></script>
+```
+
+4. Save. The bubble appears on every storefront page.
+
+The full attribute list — brand color, inline mode, escalation threshold — is on the [script tag](/integrations/widget) page.
+
+## Next steps
+
+- Don't have a project key yet? [Getting started](/getting-started) walks you through creating your first project.
+- Tune the agent's appearance — welcome message, brand color, position — in [widget settings](/learn/widget).
+- Teach the agent about your store by adding [knowledge sources](/features/knowledge-sources): your shipping and returns pages, product FAQs, and Q&A pairs.

--- a/apps/docs/content/integrations/widget.mdx
+++ b/apps/docs/content/integrations/widget.mdx
@@ -1,0 +1,78 @@
+---
+title: "Widget & iframe embed"
+description: One script tag for the floating bubble, or an iframe for an inline chat anywhere you can't add scripts
+icon: Code
+---
+
+The fastest way to put your support agent on a site: one `<script>` tag. It works on any stack — no build step, no framework, no dependencies. If you can't add script tags at all (some site builders, sandboxed pages), the iframe embed serves the same chat as a full page you can frame anywhere.
+
+## The script tag
+
+Paste this just before the closing `</body>` tag, with your project's public key:
+
+```html
+<script
+	src="https://api.clankersupport.com/widget.js"
+	data-project="pk_your_project_key"
+	async
+></script>
+```
+
+That's the whole install. The public key is safe to expose — it only identifies which project's agent answers. The dashboard generates this snippet with your key and brand color already filled in; see [where to find it](#copy-your-snippet-from-the-dashboard) below.
+
+## Data attributes
+
+The script tag is configured entirely through `data-*` attributes. This is the complete list:
+
+| Attribute                   | Default                               | What it does                                                               |
+| --------------------------- | ------------------------------------- | -------------------------------------------------------------------------- |
+| `data-project`              | — (required)                          | Your project's public key                                                  |
+| `data-api`                  | the origin the script was loaded from | API origin — only set this when self-hosting the API on a different domain |
+| `data-brand`                | `#111827`                             | Accent color for the launcher and chat header                              |
+| `data-mode`                 | `bubble`                              | `inline` renders the chat in-page instead of as a floating bubble          |
+| `data-escalation-threshold` | agent default (3)                     | Visitor messages before the widget offers **Talk to a human**              |
+
+Because `data-api` defaults to wherever `widget.js` was served from, a self-hosted install points at your own API automatically — no extra configuration.
+
+## Bubble vs inline
+
+- **Bubble** (the default) — a launcher in the bottom-right corner of every page the script is on. Visitors click it to open the chat panel. Recommended for site-wide support.
+- **Inline** (`data-mode="inline"`) — the chat renders in-page, always open, instead of as a floating bubble. For a chat pinned to a specific spot on a page — a contact page, a help center — use the [iframe embed](#the-iframe-embed).
+
+## Shadow-DOM isolation
+
+The widget mounts inside a shadow DOM, so it is fully isolated from the host page: your site's CSS can't restyle or break the chat, and the widget's styles never leak into your page. It ships as a single self-contained file — no external stylesheets or fonts to load.
+
+## The iframe embed
+
+`GET https://api.clankersupport.com/embed/{projectKey}` serves a full-page chat — the same widget in inline mode — designed to be iframed anywhere (the page explicitly allows framing by any site). Use it where script tags aren't an option:
+
+```html
+<iframe
+	src="https://api.clankersupport.com/embed/pk_your_project_key"
+	width="400"
+	height="600"
+	title="Support chat"
+	style="border: 0; border-radius: 12px;"
+	loading="lazy"
+></iframe>
+```
+
+The embed page reads your project's brand color and escalation threshold from its settings, so it stays in sync with the dashboard without any attributes. This is also what the [WordPress plugin's](/integrations/wordpress) `[clanker_support]` shortcode renders. You can open the URL directly in a browser to try your agent before installing anything.
+
+## Copy your snippet from the dashboard
+
+Open **Projects → your project → Widget** in the dashboard. The **Install** section generates both snippets — floating bubble and inline embed — with your public key and brand color pre-filled, next to the embed URL and a live preview.
+
+<ThemedImage
+	alt="Install snippet on the Widget tab"
+	basePath="/learn/embed-snippet"
+/>
+
+See [Widget & embedding](/learn/widget) for the full tour of the Widget tab, including appearance settings and the welcome message.
+
+## Other install paths
+
+- **React or Next.js?** Use the [React SDK](/integrations/react-sdk) — a Server Component instead of a script tag, restylable with CSS variables.
+- **Shopify** — a theme app extension is [coming soon to the App Store](/integrations/shopify); until then, paste the script tag into your theme.
+- **WordPress** — the [plugin](/integrations/wordpress) enqueues the widget for you and adds an iframe shortcode.

--- a/apps/docs/content/integrations/wordpress.mdx
+++ b/apps/docs/content/integrations/wordpress.mdx
@@ -1,0 +1,63 @@
+---
+title: WordPress
+description: The official plugin adds the widget to every public page of your WordPress site, plus an inline chat shortcode
+icon: Globe
+---
+
+The official WordPress plugin puts the support agent on your site without touching theme code. It loads the same `widget.js` embed the [script tag](/integrations/widget) uses — configured from a settings page in wp-admin instead of HTML — and adds a `[clanker_support]` shortcode for embedding the chat inline in any page or post.
+
+The wordpress.org listing is on its way. Today the plugin installs as a manual upload: a zip built from the plugin package in the GitHub repo.
+
+## Install
+
+1. Build the zip from [`packages/wordpress-plugin`](https://github.com/theopenco/llmchat/tree/main/packages/wordpress-plugin) in the repo — `pnpm package` there emits `dist/clanker-support-<version>.zip`.
+2. In wp-admin, go to **Plugins → Add New → Upload Plugin**, choose the zip, and activate.
+3. Copy your project's public key from the dashboard (**Projects → your project → Embed**).
+4. Go to **Settings → Clanker Support**, paste the key, and save.
+
+The launcher bubble now appears on every public page. Nothing loads in the admin area.
+
+## Settings
+
+Everything lives under **Settings → Clanker Support**:
+
+| Setting                  | Default                          | What it does                                                                               |
+| ------------------------ | -------------------------------- | ------------------------------------------------------------------------------------------ |
+| **Floating bubble**      | on                               | Shows the launcher bubble on every public page                                             |
+| **Project key**          | —                                | Your project's public key — the same key the script tag uses, safe to expose               |
+| **API URL**              | `https://api.clankersupport.com` | Point it at your own deployment if you [self-host](/features/self-hosting)                 |
+| **Brand color**          | `#111827`                        | Accent color for the launcher and chat                                                     |
+| **Escalation threshold** | project default                  | Messages before **Talk to a human** is offered — leave blank to use your project's setting |
+
+The settings page includes a **live connection check**: it verifies your project key against the API and shows a status pill, so a wrong key or API URL is flagged right on the page. The result is cached briefly; saving the settings re-checks.
+
+Under the hood, the plugin enqueues `<API URL>/widget.js` asynchronously with the same `data-*` attributes the dashboard's embed snippet generates — so everything on the [script tag](/integrations/widget) page about widget behavior applies here too.
+
+## Inline chat with the shortcode
+
+Add the shortcode to any page or post to render the chat inline:
+
+```
+[clanker_support]
+```
+
+It embeds the API's full-page chat (`/embed/{projectKey}`) in an iframe. Optional `width` and `height` attributes control the size (default 400×600):
+
+```
+[clanker_support width="500" height="700"]
+```
+
+The shortcode works independently of the floating-bubble toggle — you can turn the site-wide bubble off and still offer the chat on a single Contact page.
+
+## Requirements
+
+- WordPress 5.8 or newer
+- PHP 7.4 or newer
+
+The plugin is licensed GPLv2 or later. It stores only its settings (one option) and a short-lived connection-status cache (one transient) in WordPress — conversations live in your Clanker Support project, not your WordPress database. Uninstalling removes both stored values.
+
+## Next steps
+
+- Tune the agent's instructions, model, and knowledge base in [project settings](/learn/project-settings) and [knowledge sources](/learn/sources).
+- See how the handoff to your team works in [escalation](/features/escalation).
+- Triage conversations from your site in the [team inbox](/features/team-inbox).

--- a/apps/docs/content/learn/meta.json
+++ b/apps/docs/content/learn/meta.json
@@ -1,5 +1,5 @@
 {
-	"title": "Knowledge base",
+	"title": "Dashboard",
 	"description": "Learn how to use the Clanker Support dashboard",
 	"icon": "BookOpen",
 	"pages": [

--- a/apps/docs/content/meta.json
+++ b/apps/docs/content/meta.json
@@ -1,4 +1,13 @@
 {
 	"title": "Clanker Support",
-	"pages": ["index", "getting-started", "learn"]
+	"pages": [
+		"---Documentation---",
+		"index",
+		"getting-started",
+		"pricing",
+		"features",
+		"integrations",
+		"---Knowledge base---",
+		"learn"
+	]
 }

--- a/apps/docs/content/pricing.mdx
+++ b/apps/docs/content/pricing.mdx
@@ -1,0 +1,50 @@
+---
+title: Pricing
+description: Hosted plans, what counts as a response, and what each tier includes
+icon: CreditCard
+---
+
+Hosted Clanker Support is usage-based and **paid-only** — there is no free hosted tier. You pay for what the agent actually does: every **AI response** it sends counts toward your plan's monthly quota. Replies your teammates send from the inbox are human replies — they are never metered — and there are no per-seat fees. Prefer to run it yourself? [Self-hosting](/features/self-hosting) is free.
+
+## What counts as a response
+
+- One AI-generated answer in the widget = **one response**, recorded the moment it's produced.
+- Human replies from the [team inbox](/features/team-inbox) are unlimited and never counted.
+- The counter resets at the start of each calendar month (UTC).
+
+## Plans
+
+| Plan        | Monthly | Annual    | AI responses/mo | Projects | Seats     | Models      | Branding                |
+| ----------- | ------- | --------- | --------------- | -------- | --------- | ----------- | ----------------------- |
+| **Starter** | $19     | $190/yr   | 2,000           | 2        | 3         | Basic class | "Powered by" badge      |
+| **Growth**  | $89     | $890/yr   | 12,000          | 5        | 10        | All models  | No badge                |
+| **Scale**   | $299    | $2,990/yr | 50,000          | 20       | Unlimited | All models  | Custom branding allowed |
+
+Annual billing is 10× the monthly price — **two months free**.
+
+**Model access:** every project picks from a curated set of web-search-capable models. Starter is limited to the lighter "basic" class (mini/nano/haiku/flash/lite/small-class models); Growth and Scale unlock the full catalog. See [AI responses](/features/ai-responses).
+
+## What happens past the quota
+
+- **Starter** hard-stops: once the 2,000 included responses are used, the agent stops answering until the next month or an upgrade. Human replies keep working.
+- **Growth and Scale** meter overage: responses beyond the included quota are billed per additional response through Stripe, so the agent never goes dark mid-month. Your usage — including how far over you are — is visible on the billing page.
+
+## Enterprise
+
+Enterprise is sold, not self-served — [contact us](https://clankersupport.com/pricing) if you need:
+
+- Everything in Scale
+- Custom response volume & pricing
+- Unlimited projects & seats
+- SSO/SAML, audit logs & DPA
+- SLA + dedicated support channel
+- White-glove onboarding & migration
+- Self-host support contract
+
+## Self-hosting is free
+
+The entire stack is open source (MIT, [theopenco/llmchat](https://github.com/theopenco/llmchat)). Self-host it with your own LLM Gateway key — you pay your model provider directly, and nothing is metered by us. See [Self-hosting](/features/self-hosting).
+
+## Managing your plan
+
+You choose a plan during onboarding and manage it from the dashboard — usage meter, plan changes, invoices, and the Stripe billing portal all live at **Settings → Billing**. See [Billing & usage](/learn/billing) for the walkthrough, and the full pricing page at [clankersupport.com/pricing](https://clankersupport.com/pricing).

--- a/apps/docs/lib/get-llm-text.ts
+++ b/apps/docs/lib/get-llm-text.ts
@@ -1,0 +1,14 @@
+import type { source } from "@/lib/source";
+import type { InferPageType } from "fumadocs-core/source";
+
+const DOCS_URL = "https://docs.clankersupport.com";
+
+export async function getLLMText(page: InferPageType<typeof source>) {
+	const processed = await page.data.getText("processed");
+	// Root-relative markdown links would be resolved against whatever domain
+	// serves this text, so make them absolute docs URLs.
+	const absolute = processed.replace(/\]\((\/[^)\s]*)\)/g, `](${DOCS_URL}$1)`);
+	return `# ${page.data.title}
+URL: ${DOCS_URL}${page.url}
+${absolute}`;
+}

--- a/apps/docs/source.config.ts
+++ b/apps/docs/source.config.ts
@@ -4,6 +4,9 @@ export const { docs, meta } = defineDocs({
 	dir: "content",
 	docs: {
 		schema: frontmatterSchema,
+		postprocess: {
+			includeProcessedMarkdown: true,
+		},
 	},
 	meta: {
 		schema: metaSchema,


### PR DESCRIPTION
## What

Restructures the docs app's information architecture and adds AI-crawler endpoints, per the target structure (modeled on docs.llmgateway.io):

- **Introduction** (renamed from Welcome) → **Getting started** → **Pricing** → **Features** → **Integrations**, with the existing `/learn` pages grouped under a "Knowledge base" separator (folder retitled "Dashboard").
- **Pricing** — mirrors `BILLING_TIERS` exactly: Starter $19/2k (hard stop), Growth $89/12k + overage, Scale $299/50k + overage, annual = two months free, Enterprise contact tier, self-host free. No overage $ rate stated (lives in Stripe).
- **Features** (7 new pages) — AI responses, Knowledge sources, Escalation & human handoff, Email threading, Team inbox, Ratings & CSAT, Self-hosting.
- **Integrations** (4 new pages + hub) — Widget & iframe embed (complete data-attribute table from `packages/widget/src/config.ts`), React SDK (`@clankersupport/widget-rsc` — RSC one-liner + `/headless` API), Shopify (**coming soon to the App Store** — extension is merged but pre-submission), WordPress (**wordpress.org listing on its way** — manual zip install today).

## llms.txt / llms-full.txt

Ported from llmgateway's docs app (identical fumadocs 16.9.3 / fumadocs-mdx 15.0.12 / Next 16.2.7):

- `/llms.txt` — grouped page index with a key-facts header; **prices imported from `BILLING_TIERS`** so the file can never drift from what we charge.
- `/llms-full.txt` — full text of all 31 pages (~120 KB), root-relative links rewritten to absolute docs URLs.
- `/llms.mdx/[[...slug]]` — per-page markdown.
- Enabled via `postprocess: { includeProcessedMarkdown: true }` in `source.config.ts`.

## Fact-checking

Every new/rewritten page was adversarially verified against the repo (30-agent workflow); 17 findings fixed — notable: email is collected pre-chat (not during escalation), team escalation-notification emails are not reply-threaded (reworded to "reply from the inbox"), no separate Archive action exists, CSAT is ask-once, prompt library has no dashboard UI (removed from docs).

Follow-ups surfaced (not in this PR): dashboard Help button still links to clankersupport.com/docs instead of this app; prompt library is API-only.

## Test plan

- `pnpm --filter @llmchat/docs build` green (all routes prerender, llms routes static).
- `next start` + curl: `/llms.txt`, `/llms-full.txt`, `/llms.mdx/pricing` all render correctly.
- Internal-link check across all MDX: 0 broken; banned-wording sweep: clean.
- `tsc --noEmit`, oxlint, prettier: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CzYoZZ9RpvCpC5ZFyb2tCZ