### PR TITLE
feat(marketing): four SEO comparison posts for the Intercom-alternative query family

### DIFF
--- a/apps/marketing/content/blog/best-ai-support-agents.md
+++ b/apps/marketing/content/blog/best-ai-support-agents.md
@@ -1,0 +1,176 @@
+---
+title: "The best AI support agents in 2026 (real pricing compared)"
+description: "The best AI support agents in 2026, compared on real pricing — per-resolution vs per-seat vs flat, which LLM each tool runs on, and open-source options."
+date: "2026-07-07"
+category: "Guides"
+featured: false
+---
+
+The best AI support agents in 2026 are Fin (the strongest resolution engine, at $0.99 per outcome), Chatbase (model choice on a budget), Chatwoot (open-source omnichannel), and Clanker Support (our product: flat pricing from $19/mo, self-hostable, any LLM). The right pick mostly depends on how you'd rather pay — per resolution, per seat, or flat.
+
+Most "best AI support agent" lists are written for enterprise CX buyers: analyst quadrants, "contact sales" links, no actual prices. This one is different in three ways — every entry has a real dollar figure or an honest "they don't publish one," names which LLM it runs on and whether you can switch it, and open source gets a real section instead of a footnote.
+
+## What an AI support agent actually is
+
+An AI support agent reads your documentation, help center, and past answers, then writes original responses to customer questions — and escalates to a human when it can't answer.
+
+That's different from the decision-tree chatbot of the 2010s, which walked visitors through pre-scripted button flows ("Billing → Refunds → Here's an article"). A decision tree only handles paths someone built; an AI agent handles the long tail of oddly-phrased, never-seen-before questions that make up most of a real queue.
+
+The distinction matters for pricing too: bots were priced like software (flat or per seat); AI agents introduced per-resolution billing, turning a fixed cost into a variable one.
+
+## How we picked (and our bias, disclosed)
+
+Everything here comes from public pricing pages, vendor docs, and each vendor's own claims, checked July 2026. We didn't run a synthetic benchmark or "test each tool on 500 tickets" — nobody writing listicles does, and we won't pretend to. Prices change: treat every number as "as of July 2026" and check pricing pages before deciding.
+
+One more thing: **Clanker Support is our product.** It's on this list, it's not ranked #1, and its limits are listed next to its strengths. The other tools get their genuine wins.
+
+## The best AI support agents in 2026
+
+### 1. Fin — the resolution benchmark
+
+Fin is the agent everyone else measures against. It started as Intercom's AI product, ate the company (Intercom renamed itself Fin in May 2026), and in June 2026 Salesforce signed a definitive agreement to acquire it for roughly $3.6 billion (pending close). It works across chat, email, and phone, and runs standalone on top of Zendesk or Salesforce without Intercom seats.
+
+The catch is the meter. You pay $0.99 per "outcome," and outcomes include resolutions, procedure handoffs, and disqualifications — plus "assumed resolutions," where the customer simply stops replying. Qualification outcomes run $9.99 each, and there's a 50-outcome monthly minimum (about a $49 floor). To Fin's credit, it doesn't charge when a customer asks for a human. Full teardown: [Fin's pricing, explained](/blog/intercom-fin-pricing); head-to-head: [Clanker vs Fin](/vs/fin).
+
+- **Pricing:** $0.99 per outcome, $9.99 per qualification, ~$49/mo minimum; Intercom seats from $29/seat/mo billed annually
+- **Pricing model:** per resolution (usage-based)
+- **Underlying model / model choice:** Fin's own model, Apex, post-trained for support; no user-facing model switch
+- **Self-hostable:** no
+- **Best for:** high-volume teams that want maximum resolution rate and accept a variable bill
+
+### 2. Zendesk AI agents — for teams already on Zendesk
+
+For teams already on Zendesk, its built-in AI agents are the path of least resistance — same data, same workflows. AI agents are included in every Suite and Support plan, billed on "automated resolutions": you pay only when the AI resolves a request without human escalation.
+
+What Zendesk does not publish is the price per resolution. The pricing page lists seats ($19/agent/mo for Support Team, $55 for Suite Team, billed yearly), but the per-unit AI rate is behind "contact sales." Third-party teardowns in mid-2026 put it around $1.50–$2.00 per automated resolution, less with committed volume — treat that as reported, not confirmed.
+
+- **Pricing:** seats from $19/agent/mo (yearly); per-resolution rate not published (third-party estimates ~$1.50–$2.00)
+- **Pricing model:** per seat + per resolution
+- **Underlying model / model choice:** not disclosed; no user-facing model switch
+- **Self-hostable:** no
+- **Best for:** existing Zendesk shops that want AI without changing helpdesks
+
+### 3. Chatbase — model choice on a budget
+
+Chatbase is the pragmatic mid-market pick: build an agent on your content, deploy it to web, WhatsApp, Slack, or Messenger, and pick which LLM it runs on. There's a free plan (one agent, basic models) and paid plans from $40/mo on a credit system — read the fine print, because per Chatbase's docs premium models burn roughly 2–6 credits per message, so effective capacity depends on the model you pick. It's SOC 2 Type II certified and claims 10,000+ businesses.
+
+- **Pricing:** free plan; paid from $40/mo, credit-based
+- **Pricing model:** flat tiers with metered credits
+- **Underlying model / model choice:** yes — pick from OpenAI, Anthropic, Google, and others; heavier models consume more credits
+- **Self-hostable:** no
+- **Best for:** teams that want model flexibility and multi-channel reach without enterprise pricing
+
+Head-to-head: [Clanker vs Chatbase](/vs/chatbase).
+
+### 4. Tidio (Lyro) — SMB all-rounder on Claude
+
+Tidio is a long-running SMB live-chat suite, and Lyro is its AI agent — one of the few that publicly names its model: it runs on Anthropic's Claude — Tidio shipped one of the first Claude-powered support agents. Lyro answers on the web widget, email, Messenger, Instagram, and WhatsApp.
+
+Per Tidio's pricing page, the Lyro add-on starts at $32.50/mo for 50 AI conversations, on top of base plans from about $24/mo. Volume scales the bill quickly — the Plus tier starts at $749/mo — so model your volume before committing.
+
+- **Pricing:** Lyro add-on from $32.50/mo (50 AI conversations); base plans from ~$24/mo; high-volume tiers from $749/mo
+- **Pricing model:** flat tiers bucketed by conversation volume
+- **Underlying model / model choice:** Anthropic's Claude; not user-switchable
+- **Self-hostable:** no
+- **Best for:** small commerce teams that want chat, social channels, and AI in one tool
+
+### 5. Crisp — the European all-in-one
+
+Crisp bundles shared inbox, CRM, knowledge base, and chat into one flat-priced product with European hosting — relevant if GDPR data residency is on your checklist. The free plan covers two seats but no AI; AI features start on the Mini plan at roughly €45/mo, with Essentials at €95 and Plus at €295.
+
+- **Pricing:** free 2-seat plan (no AI); AI from ~€45/mo; Essentials €95, Plus €295
+- **Pricing model:** flat monthly
+- **Underlying model / model choice:** not disclosed; no user-facing switch
+- **Self-hostable:** no
+- **Best for:** European SMBs that want chat + CRM + AI in one flat-priced tool
+
+Feature-by-feature: [Clanker vs Crisp](/vs/crisp).
+
+### 6. eesel AI — pay-per-task on your existing helpdesk
+
+eesel takes the opposite approach to seats and subscriptions: since early 2026 it charges per task — $0.40 per support ticket, no platform fee, no per-seat fee, no monthly minimum, free until you've burned $50. It plugs into the helpdesk you already run (Zendesk, Freshdesk, Intercom, others) rather than replacing it. The model is abstracted away — you buy outcomes, not model access.
+
+- **Pricing:** $0.40 per ticket, no minimum; enterprise flat from $2,100/mo
+- **Pricing model:** per task (usage-based)
+- **Underlying model / model choice:** abstracted; no public model switch
+- **Self-hostable:** no
+- **Best for:** teams that want AI bolted onto an existing helpdesk with zero fixed cost
+
+### 7. Chatwoot — the open-source omnichannel suite
+
+Chatwoot is the biggest open-source helpdesk (34,000+ GitHub stars): a full omnichannel inbox — WhatsApp, Instagram, email, Telegram — you can self-host for free or use as a cloud service from $19/agent/mo. Its AI layer, Captain, has fine print: per Chatwoot's docs it requires the Enterprise edition with a paid plan even self-hosted, and you supply your own OpenAI-compatible API key (custom endpoints supported, so local models work). Self-hosting means running a Rails + PostgreSQL stack, with the maintenance that implies.
+
+- **Pricing:** self-hosted community edition free; cloud from $19/agent/mo; Captain (AI) needs a paid Enterprise plan
+- **Pricing model:** open source + per seat (cloud)
+- **Underlying model / model choice:** bring your own OpenAI-compatible key on self-hosted; endpoint is configurable
+- **Self-hostable:** yes
+- **Best for:** teams that want a full open-source helpdesk and have the ops capacity to run it
+
+Here's [Clanker vs Chatwoot](/vs/chatwoot) — short version: Chatwoot is a helpdesk with AI added; Clanker is an AI agent with an inbox added.
+
+### 8. Clanker Support — flat pricing, any LLM, self-hostable (ours)
+
+Full disclosure: this is our product, so weigh this entry accordingly. Clanker Support is an AI support agent you install with one `<script>` tag before `</body>` (plus a React Server Component SDK for Next.js 15+, a WordPress plugin on wordpress.org, and a Shopify theme embed). It answers only from the knowledge base you give it — page URLs, text snippets, Q&A pairs — cites its sources, and when it can't help, it tells the visitor honestly and hands off: your team gets an email (and optionally Slack), the conversation lands in a team inbox with AI-written summaries and tags, and replies thread through email both ways. A visitor who asks for a human always gets one.
+
+Three things define its lane. Pricing is flat — [plans from $19/mo](/pricing) (Growth $89, Scale $299, annual gets two months free), no per-seat or per-resolution fees, each tier with a monthly AI-response quota. It's model-agnostic — pick the LLM per project via LLM Gateway (OpenAI, Anthropic, Google, others) and swap with a config change, no code, no lock-in. And it's [open source](https://github.com/theopenco/llmchat) — self-hosting is free with your own LLM Gateway key, running serverless on Cloudflare-compatible infra with no Rails/Postgres stack to babysit.
+
+The honest limits: it covers the web widget and email only — no WhatsApp, Messenger, Instagram, or voice. There's no CRM, no product tours, no outbound campaigns. It's a newer product with a smaller ecosystem, and hosted has no free tier (self-hosting is the free path). [Try the live widget](https://showcase.clankersupport.com) before signing up for anything.
+
+- **Pricing:** flat from $19/mo; no per-seat or per-resolution fees; self-hosting free
+- **Pricing model:** flat monthly with an included response quota
+- **Underlying model / model choice:** yes — any LLM Gateway model, switchable per project with a config change
+- **Self-hostable:** yes (free, bring your own key)
+- **Best for:** developers and founders who want predictable cost, model control, and a five-minute install
+
+## What AI support actually costs at volume
+
+The pricing model matters more than the sticker price. Here's the same workload — 100, 1,000, and 10,000 AI-handled conversations a month — under each model. These are illustrative worked examples that assume every conversation counts as one billable unit.
+
+**Per resolution.** Fin at $0.99 per outcome: 100 conversations ≈ $99/mo, 1,000 ≈ $990/mo, 10,000 ≈ $9,900/mo — before any Intercom seats. eesel at $0.40 per ticket: $40, $400, and $4,000 (its flat $2,100/mo enterprise plan wins past ~5,250 tickets). Zendesk's reported ~$1.50–$2.00 band, if accurate, would put 1,000 resolutions at $1,500–$2,000 plus seats.
+
+**Per seat.** Your bill tracks headcount, not volume — Intercom from $29/seat/mo (annual) or Chatwoot cloud at $19/agent/mo. Cheap with a small team, but it buys human capacity, not AI resolutions — the AI meter usually sits on top.
+
+**Flat.** Tidio and Chatbase sell volume buckets — flat until you outgrow the bucket, then you step up (Tidio's steps get steep). Clanker's tiers are flat with an included quota, so 10,000 conversations costs whatever your tier costs, not tier × volume — see [/pricing](/pricing) for current quotas.
+
+The general rule: per-resolution pricing is fine at low volume and punishing at scale — it converts your best outcome (AI resolving more) into a bigger bill. Flat pricing inverts that: the more the agent resolves, the cheaper each resolution gets.
+
+## Which LLM does it run on — and can you switch?
+
+Worth asking before you sign: Fin runs its own post-trained model (Apex) with no switch. Zendesk and Crisp don't say. Tidio's Lyro runs on Claude, fixed. eesel abstracts the model entirely. Chatbase and Clanker let you choose — Chatbase across frontier models at varying credit costs, Clanker across any LLM Gateway model at no price difference. Chatwoot's self-hosted Captain takes whatever OpenAI-compatible key you give it. If a better support model ships next quarter, only the switchable tools let you use it the same day.
+
+## Open-source and self-hostable options
+
+If you need data control, no lock-in, or a $0 software bill, the field narrows fast. Chatwoot is the mature choice — a full omnichannel helpdesk — with the caveats above: Rails + Postgres to operate, and the AI layer paywalled behind Enterprise. Clanker Support is the lighter-weight one: the agent, widget, inbox, and email threading are all in [the repo](https://github.com/theopenco/llmchat), self-hosting is free with your own LLM key, and it deploys serverless. Papercups used to be the third name here, but development has slowed markedly. Longer list: our [open-source Intercom alternatives](/blog/open-source-intercom-alternatives) guide.
+
+## How to choose (and when to stay put)
+
+- **High volume and budget for the best resolution rate:** Fin — model the per-outcome bill first, including assumed resolutions.
+- **Already on Zendesk:** Zendesk AI — get the per-resolution rate in writing.
+- **Happy on Intercom today?** Stay. Migration costs are real, and the Salesforce deal doesn't change your product tomorrow. Switch when the meter outgrows the value — here's the [migration path](/docs/migrate/intercom) when it does.
+- **Want model choice with WhatsApp/Slack channels:** Chatbase.
+- **SMB commerce with social channels:** Tidio. **European all-in-one:** Crisp.
+- **Keep your helpdesk, add AI with zero fixed cost:** eesel.
+- **Full open-source helpdesk and ops capacity to run it:** Chatwoot.
+- **Flat predictable pricing, any LLM, one-tag install, or free self-hosting:** Clanker Support — as long as web + email covers your channels.
+
+## FAQ
+
+### How do AI support agents work?
+
+An AI support agent connects a large language model to your knowledge base — docs, help-center pages, Q&A pairs. When a visitor asks something, it retrieves relevant content, writes an answer grounded in it, and escalates to a human when confidence is low. Good ones cite sources instead of guessing.
+
+### How much does an AI support agent cost in 2026?
+
+Anywhere from $19/mo flat to thousands per month, depending on the pricing model. Per-resolution tools run $0.40 (eesel) to $0.99 (Fin) per conversation, so 1,000 resolutions cost $400–$990 a month. Flat-priced tools charge a fixed fee with an included quota. Self-hosted open-source tools cost only infrastructure plus your LLM API bill.
+
+### Can AI replace human support agents?
+
+Not fully, and tools that claim otherwise oversell. AI agents handle the repetitive majority — documented questions, order status, how-tos. Vendors publish resolution rates to make the case: Fin, for example, cites around 76% of volume for its Apex model, though these are vendor figures, not independent benchmarks. Refunds, edge cases, and angry customers still need humans. The practical goal is fewer tickets reaching people, with an honest handoff when they do.
+
+### What's the difference between a chatbot and an AI support agent?
+
+A chatbot follows pre-built decision trees — buttons and scripted flows that only cover paths someone designed. An AI support agent uses a language model to understand free-form questions and compose original answers from your documentation, escalating when it can't. Agents handle the unpredictable long tail; decision trees break on the first unexpected phrasing.
+
+### Do AI support agents work with an existing helpdesk?
+
+Many do. eesel and Fin sit on top of Zendesk, Salesforce, and similar helpdesks; Zendesk's AI is native to its own suite. Standalone agents like Chatbase and Clanker Support ship their own inbox instead — Clanker threads escalations through email both ways, so your team can work replies from any mailbox.

--- a/apps/marketing/content/blog/intercom-alternatives.md
+++ b/apps/marketing/content/blog/intercom-alternatives.md
@@ -1,0 +1,202 @@
+---
+title: "The best Intercom alternatives in 2026 (an honest comparison)"
+description: "Ten Intercom alternatives compared by pricing model — per-seat, per-resolution, flat monthly, and self-hosted — with honest cons and when to stay put."
+date: "2026-07-07"
+category: "Guides"
+featured: false
+---
+
+The best Intercom alternative depends on which pricing model you can live with: Zendesk or Freshdesk if you want a per-seat suite, Gorgias or Chatbase if usage-based billing fits your volume, Crisp or Clanker Support for flat monthly pricing, and Chatwoot if you want open source. Most teams leave over cost: seats from $29/month plus Fin's $0.99 per resolution.
+
+That is the short answer. The longer one: "best" is meaningless until you decide how you want to pay for support software, because the pricing model — not the feature checklist — determines what your bill looks like at 10x your current volume. So this guide groups the alternatives by pricing model.
+
+Two things up front. Disclosure: Clanker Support is our product; it sits in the flat-pricing section, is not ranked #1, and its weaknesses are listed as plainly as everyone else's. Methodology: this comparison is built from public pricing pages, docs, and each vendor's own claims, checked July 2026. Prices change — treat every number as "as of July 2026" and confirm on the vendor's pricing page.
+
+## Why teams are leaving Intercom in 2026
+
+Intercom renamed itself Fin in May 2026, after its AI agent, and on June 15, 2026 Salesforce signed a definitive agreement to acquire Fin for roughly $3.6 billion. The deal has not closed yet; an acquisition that size means roadmap and pricing uncertainty for at least a year.
+
+But the acquisition mostly accelerated a migration already underway, and the reason is the bill. Intercom runs two meters at once:
+
+- **Seats.** From $29 per seat per month on annual billing ($39 monthly), $85 ($99 monthly) for Advanced, $132 ($139 monthly) for Expert. Copilot, the AI assistant for your human agents, is another $29 per agent per month on annual billing.
+- **Fin resolutions.** Fin, the AI agent, costs $0.99 per "outcome" — a resolution, a procedure handoff, or a disqualification — plus $9.99 per qualification, with a 50-outcome monthly minimum (roughly a $49 floor). The detail that surprises people: "assumed resolutions," where the customer simply stops replying and leaves, are billable. Asking for a human is free.
+
+An illustrative worked example at those published rates: a five-person team on Advanced pays 5 × $85 = $425/month for seats, plus Copilot for everyone at 5 × $29 = $145. If Fin handles 600 billable outcomes that month, add $594. Total: about $1,164/month, roughly $14,000/year — and the Fin line grows with traffic, including conversations where the visitor just closed the tab. Full mechanics in [our Fin pricing teardown](/blog/intercom-fin-pricing).
+
+None of this makes Intercom bad. It makes it expensive with an unpredictable AI line item, which is what sends people searching.
+
+## How AI support pricing actually works in 2026
+
+Every vendor's pricing page looks different, but there are only four underlying models.
+
+- **Per-seat.** You pay per human agent per month (Zendesk, Freshdesk, Help Scout, Intercom's base plans). Predictable if headcount is stable — but in 2026 nearly every per-seat vendor has bolted a usage-priced AI meter on top, so you often pay both.
+- **Per-resolution / usage-based.** You pay per AI resolution, ticket, conversation, or credit (Fin, Gorgias, Tidio's Lyro, Chatbase, Zendesk's AI agents). Cheap at low volume — but the bill scales with traffic, is hard to forecast, and the vendor decides what counts as "resolved."
+- **Flat monthly.** A fixed subscription per workspace, regardless of seats (Crisp, Clanker Support). The number on the pricing page is the number on the invoice; tiers include a usage quota, so check your volume fits.
+- **Self-hosted open source.** The software is free (Chatwoot, Clanker Support's open-source edition); you pay in infrastructure and your own time, plus LLM API costs if you run an AI agent.
+
+The most common billing surprise in 2026 is the hybrid: per-seat base plan plus usage-priced AI add-on — two meters at once, the structure Intercom, Zendesk, Freshdesk, and Help Scout now share.
+
+## Per-seat suites: the classic helpdesks
+
+### Zendesk
+
+The default enterprise answer, and genuinely the deepest omnichannel suite on this list.
+
+- **Pricing:** Suite Team $55/agent/month, Suite Professional $115 on annual billing, as of July 2026; Copilot is a $50/agent/month add-on; AI agents bill separately per automated resolution, with no flat rate published on the pricing page
+- **Pricing model:** per seat, plus per-resolution AI on top
+- **Self-hostable:** no
+- **Model choice:** no — Zendesk's own AI stack
+- **Best for:** mid-size and large teams that need mature workflows, SLAs, a big marketplace, and every channel under one roof
+- **Honest cons:** both meters — seats and resolutions; admin configuration is a real job; the entry price is nearly double Intercom's
+
+### Freshdesk
+
+The budget per-seat suite. Same shape as Zendesk, lower sticker price.
+
+- **Pricing:** Growth $19/agent/month, Pro $55, Enterprise $89 on annual billing, as of July 2026, plus a limited free tier for 1–2 agents. The Freddy AI Agent includes 500 sessions on Pro and Enterprise, then $49 per 100 sessions; the Freddy Copilot add-on is priced separately.
+- **Pricing model:** per seat, plus AI sessions on top
+- **Self-hostable:** no
+- **Model choice:** no
+- **Best for:** teams that want a traditional ticketing suite at the lowest per-seat price, with room to grow into the wider Freshworks stack
+- **Honest cons:** the interesting AI is gated to Pro and above; AI sessions are yet another meter; breadth over depth across the product
+
+### Help Scout
+
+The shared-inbox veteran, loved for being simple where the suites are heavy.
+
+- **Pricing:** a free plan covers up to 5 users and 100 contacts/month; paid plans run Standard $25, Plus $45, and Pro $75 per user/month as of July 2026 (annual discounts apply). Its AI answers feature bills at $0.75 per resolution.
+- **Pricing model:** per seat, with per-resolution AI on top
+- **Self-hostable:** no
+- **Model choice:** no
+- **Best for:** small teams doing primarily email support who want a tool the whole team understands in an afternoon
+- **Honest cons:** the AI is newer and shallower than the AI-first products here — and adopting it imports the same per-resolution unpredictability you were fleeing at Intercom
+
+## Usage-based: pay per resolution, ticket, or conversation
+
+### Fin standalone
+
+The twist most listicles miss: you can keep Fin and drop Intercom. Fin works standalone on top of Zendesk or Salesforce, no Intercom seats required.
+
+- **Pricing:** $0.99 per outcome (resolution, procedure handoff, or disqualification), $9.99 per qualification, 50-outcome monthly minimum — roughly a $49 floor — as of July 2026
+- **Pricing model:** pure per-resolution
+- **Self-hostable:** no
+- **Model choice:** no — Fin runs on its proprietary Apex model
+- **Best for:** teams already on Zendesk or Salesforce that want the highest-profile resolution engine without Intercom's suite
+- **Honest cons:** assumed resolutions (the visitor leaves without replying) are billable; the bill scales with traffic; the pending Salesforce acquisition makes long-term pricing a guess
+
+### Gorgias
+
+The ecommerce specialist. Charges per ticket, not per agent — unlimited seats on every plan.
+
+- **Pricing:** Starter $10/month for 50 tickets, Basic $50–60 for 300, Pro $300–360 for 2,000, Advanced $750–900 for 5,000 (lower figures are annual), as of July 2026. Its AI agent bills separately at $0.90–1.00 per automated interaction — and those interactions also count as tickets.
+- **Pricing model:** per ticket, plus per-AI-interaction
+- **Self-hostable:** no
+- **Model choice:** no
+- **Best for:** Shopify and ecommerce brands — the order-management integrations are the point
+- **Honest cons:** built for ecommerce, awkward outside it; two usage meters at once; per-ticket pricing punishes high-volume, low-value contact patterns
+
+### Tidio
+
+SMB live chat with an AI agent (Lyro) bolted on as a metered add-on.
+
+- **Pricing:** free plan with 50 conversations; Starter from about $24/month and Growth from about $49/month on annual billing; the Lyro AI add-on starts around $32.50/month for 50 AI conversations; Plus starts at $749/month, as of July 2026
+- **Pricing model:** tiered conversation quotas, plus a separate AI-conversation quota
+- **Self-hostable:** no
+- **Model choice:** no
+- **Best for:** small ecommerce and SMB sites that want chat plus basic automation running today
+- **Honest cons:** multiple separately-billed quotas (conversations, Lyro conversations, automation triggers); the jump from Growth (~$49) to Plus ($749) strands scaling teams in between
+
+### Chatbase
+
+An AI-agent builder rather than a helpdesk: train an agent on your docs, deploy it across channels.
+
+- **Pricing:** free plan (1 agent, basic models); paid plans from $40/month on a credit-based system, as of July 2026
+- **Pricing model:** subscription tiers with usage credits
+- **Self-hostable:** no
+- **Model choice:** yes — you can pick between multiple LLMs
+- **Best for:** getting a capable AI agent onto web, WhatsApp, Slack, and Messenger fast, with SOC 2 Type II compliance; it claims 10,000+ businesses
+- **Honest cons:** an agent platform, not a support inbox — human handoff and team triage are thin compared to helpdesks; credits are one more meter to watch
+
+We compare it to our own approach in [Clanker Support vs Chatbase](/vs/chatbase).
+
+## Flat monthly pricing: predictable bills
+
+### Crisp
+
+The all-in-one European contender: chat, CRM, knowledge base, and campaigns in one box, priced per workspace instead of per seat.
+
+- **Pricing:** a free 2-seat plan (no AI); AI-inclusive plans from roughly €45/month (Mini), with Essentials at €95 and Plus at €295 per workspace, as of July 2026
+- **Pricing model:** flat monthly, per workspace
+- **Self-hostable:** no
+- **Model choice:** no
+- **Best for:** SMBs that want chat, a lightweight CRM, and a knowledge base on one bill, with European hosting
+- **Honest cons:** the AI is younger than the dedicated AI-first products; tier jumps are chunky; all-in-one breadth means some modules are shallow
+
+### Clanker Support
+
+Our product, so read this section knowing who wrote it. Clanker Support is an AI support agent installed with one script tag: it answers only from your knowledge base (page URLs, text snippets, Q&A pairs), cites its sources, and when it cannot help — or a visitor asks for a human — it hands off honestly: email and optional Slack notification, conversation landing in a team inbox, replies threading through email both ways. There is also a React Server Component SDK, a WordPress plugin, and a Shopify theme embed.
+
+- **Pricing:** flat plans from $19/month (Starter), $89 (Growth), $299 (Scale); annual gives two months free; no per-seat fees, no per-resolution fees — each tier includes a monthly AI-response quota, detailed on the [pricing page](/pricing)
+- **Pricing model:** flat monthly
+- **Self-hostable:** yes — [open source](https://github.com/theopenco/llmchat), free to self-host with your own LLM Gateway key, running serverless on Cloudflare-compatible infrastructure with no Rails-and-Postgres stack to babysit
+- **Model choice:** yes — pick the LLM per project (OpenAI, Anthropic, Google, and others) and swap it with a config change, no code change
+- **Best for:** SaaS and developer-led teams that want a predictable bill, grounded answers with citations, and a clean human handoff
+- **Honest cons:** web widget and email only — no WhatsApp, Messenger, Instagram, or voice; no CRM, product tours, or outbound campaigns; it is a newer product with a small ecosystem; and the hosted version has no free tier (self-hosting is the free path)
+
+The [Intercom migration guide](/docs/migrate/intercom) covers the move step by step; the [live demo](https://showcase.clankersupport.com) runs the real widget, not a mockup; and [Clanker Support vs Intercom](/vs/intercom) has the feature-by-feature breakdown.
+
+## Open source and self-hosted
+
+### Chatwoot
+
+The established open-source support platform, and the right default if omnichannel on your own infrastructure is the requirement.
+
+- **Pricing:** the community edition is free to self-host; the paid cloud starts at $19/agent/month, as of July 2026
+- **Pricing model:** free self-hosted, or per-seat cloud
+- **Self-hostable:** yes — a Rails + PostgreSQL stack you operate yourself
+- **Model choice:** not the core pitch — Chatwoot is inbox-first, not AI-first
+- **Best for:** WhatsApp, Instagram, Telegram, and email in one self-hosted inbox with full data ownership; real momentum, with 34,000+ GitHub stars as of July 2026
+- **Honest cons:** you are signing up to run and upgrade a Rails and Postgres deployment; AI capabilities are lighter than the AI-first agents here
+
+Clanker Support also belongs in this category — same open-source, self-host-for-free deal, but AI-agent-first and serverless rather than inbox-first on Rails. Opposite trade-offs, unpacked in [Clanker Support vs Chatwoot](/vs/chatwoot) and our [open-source Intercom alternatives guide](/blog/open-source-intercom-alternatives).
+
+## When to stay on Intercom
+
+An honest comparison owes you this section. Intercom (now Fin) is still the right choice if:
+
+- **You live on channels nobody here covers as well.** Fin runs across live chat, email, WhatsApp, SMS, phone, and Slack. If voice and WhatsApp are core channels, most alternatives on this list — ours included — do not compete.
+- **Resolution economics favor you.** If Fin genuinely deflects a large share of your volume, $0.99 per resolution can beat the agents you would otherwise hire. Per-resolution pricing is bad when unpredictable, not when high-deflection and measured.
+- **You use the whole platform.** Product tours, outbound messages, and campaigns are real products; replacing Intercom with three tools plus glue code changes the math.
+- **Switching costs exceed the savings.** A large team with years of macros and reporting should price the migration honestly first.
+
+If none of those describe you — mostly web and email support, modest or spiky volume, paying for seats and resolutions you barely use — that is exactly the profile that leaves.
+
+## How to choose
+
+- **1–5 people, early-stage SaaS:** minimize the floor and the variance. A flat plan (Clanker Support from $19/month, Crisp from ~€45) or a free tier (Chatbase, Tidio, Help Scout) gets you live without a usage meter to babysit.
+- **Ecommerce:** Gorgias on Shopify for deep order integrations; Tidio for lighter chat automation.
+- **10+ agents, many channels:** Zendesk or Freshdesk, eyes open about the AI add-on meters; consider Fin standalone on Zendesk if raw deflection is the goal.
+- **Data ownership or compliance:** self-host — Chatwoot for omnichannel inbox depth, Clanker Support for an AI-first agent on serverless infrastructure.
+- **You mainly want the AI to answer well and hand off cleanly:** compare the AI-first products directly in our [best AI support agents guide](/blog/best-ai-support-agents).
+
+## FAQ
+
+### Is there a free alternative to Intercom?
+
+Yes, several. Crisp has a free 2-seat plan (without AI), Chatbase and Tidio have free tiers, and Help Scout's free plan covers up to 100 contacts a month. For a permanently free option with full features, self-host an open-source tool: Chatwoot's community edition or Clanker Support's open-source edition, where you bring your own LLM key.
+
+### Why is Intercom so expensive?
+
+Because two meters run at once. You pay per seat ($29–132 per agent per month on annual billing, as of July 2026), then Fin bills $0.99 for every resolution on top, with a 50-outcome monthly minimum. Copilot for human agents is another $29 per agent. Each line looks reasonable; the compounding is what shocks people at invoice time.
+
+### What counts as a Fin resolution?
+
+Fin bills $0.99 per "outcome": a resolution, a procedure handoff, or a disqualification, with qualifications billed at $9.99. Crucially, "assumed resolutions" — where the customer leaves without replying — are billable. You are not charged when a customer asks for a human. There is a 50-outcome monthly minimum, roughly a $49 floor, as of July 2026.
+
+### What is the best open-source Intercom alternative?
+
+Chatwoot is the established choice: an omnichannel inbox (WhatsApp, Instagram, Telegram, email) with 34,000+ GitHub stars, self-hosted on Rails and PostgreSQL. Clanker Support — our product — is the AI-agent-first alternative: serverless, model-agnostic, one-script install. Pick Chatwoot for channel breadth, Clanker Support if the AI agent and a predictable bill are the point.
+
+### What is the best Intercom alternative for early-stage SaaS?
+
+Prioritize a low, fixed floor over features you will not use yet. Flat-priced tools (Clanker Support from $19/month, Crisp from about €45/month as of July 2026) keep the bill predictable while volume is spiky. If WhatsApp or Instagram support is essential from day one, look at Chatwoot or Crisp instead — the AI-first agents, ours included, skip those channels.

--- a/apps/marketing/content/blog/intercom-fin-pricing.md
+++ b/apps/marketing/content/blog/intercom-fin-pricing.md
@@ -22,7 +22,7 @@ As of July 2026, per [fin.ai/pricing](https://fin.ai/pricing):
 - **Human handoffs: free, mostly.** Per fin.ai/pricing: "You're not charged when a conversation is simply passed to your team without an outcome." The exception is a procedure you deliberately configured to end in a handoff — that is billable.
 - **Billed once per conversation.** However many questions Fin answers in one thread, it charges at most one outcome for it.
 - **No seat requirement for Fin itself.** Fin runs standalone on Zendesk, Salesforce, and other helpdesks without Intercom seats, with no setup or platform fees.
-- **Intercom seats (if you use their helpdesk): Essential $29** per seat per month billed annually ($39 monthly), **Advanced $85** ($99 monthly), **Expert $132** ($139 monthly), as of July 2026. The pricing page now routes you through a calculator rather than a flat price list, so confirm against your own configuration and [Intercom's pricing FAQs](https://www.intercom.com/help/en/articles/8344190-intercom-pricing-faqs).
+- **Intercom seats (if you use their helpdesk): Essential $29** per seat per month billed annually ($39 monthly), **Advanced $85** ($99 monthly), **Expert $132** ($139 monthly), as of July 2026. The pricing page now routes you through a calculator rather than a flat price list, so confirm against your own configuration on [Intercom's pricing page](https://www.intercom.com/pricing).
 
 ## What counts as a billable outcome — the fine print
 
@@ -85,7 +85,7 @@ The second-order problem is forecastability. Your bill is a function of ticket v
 
 ## The Salesforce acquisition: what it means if you're deciding now
 
-The corporate facts, since most pricing explainers bury them: Intercom renamed itself Fin earlier in 2026, and on June 15, 2026, [Salesforce signed a definitive agreement to acquire Fin](https://www.salesforce.com/news/press-releases/2026/06/15/salesforce-signs-definitive-agreement-to-acquire-fin/) for approximately $3.6 billion, as covered by [TechCrunch](https://techcrunch.com/2026/06/15/salesforce-acquires-ai-customer-service-platform-fin-for-3-6b/) among others. The deal is expected to close in the final quarter of Salesforce's fiscal 2027 — around the turn of the calendar year — pending regulatory clearance. Salesforce says Fin's team and technology will complement Agentforce, its AI-agent platform. Fin's CEO and co-founder Eoghan McCabe has said he will stay on and that little will change operationally for existing customers in the near term.
+The corporate facts, since most pricing explainers bury them: Intercom renamed itself Fin earlier in 2026, and on June 15, 2026, [Salesforce signed a definitive agreement to acquire Fin](https://www.salesforce.com/news/press-releases/2026/06/15/salesforce-signs-definitive-agreement-to-acquire-fin/) for approximately $3.6 billion, [confirmed on Intercom's own blog](https://www.intercom.com/blog/salesforce-signs-definitive-agreement-to-acquire-fin/). The deal is expected to close in the final quarter of Salesforce's fiscal 2027 — around the turn of the calendar year — pending regulatory clearance. Salesforce says Fin's team and technology will join Agentforce, its AI-agent platform. Fin's CEO and co-founder Eoghan McCabe said he will stay on and that, with Salesforce's resources, "little will practically change."
 
 We won't speculate beyond that, and you should be wary of competitors who do. But if you are signing a contract today, three questions are legitimately on the table, acquisition or not:
 

--- a/apps/marketing/content/blog/intercom-fin-pricing.md
+++ b/apps/marketing/content/blog/intercom-fin-pricing.md
@@ -1,0 +1,150 @@
+---
+title: "Intercom Fin pricing in 2026: the real math behind $0.99"
+description: "A primary-source teardown of Intercom Fin's $0.99-per-resolution pricing: billable outcomes, assumed resolutions, seat costs, and the real monthly math."
+date: "2026-07-07"
+category: "Guides"
+featured: false
+---
+
+Intercom Fin costs $0.99 per outcome — a resolution, a configured procedure handoff, or a lead disqualification — plus $9.99 per qualification, with a 50-outcome monthly minimum on non-Intercom helpdesks (about $49.50). Intercom seats stack on top, from $29 to $132 per seat per month on annual billing. Volume, not seats, drives the bill.
+
+That is the one-paragraph answer. The rest of this post is the line-by-line version: what the fine print actually says, what stacks on top, and what two realistic teams would pay. Everything here was checked in July 2026 against the vendor pages and pricing calculator — [fin.ai/pricing](https://fin.ai/pricing), [intercom.com/pricing](https://www.intercom.com/pricing), and both companies' help centers — not against other vendors' blog posts, which is where most Fin pricing explainers get their numbers. Prices change; treat the vendor pages as the source of truth and this post as the map.
+
+One disclosure up front: we build [Clanker Support](/pricing), a flat-priced, open-source AI support agent. We compete with Fin in one lane and not in several others, and we'll be explicit about which is which.
+
+## Fin pricing at a glance
+
+As of July 2026, per [fin.ai/pricing](https://fin.ai/pricing):
+
+- **Per outcome: $0.99.** An outcome is a resolution, a procedure handoff (a workflow you configured to end with a human), or a disqualification (Fin decides a prospect doesn't meet your criteria).
+- **Per qualification: $9.99.** When Fin matches a prospect to your qualification criteria and routes them, that single outcome costs ten times a resolution.
+- **Monthly minimum: 50 outcomes** when running Fin on a non-Intercom helpdesk — roughly a $49.50 floor at $0.99 each. Intercom's own pricing page confirms a "minimum monthly commitment" applies to standalone Fin.
+- **Human handoffs: free, mostly.** Per fin.ai/pricing: "You're not charged when a conversation is simply passed to your team without an outcome." The exception is a procedure you deliberately configured to end in a handoff — that is billable.
+- **Billed once per conversation.** However many questions Fin answers in one thread, it charges at most one outcome for it.
+- **No seat requirement for Fin itself.** Fin runs standalone on Zendesk, Salesforce, and other helpdesks without Intercom seats, with no setup or platform fees.
+- **Intercom seats (if you use their helpdesk): Essential $29** per seat per month billed annually ($39 monthly), **Advanced $85** ($99 monthly), **Expert $132** ($139 monthly), as of July 2026. The pricing page now routes you through a calculator rather than a flat price list, so confirm against your own configuration and [Intercom's pricing FAQs](https://www.intercom.com/help/en/articles/8344190-intercom-pricing-faqs).
+
+## What counts as a billable outcome — the fine print
+
+The number that actually determines your bill is not $0.99. It is your **outcome rate**: what fraction of AI conversations end in a state Fin counts as billable. That definition lives in the help center, and it is worth quoting.
+
+Per [Fin's pricing-outcomes article](https://fin.ai/help/en/articles/13975800-fin-pricing-outcomes), a resolution is counted when the customer either "confirms the answer was satisfactory (confirmed resolution), or exits the conversation without requesting further assistance (assumed resolution)." And the window: "If a customer disengages from the conversation for 24 hours after Fin's last answer, it is considered an assumed resolution."
+
+Read that twice. **Silence is billable.** A customer who reads Fin's answer and closes the tab — satisfied, unsatisfied, or merely gone — counts as a resolution after 24 hours. This is the single most important line in Fin's pricing, and it is the one the $0.99 headline doesn't tell you. It is also the mechanic nearly every third-party Fin pricing explainer singles out, because it is the part customers say surprised them at invoice time.
+
+In fairness, the fine print also contains genuinely pro-customer carve-outs, and most teardowns skip these too:
+
+- **The clarifying-question exception.** If Fin's last message was a question rather than an answer and the customer never responds, "no resolution state is recorded and this is not a billable outcome."
+- **The return deduction.** If a resolved conversation is reopened by the customer "even across billing periods, that resolution will be deducted and not charged."
+- **Default escalations are free.** Handoffs triggered by Fin's default behavior or workspace rules aren't billed — only handoffs you explicitly built as procedures are.
+
+So the honest summary: the definitions are reasonable and the carve-outs are real, but the assumed-resolution mechanic means your bill is decided partly by customer behavior you can't observe, using a counter you don't control.
+
+## What stacks on top
+
+Fin's per-outcome fee is the metered part. If your team also works inside Intercom's helpdesk, seats stack on top — as of July 2026, that's $29/$85/$132 per seat per month on annual billing (Essential/Advanced/Expert), or $39/$99/$139 monthly.
+
+Then the add-ons, per [intercom.com/pricing](https://www.intercom.com/pricing):
+
+- **Copilot** — the AI assistant for your human agents, distinct from Fin — is **$29 per agent per month billed annually** ($35 monthly) for unlimited usage, beyond a small free allowance of 10 Copilot conversations per agent per month.
+- **Proactive Support Plus** is **$99/month** with 500 messages included.
+- A **$99/month** conversation-analysis add-on includes 1,000 analyses monthly.
+- Email campaigns, SMS, WhatsApp, and phone are **pay-as-you-go** on top.
+
+None of these are hidden — they're on the pricing page. But "from $0.99 per resolution" and "what a 10-person support org pays Intercom per month" are very different numbers, which is why the next section does the arithmetic.
+
+## The math: two illustrative teams
+
+These are worked examples, not benchmarks — the assumptions are stated so you can rerun them with your own numbers. The key variable is the billable-outcome rate: the share of AI conversations that end in a confirmed resolution, an assumed resolution, or a configured handoff. We'll bracket it at 50–70%, on the assumption that the remainder escalate by default (free) or end on an unanswered clarifying question (free).
+
+### A 2-person team at 300 AI conversations a month
+
+- Outcomes: 150 to 210 conversations × $0.99 = **$148.50 to $207.90**
+- Seats: 2 × $29 (Essential, annual) = **$58**
+- Total: **$206.50 to $265.90 per month**
+- With Copilot for both agents (2 × $29 = $58): **$264.50 to $323.90 per month**
+
+Effective cost lands around $0.69 to $1.08 per AI-handled conversation once seats are included. At this scale Fin is not outrageous — the metered model is arguably at its best here, because a low-volume month produces a low bill (down to the ~$49.50 floor on standalone deployments).
+
+### A 10-person team at 2,000 AI conversations a month
+
+- Outcomes: 1,000 to 1,400 × $0.99 = **$990 to $1,386**
+- Seats: 10 × $85 (Advanced, annual) = **$850**
+- Copilot: 10 × $29 = **$290**
+- Total: **$2,130 to $2,526 per month**, or roughly **$25,600 to $30,300 per year**
+
+Note what happened between the two examples: conversation volume grew about 6.7×, and the bill grew roughly 8× to 10× depending on configuration. Metered pricing plus per-seat pricing compounds. And this is before pay-as-you-go channels or the $99 add-ons.
+
+## Why the bill grows when the AI gets better
+
+Per-outcome pricing has a clean sales pitch: you only pay when the AI succeeds. That alignment is real, and it deserves credit — a vendor that only earns on resolutions is motivated to resolve.
+
+But follow the incentive one step further. Every improvement you make — a better knowledge base, tighter procedures, each model upgrade Fin ships — raises the resolution rate, and the resolution rate is the billing rate. The reward for doing support well is a larger invoice. Under a flat or quota model, deflection improvements accrue to you; under per-resolution pricing, they're split with the vendor, indefinitely.
+
+The second-order problem is forecastability. Your bill is a function of ticket volume (seasonal, launch-driven, outage-driven) multiplied by an outcome rate that depends on Fin's own judgment calls and on the 24-hour silence rule. Finance teams can budget seats. Budgeting "how often will customers not reply to the bot" is harder. This isn't an accusation of bad faith — it is simply what the model does, and you should price it with your growth curve in mind, not your current one.
+
+## The Salesforce acquisition: what it means if you're deciding now
+
+The corporate facts, since most pricing explainers bury them: Intercom renamed itself Fin earlier in 2026, and on June 15, 2026, [Salesforce signed a definitive agreement to acquire Fin](https://www.salesforce.com/news/press-releases/2026/06/15/salesforce-signs-definitive-agreement-to-acquire-fin/) for approximately $3.6 billion, as covered by [TechCrunch](https://techcrunch.com/2026/06/15/salesforce-acquires-ai-customer-service-platform-fin-for-3-6b/) among others. The deal is expected to close in the final quarter of Salesforce's fiscal 2027 — around the turn of the calendar year — pending regulatory clearance. Salesforce says Fin's team and technology will complement Agentforce, its AI-agent platform. Fin's CEO and co-founder Eoghan McCabe has said he will stay on and that little will change operationally for existing customers in the near term.
+
+We won't speculate beyond that, and you should be wary of competitors who do. But if you are signing a contract today, three questions are legitimately on the table, acquisition or not:
+
+- **Pricing continuity.** Nothing published promises today's $0.99 survives the integration; nothing says it won't. Ask for term protection in writing if it matters to you.
+- **Roadmap gravity.** Post-close, Fin's roadmap presumably bends toward Agentforce and the Salesforce ecosystem. If you're a Salesforce shop, that may be good news. If you're not, ask where standalone deployments sit in the plan.
+- **Contract length.** An annual commitment signed now matures inside someone else's integration timeline. Shorter terms buy optionality.
+
+## Three ways to price an AI support agent
+
+Most "Fin alternatives" posts pitch the same model at a lower unit price. The more useful comparison is between models, because the model determines how your costs behave as you grow.
+
+- **Per resolution (Fin's model).** Lowest floor, aligned incentives, unbounded ceiling. Best when volume is low or spiky and you want to pay nothing for a quiet month. Worst when the AI works, because success is metered.
+- **Cheaper per unit (credits and message packs).** Chatbase, for example, starts around $40/month on a credit system as of July 2026. The unit price is lower and the accounting simpler, but the shape is identical: costs scale with usage, and you're managing a credit balance instead of an outcome definition.
+- **Flat subscription or self-hosted.** A fixed monthly price with a usage quota, or open-source software you run yourself. Predictable and immune to the deflection tax; the tradeoff is a real floor even in quiet months, and quotas you should read before buying. This is the lane [Chatwoot](/vs/chatwoot)'s self-hosted edition and our product occupy.
+
+We compare the specific tools in more depth in our [Intercom alternatives](/blog/intercom-alternatives) and [open-source Intercom alternatives](/blog/open-source-intercom-alternatives) posts.
+
+## The flat-price alternative (disclosure: ours)
+
+Clanker Support is our product, so weight this section accordingly.
+
+- **Pricing:** flat monthly plans from $19/month (Starter), with Growth at $89 and Scale at $299; annual billing gives two months free. Each tier includes a monthly AI-response quota — details on [/pricing](/pricing). No per-seat fees, no per-resolution fees. Your bill in a great month equals your bill in a quiet one.
+- **Pricing model:** flat subscription, or free if you self-host — the code is [open source](https://github.com/theopenco/llmchat) and runs serverless on Cloudflare-compatible infrastructure with your own LLM Gateway key.
+- **Setup:** one script tag before `</body>`, a React Server Components SDK, a WordPress plugin, or a Shopify theme embed.
+- **How it answers:** only from the knowledge base you give it — page URLs, text snippets, Q&A pairs — with cited sources, and an honest, visible handoff to your team when it can't help. Asking for a human always overrides the AI.
+- **Model choice:** pick the LLM per project (OpenAI, Anthropic, Google, and others) and swap it with a config change.
+
+The honest tradeoffs: we are web widget and email only — no WhatsApp, Messenger, or voice. There's no CRM, no product tours, no outbound campaigns. We're a newer product with a smaller ecosystem, and the hosted version has no free tier (self-hosting is the free path). If those are dealbreakers, we're not your tool. If flat pricing and no metering are the point, the [Fin comparison](/vs/fin) and the [migration guide](/docs/migrate/fin) cover the details.
+
+## When Fin is worth it
+
+Genuinely, sometimes it is:
+
+- **Low or spiky volume.** At a few hundred conversations a month, per-outcome pricing with a ~$49.50 floor can undercut any subscription, ours included.
+- **Omnichannel requirements.** Fin operates across live chat, email, WhatsApp, SMS, phone, and Slack. If your support runs through channels beyond web and email, Fin does things we simply don't.
+- **You already live in Zendesk or Salesforce.** Fin runs standalone on other helpdesks with no Intercom seats, and the Salesforce acquisition will likely deepen that side of the story.
+- **Enterprise procurement.** A Salesforce-owned vendor with a mature compliance and integration ecosystem is an easier security-review conversation than a young open-source project.
+- **You qualify for the startup program.** Intercom's pricing page advertises up to 93% off plus a year of Fin free for early-stage companies — at that discount, the math above changes completely.
+
+If you're weighing the whole field rather than just Fin, start with the [full comparison](/compare) or the [Intercom comparison](/vs/intercom).
+
+## FAQ
+
+### How much does Intercom Fin cost per month?
+
+Fin costs $0.99 per billable outcome, per fin.ai/pricing as of July 2026, with a 50-outcome monthly minimum (about $49.50) on non-Intercom helpdesks. Total monthly cost depends on conversation volume and your outcome rate: illustratively, a team handling 2,000 AI conversations could pay roughly $990–$1,386 for Fin alone, before Intercom seats and add-ons.
+
+### What counts as a resolution with Fin?
+
+Per Fin's help center, a resolution is counted when the customer confirms the answer helped, or exits without requesting further assistance — an "assumed resolution," triggered after 24 hours of silence following Fin's last answer. Procedure handoffs and disqualifications also bill at $0.99; qualifications bill at $9.99. Each conversation is charged at most once.
+
+### Does Fin charge for human handoffs?
+
+Mostly no. Per fin.ai/pricing, "you're not charged when a conversation is simply passed to your team without an outcome," and default escalations are free. The exception is a procedure you explicitly configured to end in a handoff — completing that workflow counts as a billable $0.99 outcome.
+
+### Can I use Fin without Intercom?
+
+Yes. As of July 2026, Fin runs standalone on Zendesk, Salesforce, and other helpdesks with no Intercom seat costs and no setup or platform fees, per fin.ai/pricing. The 50-outcome monthly minimum applies to these standalone deployments, so expect a floor of roughly $49.50 per month even at low volume.
+
+### What does the Salesforce deal mean for Fin customers?
+
+Salesforce signed a definitive agreement on June 15, 2026 to acquire Fin for about $3.6 billion, expected to close around the turn of the year (Salesforce's fiscal Q4 2027) pending regulatory approval. Salesforce plans to fold Fin into Agentforce, and Fin's CEO says he will stay on with little operational change near-term. Nothing published guarantees pricing continuity either way, so ask for terms in writing.

--- a/apps/marketing/content/blog/open-source-intercom-alternatives.md
+++ b/apps/marketing/content/blog/open-source-intercom-alternatives.md
@@ -1,0 +1,162 @@
+---
+title: "6 open-source Intercom alternatives you can self-host in 2026"
+description: "Six open-source Intercom alternatives you can self-host, compared on license, stack weight, built-in AI, and model choice — checked July 2026."
+date: "2026-07-07"
+category: "Guides"
+featured: false
+---
+
+The strongest open-source Intercom alternatives in 2026 are Chatwoot (the most complete omnichannel helpdesk), Zammad (process-heavy ticketing), FreeScout (lightweight shared inbox), Tiledesk (LLM agent flows), Papercups (maintenance mode), and Clanker Support (our AI-first agent: one script tag, any LLM, serverless self-hosting). The right pick depends on whether you need a helpdesk or an AI agent that answers and escalates.
+
+That's the short version. The longer one matters, because these six tools share little beyond a public repo: some are full Rails platforms, some are single-purpose widgets, some haven't shipped in years — and only a couple can answer the question people actually ask in 2026: can it do what Fin does, without Fin's bill?
+
+## Why developers are leaving Intercom
+
+As of July 2026, Intercom starts at $29 per seat per month on annual billing ($39 if you pay monthly), and Fin — its AI agent — bills $0.99 per resolution on top. The definition of "resolution" is broad: it includes "assumed resolutions," where the customer simply leaves without replying. There's also a 50-outcome monthly minimum — a floor of roughly $50 a month (50 × $0.99 = $49.50, illustrative) before Fin has demonstrably resolved anything. The full math is in [our Fin pricing teardown](/blog/intercom-fin-pricing); check Intercom's pricing page for current numbers.
+
+Cost isn't the only pressure. Intercom renamed itself Fin in May 2026, and on June 15, 2026 [Salesforce signed a definitive agreement to acquire Fin](https://www.salesforce.com/news/press-releases/2026/06/15/salesforce-signs-definitive-agreement-to-acquire-fin/) for roughly $3.6 billion (the deal hasn't closed). If part of your support stack's roadmap just became a Salesforce integration question, wanting an exit you control is rational.
+
+And the structural issue: per-resolution pricing means your vendor profits from counting generously, and a closed product means you never choose which model answers your customers.
+
+## What open source actually buys you
+
+Three things, concretely:
+
+- **A license nobody can re-price.** MIT or AGPL code can't be acquired out from under you, moved to per-resolution billing, or sunset by a new owner. Worst case, you pin a version or fork. Not a hypothetical benefit in the year your incumbent got acquired.
+- **Your data, in your database.** Conversations, customer emails, and knowledge content sit in Postgres, MySQL, or SQLite that you control. Migrations become a schema problem, not an export-negotiation problem.
+- **Your choice of LLM.** The axis almost nobody comparing these tools writes about. Closed AI support products bundle a proprietary model into an opaque per-resolution price. Open-source AI-era tools let you bring your own key — pick the model, swap when a better one ships, pay your provider per token, at cost.
+
+What it does not buy you: someone else's pager. More on that below.
+
+## The alternatives, compared
+
+Method note: this comparison is built from each project's public repo, license file, docs, and pricing pages, checked in July 2026 — no synthetic benchmarks. Where a vendor's numbers appear, verify them on their pricing page before you budget.
+
+### Chatwoot — the most complete open-source helpdesk
+
+If you want the closest thing to a full Intercom replacement, it's Chatwoot — no contest. Live chat, shared email inbox, WhatsApp, Instagram, Telegram — a genuine omnichannel desk with 34,000+ GitHub stars and steady releases. Its AI agent, Captain, handles FAQ-style answers and agent assists — but as of July 2026 Captain is a credit-metered paid feature, not part of the free self-hosted community edition. If your reason for self-hosting is "free AI support," that combination doesn't exist here.
+
+- **License:** MIT, with the `enterprise/` directory under a separate commercial license
+- **Stack & self-host weight:** Ruby on Rails + Vue + PostgreSQL + Redis — a real platform to operate, not a widget
+- **Built-in AI:** Captain (answers, summaries, agent copilot) — paid, credit-metered, not in the free community edition
+- **Model choice:** Captain is Chatwoot's managed AI feature; you're not picking the model per project
+- **Hosted option:** yes, cloud from $19 per agent/month as of July 2026
+- **Best for:** teams that want a full omnichannel helpdesk and have the ops capacity to run a Rails stack
+
+We compare directly in [Clanker Support vs Chatwoot](/vs/chatwoot) — and in plenty of scenarios, Chatwoot is the right call.
+
+### Zammad — process-heavy ticketing done properly
+
+Zammad is a mature helpdesk/ticketing system (5,700+ stars) with strong workflow, SLA, and audit features — the kind of tool an IT department or regulated support org loves. It is emphatically not an AI-first product.
+
+- **License:** AGPL-3.0
+- **Stack & self-host weight:** heavy — Rails plus PostgreSQL 13+, Redis 6+, a reverse proxy, and Elasticsearch (optional per the docs, but performance degrades significantly without it)
+- **Built-in AI:** not the pitch — this is tickets, queues, and process
+- **Model choice:** n/a
+- **Hosted option:** yes, Zammad sells hosted plans; pricing on their site
+- **Best for:** structured ticketing with SLAs, roles, and reporting — internal IT, agencies, regulated teams
+
+### FreeScout — the lightweight shared inbox
+
+FreeScout is the anti-platform: a free, self-hosted help desk and shared mailbox (closer to a Help Scout alternative than an Intercom one), 4,400+ stars, demonstrably alive — its latest release shipped in July 2026. The economics are honest: a free AGPL core plus optional paid modules (WhatsApp, Telegram, Slack, dozens more) sold as one-time lifetime licenses.
+
+- **License:** AGPL-3.0
+- **Stack & self-host weight:** light — a PHP (Laravel) app; by far the easiest classic helpdesk on this list to run
+- **Built-in AI:** none in the core; AI isn't the project's focus
+- **Model choice:** n/a
+- **Hosted option:** no first-party cloud — self-hosting is the product
+- **Best for:** small teams that want email-first support on minimal infrastructure for near-zero recurring cost
+
+### Tiledesk — open-source LLM agent flows
+
+Tiledesk started as an open-source live chat and has pivoted hard toward AI: the project now describes itself as an open-source alternative to Voiceflow for building LLM-powered agents with human-in-the-loop handoff. If you want to visually design conversation flows — automated answers here, human handoff there — this is the tool aimed at exactly that.
+
+- **License:** MIT
+- **Stack & self-host weight:** moderate-to-heavy — a Node.js microservices architecture deployed via Docker Compose or Kubernetes/Helm; more moving parts than a single app
+- **Built-in AI:** yes — LLM-powered agent building is now the core product
+- **Model choice:** built around LLM integrations; check their docs for the currently supported provider list
+- **Hosted option:** yes, a managed cloud exists; pricing on their site
+- **Best for:** teams that want to design multi-step agent workflows rather than install a ready-made support agent
+
+### Papercups — check the pulse before you commit
+
+Papercups earns its place here mostly as a caution. It's a pleasant, minimal open-source live chat (MIT, Elixir/Phoenix, 6,000+ stars) — but the repo states plainly that it's in maintenance mode: no major new features planned, pull requests and bug fixes still accepted. Chaskiq, another Intercom-style project common in these roundups, warrants similar care: its license is AGPL-3.0 with a Commons Clause attached (source-available, not OSI-approved open source) and development has slowed markedly — the most recent tagged release dates to late 2023.
+
+- **License:** MIT (Papercups); AGPL-3.0 + Commons Clause (Chaskiq — not OSI open source)
+- **Stack & self-host weight:** Elixir/Phoenix (Papercups); Rails + React + PostgreSQL + Redis (Chaskiq)
+- **Built-in AI:** none — both predate the AI-agent era of support tooling
+- **Model choice:** n/a
+- **Hosted option:** don't count on one for either project
+- **Best for:** teams with Elixir chops who want a small codebase to own and extend — eyes open
+
+### Clanker Support — AI-first, one script tag, any model
+
+Disclosure first: Clanker Support is our product — read this entry knowing who wrote it. It's placed last on purpose.
+
+Clanker Support is not a helpdesk platform. It's an AI support agent you add with one `<script>` tag (shadow DOM, no style bleed) — plus a React Server Components SDK, a WordPress plugin, and a Shopify theme embed. It answers only from the knowledge you give it — page URLs, text snippets, Q&A pairs — and cites its sources. When it can't help, it says so visibly and escalates: email (and optionally Slack) to your team, and the conversation lands in a team inbox with AI-written summaries, tags, and search. Email replies thread back into the conversation in both directions, and a visitor who asks for a human always gets one — that request overrides the escalation threshold.
+
+- **License:** MIT ([github.com/theopenco/llmchat](https://github.com/theopenco/llmchat))
+- **Stack & self-host weight:** serverless — runs on Cloudflare-compatible infrastructure (workerd, D1, KV). No Rails, no Postgres, no Elasticsearch to babysit
+- **Built-in AI:** the entire product — grounded answers with citations, honest escalation, per-message thumbs, and 1–5 CSAT
+- **Model choice:** any model via LLM Gateway — OpenAI, Anthropic, Google, and others — set per project, swappable with a config change
+- **Hosted option:** flat plans from $19/month (annual = two months free), no per-seat or per-resolution fees; each tier includes a monthly AI-response quota — details on [pricing](/pricing)
+- **Best for:** developer-led teams that want an AI agent answering from their docs today, without adopting a platform
+
+What we don't do, stated plainly: web widget and email only — no WhatsApp, Messenger, Instagram, or voice. No CRM, no product tours, no outbound campaigns. It's a newer product with a smaller ecosystem than Chatwoot's. And the hosted version has no free tier — self-hosting is the free path. If you need omnichannel, pick Chatwoot — we mean that. Poke the real widget on our [live demo](https://showcase.clankersupport.com) before forming an opinion.
+
+## The honest cost of self-hosting
+
+Every "open source is free" pitch skips this part.
+
+Self-hosting Chatwoot or Zammad means operating a Rails application: a VPS, PostgreSQL, Redis, possibly Elasticsearch, plus backups, upgrades, security patches, and email deliverability (SPF, DKIM, bounces — the part everyone underestimates). None of it is hard; all of it is recurring. A few engineer-hours a month babysitting the stack usually costs more than a flat hosted plan — the line item just moves from "software" to "engineering time," where it's harder to see.
+
+FreeScout sits at the cheap end of the trade: one PHP app. The serverless route — how Clanker Support is built — removes most of it: no server to patch, no database process to back up. You bring an LLM Gateway key, deploy, and your marginal cost is model tokens.
+
+The honest framing: free license plus your ops time, or flat hosted fee plus someone else's. Pick deliberately.
+
+## Is there an open-source alternative to Intercom Fin specifically?
+
+Not a clone — and that's arguably the point. Fin bundles a proprietary model, a resolution-counting system, and a $0.99-per-outcome price into one product. As of July 2026 it charges for "assumed resolutions" (the customer left without replying) and carries the ~$50 monthly minimum — though it doesn't charge when the customer asks for a human.
+
+The open-source answer decomposes the bundle instead of cloning it. On the AI axis there are three real options: Chatwoot's Captain (capable, but credit-metered and paid), Tiledesk's agent builder (if you want to design flows yourself), and Clanker Support (answers from your knowledge base with citations, escalates honestly, and lets you choose the model — paying your provider per token instead of per "resolution"). The economics differ in kind: token costs fall as models get cheaper; per-resolution fees scale with however your vendor defines success. Head-to-head details are in [Clanker Support vs Fin](/vs/fin) and [our guide to AI support agents](/blog/best-ai-support-agents).
+
+## What a minimal self-hosted AI live chat setup looks like
+
+Strip the category to parts and you need five things: a widget on your site, a place to put knowledge (docs URLs, snippets, Q&A), an inference path to some LLM, an escalation hatch to a human channel, and an inbox where a human triages what the AI couldn't handle.
+
+The classic path: provision a VPS, run Docker Compose for a Rails or Node platform, configure Postgres and Redis, wire up SMTP, then bolt AI on top — often as a paid feature with its own configuration. Doable; plan a weekend plus ongoing care.
+
+The serverless path, ours as the example: deploy the open-source repo to Cloudflare-compatible infrastructure, add your LLM Gateway key, paste one script tag before `</body>`, and point the knowledge base at your docs; escalation lands in email and Slack out of the box — the [self-hosting docs](https://docs.clankersupport.com) walk through it. Either way the parts list is the same; the difference is how much of it you maintain.
+
+## Which one should you pick?
+
+- **You want the full Intercom experience, open source:** Chatwoot. Most complete, most alive, biggest community. Budget for Rails ops, plus Captain credits if you want the AI.
+- **You want structured ticketing with process and audit trails:** Zammad.
+- **You want the cheapest sustainable email-first setup:** FreeScout.
+- **You want to build custom LLM agent flows:** Tiledesk.
+- **You want a minimal codebase to own and extend:** Papercups — clear-eyed about maintenance mode.
+- **You want an AI agent grounded in your docs, on your choice of model:** Clanker Support — self-host free, or flat from $19/month hosted.
+
+The case for staying put: if you depend on Intercom's omnichannel breadth, its outbound and product-tour tooling, or you're a Salesforce shop that stands to gain from the acquisition, Fin remains polished and migration has real switching costs. Leave because the pricing or lock-in bothers you — not because a blog post said so. The wider field, open source and not, is in our [Intercom alternatives roundup](/blog/intercom-alternatives).
+
+## FAQ
+
+### Is there a completely free open-source alternative to Intercom?
+
+Yes, with a caveat. Chatwoot's community edition, FreeScout, and self-hosted Clanker Support all cost nothing in license fees. But "free" excludes your server and the AI: model usage needs an API key everywhere, and Chatwoot's Captain AI is a paid feature even self-hosted. Budget hosting plus per-token model costs — still typically far below per-seat-plus-per-resolution pricing.
+
+### How hard is it to migrate off Intercom?
+
+Easier than it looks. Export your conversation history from Intercom, rebuild your help content as knowledge sources in the new tool, swap the embed script, and run both widgets in parallel for a week while you compare answers. The knowledge rebuild is the real work; the widget swap is minutes. Our [Intercom migration guide](/docs/migrate/intercom) covers the steps.
+
+### What does self-hosting a support tool actually cost?
+
+The license is free; the total cost isn't. Count a server (or serverless infrastructure), an LLM API key if you want AI answers, and — the big one — engineer time for upgrades, backups, and email deliverability. A Rails platform needs far more care than a single PHP app or serverless worker. If upkeep eats hours monthly, flat hosted plans are often cheaper.
+
+### Are open-source support tools sustainable long-term?
+
+Judge each project, not the category. Look at release dates, commit activity, and how the maintainers earn money — Chatwoot, Zammad, and FreeScout all ship regularly and fund themselves through hosting, support, or paid modules. Papercups is in maintenance mode and Chaskiq has slowed. The floor is real, though: permissively licensed code can be forked and pinned, if you have the engineers.
+
+### What's the closest open-source equivalent to Intercom Fin?
+
+Nothing replicates Fin's bundled model and per-resolution billing — by design. Chatwoot's Captain is the closest inside a full helpdesk (paid, credit-based). Tiledesk is closest for custom agent building. Clanker Support is closest as a drop-in AI agent: grounded answers with citations, honest human escalation, your choice of LLM, and per-token economics instead of $0.99 per counted resolution.


### PR DESCRIPTION
## What

Four long-form comparison posts targeting the highest-intent queries in the Intercom-alternative / best-AI-support-agent family. Written from a July 2026 SERP recon: every ranking listicle in this space crowns itself #1 and none organizes by pricing model, names the underlying LLM, or covers open-source/self-hosting — so these posts own those gaps.

| Post | Targets |
|---|---|
| `intercom-alternatives.md` | "Intercom alternatives", "cheaper alternative to Intercom" — grouped **by pricing model**, with a "when to stay on Intercom" section |
| `best-ai-support-agents.md` | "best AI support agent" — real pricing per tool, LLM-choice column, cost-at-volume math |
| `intercom-fin-pricing.md` | "Intercom Fin pricing", "$0.99 per resolution" — primary-source teardown of the per-outcome billing |
| `open-source-intercom-alternatives.md` | "open source Intercom alternative", "self-hosted live chat with AI" — the most winnable SERP probed |

All ~2,500–2,700 words, category **Guides**, direct-answer opening + FAQ per post.

## Honesty rail (the ranking wedge)

Clanker Support is **disclosed as ours in-body and never ranked #1**; competitors get genuine wins; each post has a "when to stay with the incumbent" section. No invented statistics, no fake "we tested on N tickets" claims, every external price hedged "as of July 2026".

## Fact verification

Every load-bearing third-party claim was independently verified via web search (as of July 2026):
- **Salesforce → Fin acquisition** (June 15 2026, ≈$3.6B) — confirmed by TechCrunch, CNBC, CMSWire, Salesforce IR, Intercom's own blog
- **Intercom → Fin company rename** (May 12 2026)
- **Fin pricing** — $0.99/outcome, 24-hour assumed-resolution rule, free clarifying-question/frustration carve-outs (fin.ai/help)
- Zendesk / Help Scout prices; Chatwoot 34,124 GitHub stars

Corrections applied during review: softened a paraphrase presented as a direct executive quote, removed one unverifiable forum URL, fixed a 25k→34k Chatwoot star inconsistency, hedged a resolution-rate range to Fin's one published figure (~76%).

## Verification

- `pnpm --filter @llmchat/marketing build` compiles all four posts
- All four render (200, correct titles) and appear in the blog index + sitemap
- 29 marketing tests pass; format clean
- No markdown pipe tables (pipeline lacks remark-gfm); all internal links resolve (`/vs/*`, `/docs/migrate/*`, `/pricing`, cross-links between the four)

## Follow-up (operator)

After deploy, Recrawl the llms.txt / blog knowledge sources in the dashboard — URL sources are stored snapshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018pJJgDHCnnNeEqEAApxFcQ