### PR TITLE
sec: harden agent integrations (#128) — SSRF, audit log, Cal.com binding, action limits

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -142,3 +142,13 @@ INTERNAL_ACCOUNT_EMAILS=
 # listed address is a live admin grant. Local dev needs nothing here: the dev
 # seed's admin@example.com is seeded with role='admin' (and pre-verified).
 ADMIN_EMAILS=
+
+# TRUSTED upstream base-URL overrides for the agent's integration clients
+# (Cal.com scheduling, Shopify order actions). Server-set ONLY — the untrusted
+# stored integration config no longer accepts an apiBase (that was an SSRF /
+# access-token-exfiltration vector). Leave BLANK in prod: Shopify is pinned to
+# the connected shop's *.myshopify.com domain and Cal.com to api.cal.com. Set
+# these only to point the clients at a mock upstream for tests / the local demo
+# (apps/api/scripts/integrations-demo). Example: http://127.0.0.1:9099
+SHOPIFY_API_BASE=
+CALCOM_API_BASE=

--- a/apps/api/env.d.ts
+++ b/apps/api/env.d.ts
@@ -52,6 +52,12 @@ declare module "@meetploy/nextjs" {
 			GOOGLE_CLIENT_SECRET?: string;
 			GITHUB_CLIENT_ID?: string;
 			GITHUB_CLIENT_SECRET?: string;
+			// TRUSTED upstream base-URL overrides for integration clients (tests /
+			// self-hosters / the demo mock). Server-set only — the untrusted stored
+			// integration config no longer carries an apiBase (SSRF fix). Unset in
+			// prod ⇒ Shopify is pinned to the shopDomain and Cal.com to api.cal.com.
+			SHOPIFY_API_BASE?: string;
+			CALCOM_API_BASE?: string;
 		};
 		DB: Database;
 		STATE: StateBinding;
@@ -109,6 +115,12 @@ declare global {
 			GOOGLE_CLIENT_SECRET?: string;
 			GITHUB_CLIENT_ID?: string;
 			GITHUB_CLIENT_SECRET?: string;
+			// TRUSTED upstream base-URL overrides for integration clients (tests /
+			// self-hosters / the demo mock). Server-set only — the untrusted stored
+			// integration config no longer carries an apiBase (SSRF fix). Unset in
+			// prod ⇒ Shopify is pinned to the shopDomain and Cal.com to api.cal.com.
+			SHOPIFY_API_BASE?: string;
+			CALCOM_API_BASE?: string;
 		};
 		DB: Database;
 		STATE: StateBinding;

--- a/apps/api/migrations/0019_agent_action.sql
+++ b/apps/api/migrations/0019_agent_action.sql
@@ -1,0 +1,26 @@
+-- Durable, operator-visible audit trail of every action the AGENT took on a
+-- visitor's behalf — Cal.com bookings and Shopify order lookups / returns.
+-- Append-only; `params` is the sanitized tool input (order number, email, slot,
+-- item titles) and NEVER holds credentials. `ok` records the upstream outcome
+-- (a blocked/refused attempt is stored with ok=0 so abuse is visible). Surfaced
+-- in the dashboard conversation thread so a mistaken or abusive return/booking
+-- can be seen and reversed in Shopify/Cal.com instead of being invisible.
+-- Additive CREATE TABLE, matching the ledger idiom — Ploy applies each migration
+-- file once, in filename order.
+CREATE TABLE `agent_action` (
+	`id` text PRIMARY KEY NOT NULL,
+	`conversation_id` text NOT NULL,
+	`project_id` text NOT NULL,
+	`workspace_id` text NOT NULL,
+	`kind` text NOT NULL,
+	`tool` text NOT NULL,
+	`ok` integer NOT NULL,
+	`detail` text,
+	`params` text DEFAULT '{}' NOT NULL,
+	`created_at` integer DEFAULT (unixepoch()) NOT NULL,
+	FOREIGN KEY (`conversation_id`) REFERENCES `conversation`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`project_id`) REFERENCES `project`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`workspace_id`) REFERENCES `workspace`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `agent_action_conv` ON `agent_action` (`conversation_id`,`created_at`);

--- a/apps/api/ploy.yaml
+++ b/apps/api/ploy.yaml
@@ -48,6 +48,10 @@ env:
   POSTHOG_PERSONAL_API_KEY: $POSTHOG_PERSONAL_API_KEY
   POSTHOG_PROJECT_ID: $POSTHOG_PROJECT_ID
   POSTHOG_QUERY_HOST: $POSTHOG_QUERY_HOST
+  # TRUSTED integration upstream overrides (tests/self-host/demo mock). Leave
+  # unset in prod: Shopify pins to the shop domain, Cal.com to api.cal.com.
+  SHOPIFY_API_BASE: $SHOPIFY_API_BASE
+  CALCOM_API_BASE: $CALCOM_API_BASE
 
 # Traffic report crons (see src/lib/traffic-report.ts — the expressions MUST
 # stay in sync with TRAFFIC_CRON_WEEKLY / TRAFFIC_CRON_MONTHLY, which map the

--- a/apps/api/scripts/integrations-demo/setup.mjs
+++ b/apps/api/scripts/integrations-demo/setup.mjs
@@ -1,8 +1,12 @@
 // Configure the seeded demo project's integrations THROUGH the real API
-// (sign in as the seeded admin, then PUT both integration configs with
-// apiBase pointed at the local mock upstream).
+// (sign in as the seeded admin, then PUT both integration configs).
+//
+// NOTE: the stored config no longer accepts an `apiBase` (that was an SSRF /
+// token-exfiltration vector). To point the agent's integration clients at the
+// local mock upstream, boot the api with the TRUSTED env overrides instead:
+//   SHOPIFY_API_BASE=http://127.0.0.1:9099 CALCOM_API_BASE=http://127.0.0.1:9099 pnpm dev
+// (see apps/api/.env.example). The mock still listens on 127.0.0.1:9099.
 const API = "http://localhost:8787";
-const MOCK = "http://127.0.0.1:9099";
 
 async function main() {
 	// Better Auth email+password sign-in → session cookie.
@@ -60,12 +64,10 @@ async function main() {
 		apiKey: "cal_demo_key",
 		eventTypeId: 42,
 		timeZone: "UTC",
-		apiBase: MOCK,
 	});
 	await putIntegration("shopify", {
 		shopDomain: "acme-tools.myshopify.com",
 		accessToken: "shpat_demo_token",
-		apiBase: MOCK,
 	});
 
 	const list = await (

--- a/apps/api/src/lib/calcom.test.ts
+++ b/apps/api/src/lib/calcom.test.ts
@@ -62,11 +62,23 @@ describe("calcomGetSlots", () => {
 		]);
 	});
 
-	it("honors the apiBase override (tests / self-hosters)", async () => {
+	it("pins the host to api.cal.com — the config cannot redirect it (SSRF fix)", async () => {
+		// The stored config has no apiBase field any more; even a stray one is
+		// ignored, so the Bearer key can only ever be sent to api.cal.com.
 		const calls = stubFetch(200, { status: "success", data: {} });
 		await calcomGetSlots(
-			{ ...CFG, apiBase: "http://127.0.0.1:9099" },
+			{ ...CFG, apiBase: "http://evil.example" } as CalcomConfig,
 			{ start: "2026-07-07", end: "2026-07-08" },
+		);
+		expect(new URL(calls[0]!.url).origin).toBe("https://api.cal.com");
+	});
+
+	it("uses a TRUSTED baseOverride param (tests / self-hosters / demo mock)", async () => {
+		const calls = stubFetch(200, { status: "success", data: {} });
+		await calcomGetSlots(
+			CFG,
+			{ start: "2026-07-07", end: "2026-07-08" },
+			"http://127.0.0.1:9099",
 		);
 		expect(calls[0]!.url.startsWith("http://127.0.0.1:9099/v2/slots")).toBe(
 			true,

--- a/apps/api/src/lib/calcom.ts
+++ b/apps/api/src/lib/calcom.ts
@@ -13,8 +13,14 @@ const BOOKINGS_API_VERSION = "2024-08-13";
 /** Upstream failure with a visitor-safe message (no key material, no URLs). */
 export class CalcomError extends Error {}
 
-function base(cfg: CalcomConfig): string {
-	return (cfg.apiBase ?? DEFAULT_BASE).replace(/\/$/, "");
+// The host is pinned to api.cal.com. The old config-supplied `apiBase` was an
+// SSRF/key-exfiltration vector — a stored value chosen by a workspace admin sent
+// the raw Bearer key to any host. `baseOverride` is a TRUSTED, server-set value
+// (a CALCOM_API_BASE env var or a unit-test argument) threaded from the worker,
+// never from the untrusted config blob, so tests/self-hosters keep a mock path.
+function base(cfg: CalcomConfig, baseOverride?: string): string {
+	void cfg;
+	return (baseOverride ?? DEFAULT_BASE).replace(/\/$/, "");
 }
 
 async function calFetch(
@@ -22,11 +28,12 @@ async function calFetch(
 	path: string,
 	apiVersion: string,
 	init?: RequestInit,
+	baseOverride?: string,
 ): Promise<unknown> {
 	// Typed off fetch itself — the workerd Response type and lib.dom's disagree.
 	let res: Awaited<ReturnType<typeof fetch>>;
 	try {
-		res = await fetch(`${base(cfg)}${path}`, {
+		res = await fetch(`${base(cfg, baseOverride)}${path}`, {
 			...init,
 			headers: {
 				authorization: `Bearer ${cfg.apiKey}`,
@@ -66,6 +73,7 @@ export interface CalcomSlot {
 export async function calcomGetSlots(
 	cfg: CalcomConfig,
 	opts: { start: string; end: string; maxSlots?: number },
+	baseOverride?: string,
 ): Promise<CalcomSlot[]> {
 	const params = new URLSearchParams({
 		eventTypeId: String(cfg.eventTypeId),
@@ -73,7 +81,13 @@ export async function calcomGetSlots(
 		end: opts.end,
 		timeZone: cfg.timeZone,
 	});
-	const data = await calFetch(cfg, `/v2/slots?${params}`, SLOTS_API_VERSION);
+	const data = await calFetch(
+		cfg,
+		`/v2/slots?${params}`,
+		SLOTS_API_VERSION,
+		undefined,
+		baseOverride,
+	);
 	// Shape: { "2026-07-07": [{ start: "..." }, ...], ... }
 	const flat: CalcomSlot[] = [];
 	if (data && typeof data === "object") {
@@ -102,20 +116,29 @@ export interface CalcomBooking {
 export async function calcomCreateBooking(
 	cfg: CalcomConfig,
 	opts: { start: string; name: string; email: string; notes?: string },
+	baseOverride?: string,
 ): Promise<CalcomBooking> {
-	const data = (await calFetch(cfg, "/v2/bookings", BOOKINGS_API_VERSION, {
-		method: "POST",
-		body: JSON.stringify({
-			start: opts.start,
-			eventTypeId: cfg.eventTypeId,
-			attendee: {
-				name: opts.name,
-				email: opts.email,
-				timeZone: cfg.timeZone,
-			},
-			...(opts.notes ? { metadata: { notes: opts.notes.slice(0, 500) } } : {}),
-		}),
-	})) as {
+	const data = (await calFetch(
+		cfg,
+		"/v2/bookings",
+		BOOKINGS_API_VERSION,
+		{
+			method: "POST",
+			body: JSON.stringify({
+				start: opts.start,
+				eventTypeId: cfg.eventTypeId,
+				attendee: {
+					name: opts.name,
+					email: opts.email,
+					timeZone: cfg.timeZone,
+				},
+				...(opts.notes
+					? { metadata: { notes: opts.notes.slice(0, 500) } }
+					: {}),
+			}),
+		},
+		baseOverride,
+	)) as {
 		uid?: unknown;
 		status?: unknown;
 		start?: unknown;

--- a/apps/api/src/lib/integration-hardening.test.ts
+++ b/apps/api/src/lib/integration-hardening.test.ts
@@ -1,0 +1,341 @@
+// ADVERSARIAL re-test of the PR #128 merge-blocking hardening. Each block first
+// runs the ATTACK against the hardened tool code and asserts it is now blocked,
+// then confirms the legit happy path still works and the audit trail captured
+// the action. Complements the per-client tests in shopify-admin/calcom .test.ts.
+//
+//   C1 SSRF          — a config-supplied apiBase can no longer redirect the
+//                      access token; only a trusted param/env override can.
+//   C2 audit         — every tool call surfaces an onAction record (params carry
+//                      order/email, NEVER credentials).
+//   C3 Cal.com bind  — book_meeting attendee is the on-file identity email, never
+//                      a model-chosen ("book for victim@x.com") address.
+//   C4 rate + once   — a blocking actionLimit refuses before any upstream call;
+//                      create_return is idempotent (no double-file).
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { buildIntegrationTools } from "./integration-tools";
+
+const IDENTITY = { name: "Ada", email: "ada@example.com" };
+
+const CAL_ROW = {
+	kind: "calcom",
+	config: JSON.stringify({
+		apiKey: "cal_secret",
+		eventTypeId: 42,
+		timeZone: "UTC",
+	}),
+};
+const SHOP_ROW = {
+	kind: "shopify",
+	config: JSON.stringify({
+		shopDomain: "acme.myshopify.com",
+		accessToken: "shpat_secret",
+	}),
+};
+
+type ToolLike = {
+	execute: (input: Record<string, unknown>) => Promise<Record<string, unknown>>;
+};
+const toolOf = (
+	built: ReturnType<typeof buildIntegrationTools>,
+	name: string,
+) => (built!.tools as Record<string, unknown>)[name] as ToolLike;
+
+const ORDER = {
+	orders: {
+		nodes: [
+			{
+				id: "gid://shopify/Order/1",
+				name: "#1001",
+				email: "ada@example.com",
+				createdAt: "2026-06-20T00:00:00Z",
+				displayFinancialStatus: "PAID",
+				displayFulfillmentStatus: "FULFILLED",
+				totalPriceSet: { shopMoney: { amount: "49.00", currencyCode: "USD" } },
+				lineItems: { nodes: [{ title: "Wrench", quantity: 1 }] },
+				fulfillments: [],
+			},
+		],
+	},
+};
+
+/** Records every fetch, routing Shopify GraphQL by operation name. */
+function stubFetch() {
+	const calls: { url: string; body: string }[] = [];
+	const fn = vi.fn(async (url: string, init: RequestInit) => {
+		const body = (init?.body as string) ?? "";
+		calls.push({ url, body });
+		// Cal.com booking
+		if (url.includes("/v2/bookings")) {
+			return Response.json({
+				status: "success",
+				data: {
+					uid: "bk1",
+					status: "accepted",
+					start: "2026-07-07T09:00:00.000Z",
+				},
+			});
+		}
+		// Shopify GraphQL — pick response by operation
+		if (body.includes("LookupOrder")) return Response.json({ data: ORDER });
+		if (body.includes("ReturnableItems")) {
+			return Response.json({
+				data: {
+					returnableFulfillments: {
+						edges: [
+							{
+								node: {
+									returnableFulfillmentLineItems: {
+										edges: [
+											{
+												node: {
+													quantity: 1,
+													fulfillmentLineItem: {
+														id: "fli1",
+														lineItem: { title: "Wrench" },
+													},
+												},
+											},
+										],
+									},
+								},
+							},
+						],
+					},
+				},
+			});
+		}
+		if (body.includes("CreateReturn")) {
+			return Response.json({
+				data: {
+					returnCreate: {
+						return: { id: "r1", status: "OPEN", name: "#1001-R1" },
+						userErrors: [],
+					},
+				},
+			});
+		}
+		return Response.json({ data: {} });
+	});
+	vi.stubGlobal("fetch", fn);
+	return { calls, fn };
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+// ── C3: Cal.com attendee binding ────────────────────────────────────────────
+describe("C3 — book_meeting attendee is bound to the on-file identity", () => {
+	it("ATTACK: a model-supplied 'victim@x.com' email is ignored; the invite goes to the on-file address", async () => {
+		const { calls } = stubFetch();
+		const built = buildIntegrationTools({
+			rows: [CAL_ROW],
+			identity: IDENTITY,
+		});
+		// The tool schema no longer exposes an `email` param; even if the model
+		// smuggles one, execute ignores it and uses identity.email.
+		const out = await toolOf(built, "book_meeting").execute({
+			start: "2026-07-07T09:00:00.000Z",
+			email: "victim@x.com",
+		});
+		expect((out as { ok: boolean }).ok).toBe(true);
+		const booking = calls.find((c) => c.url.includes("/v2/bookings"))!;
+		const attendee = JSON.parse(booking.body).attendee;
+		expect(attendee.email).toBe("ada@example.com");
+		expect(attendee.email).not.toBe("victim@x.com");
+	});
+
+	it("the book_meeting tool schema exposes NO attendee-email field to the model", () => {
+		const built = buildIntegrationTools({
+			rows: [CAL_ROW],
+			identity: IDENTITY,
+		});
+		const schema = (
+			built!.tools.book_meeting as unknown as {
+				inputSchema: { shape?: Record<string, unknown> };
+			}
+		).inputSchema;
+		// zod object exposes `.shape`; email must be absent.
+		const keys = Object.keys(schema.shape ?? {});
+		expect(keys).not.toContain("email");
+		expect(keys).toContain("start");
+	});
+
+	it("HAPPY PATH: an anonymous conversation cannot book (no email on file) and never calls Cal.com", async () => {
+		const { fn } = stubFetch();
+		const built = buildIntegrationTools({ rows: [CAL_ROW], identity: {} });
+		const out = await toolOf(built, "book_meeting").execute({
+			start: "2026-07-07T09:00:00.000Z",
+		});
+		expect(out).toMatchObject({ ok: false });
+		expect((out as { error: string }).error).toContain("email");
+		expect(fn).not.toHaveBeenCalled();
+	});
+});
+
+// ── C1: SSRF via config apiBase ─────────────────────────────────────────────
+describe("C1 — a config-supplied apiBase can no longer redirect the token (SSRF)", () => {
+	it("ATTACK: a shopify row whose config carries apiBase=evil is stripped; the token only reaches the shop domain", async () => {
+		const { calls } = stubFetch();
+		const evilRow = {
+			kind: "shopify",
+			config: JSON.stringify({
+				shopDomain: "acme.myshopify.com",
+				accessToken: "shpat_secret",
+				apiBase: "http://evil.example", // admin-smuggled — must be ignored
+			}),
+		};
+		const built = buildIntegrationTools({
+			rows: [evilRow],
+			identity: IDENTITY,
+		});
+		await toolOf(built, "lookup_order").execute({ orderNumber: "1001" });
+		expect(calls).toHaveLength(1);
+		expect(calls[0]!.url.startsWith("https://acme.myshopify.com/")).toBe(true);
+		expect(calls[0]!.url).not.toContain("evil.example");
+	});
+
+	it("HAPPY PATH: a TRUSTED baseOverride (env/self-host) still redirects the client", async () => {
+		const { calls } = stubFetch();
+		const built = buildIntegrationTools({
+			rows: [SHOP_ROW],
+			identity: IDENTITY,
+			baseOverrides: { shopify: "http://127.0.0.1:9099" },
+		});
+		await toolOf(built, "lookup_order").execute({ orderNumber: "1001" });
+		expect(calls[0]!.url.startsWith("http://127.0.0.1:9099/")).toBe(true);
+	});
+});
+
+// ── C4: action rate/quota gate ──────────────────────────────────────────────
+describe("C4 — a blocking actionLimit refuses before any upstream call", () => {
+	it("ATTACK: spammed book_meeting is refused with no Cal.com call once the limit trips", async () => {
+		const { fn } = stubFetch();
+		const actions: { tool: string; ok: boolean; detail?: string }[] = [];
+		const built = buildIntegrationTools({
+			rows: [CAL_ROW],
+			identity: IDENTITY,
+			guards: { actionLimit: async () => false },
+			onAction: (r) => actions.push(r),
+		});
+		const out = await toolOf(built, "book_meeting").execute({
+			start: "2026-07-07T09:00:00.000Z",
+		});
+		expect(out).toMatchObject({ ok: false });
+		expect((out as { error: string }).error).toMatch(/limit|later|human/i);
+		expect(fn).not.toHaveBeenCalled();
+		expect(actions.at(-1)).toMatchObject({ tool: "book_meeting", ok: false });
+		expect(actions.at(-1)!.detail).toContain("blocked");
+	});
+
+	it("ATTACK: spammed create_return is refused before any Shopify mutation", async () => {
+		const { fn } = stubFetch();
+		const built = buildIntegrationTools({
+			rows: [SHOP_ROW],
+			identity: IDENTITY,
+			guards: { actionLimit: async () => false },
+		});
+		const out = await toolOf(built, "create_return").execute({
+			orderNumber: "1001",
+		});
+		expect(out).toMatchObject({ ok: false });
+		expect(fn).not.toHaveBeenCalled();
+	});
+});
+
+// ── C4: create_return idempotency ───────────────────────────────────────────
+describe("C4 — create_return is idempotent (no double-file)", () => {
+	it("ATTACK: two identical return requests file the return exactly once", async () => {
+		const { calls } = stubFetch();
+		const seen = new Set<string>();
+		const built = buildIntegrationTools({
+			rows: [SHOP_ROW],
+			identity: IDENTITY,
+			conversationId: "conv1",
+			guards: {
+				once: async (key) => {
+					if (seen.has(key)) return false;
+					seen.add(key);
+					return true;
+				},
+			},
+		});
+		const first = await toolOf(built, "create_return").execute({
+			orderNumber: "1001",
+		});
+		const second = await toolOf(built, "create_return").execute({
+			orderNumber: "1001",
+		});
+		expect((first as { ok: boolean }).ok).toBe(true);
+		expect(second).toMatchObject({ ok: false });
+		expect((second as { error: string }).error).toMatch(
+			/just filed|won't file/i,
+		);
+		// Exactly ONE returnCreate mutation across both attempts.
+		const mutations = calls.filter((c) => c.body.includes("CreateReturn"));
+		expect(mutations).toHaveLength(1);
+	});
+});
+
+// ── C2: audit trail ─────────────────────────────────────────────────────────
+describe("C2 — every action surfaces an audit record, never a credential", () => {
+	it("HAPPY PATH: a filed return emits ok:true with a human detail and NO secret in params", async () => {
+		stubFetch();
+		const actions: {
+			kind: string;
+			tool: string;
+			ok: boolean;
+			detail?: string;
+			params?: Record<string, unknown>;
+		}[] = [];
+		const built = buildIntegrationTools({
+			rows: [SHOP_ROW],
+			identity: IDENTITY,
+			onAction: (r) => actions.push(r),
+		});
+		const out = await toolOf(built, "create_return").execute({
+			orderNumber: "1001",
+			itemTitles: ["wrench"],
+			reason: "too small",
+		});
+		expect((out as { ok: boolean }).ok).toBe(true);
+		const rec = actions.find((a) => a.tool === "create_return" && a.ok);
+		expect(rec).toBeTruthy();
+		expect(rec!.kind).toBe("shopify");
+		expect(rec!.detail).toMatch(/return/i);
+		// Params carry the visitor-supplied order/email but NEVER the token.
+		const serialized = JSON.stringify(rec!.params ?? {});
+		expect(serialized).toContain("1001");
+		expect(serialized).not.toContain("shpat_secret");
+		expect(serialized).not.toContain("accessToken");
+	});
+
+	it("cross-tenant guard intact: a mismatched order email yields no order + an ok:false audit record", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () =>
+				// order belongs to someone else — the server re-check returns null
+				Response.json({
+					data: {
+						orders: {
+							nodes: [
+								{ ...ORDER.orders.nodes[0], email: "someone-else@x.com" },
+							],
+						},
+					},
+				}),
+			),
+		);
+		const actions: { tool: string; ok: boolean }[] = [];
+		const built = buildIntegrationTools({
+			rows: [SHOP_ROW],
+			identity: { email: "attacker@evil.com" },
+			onAction: (r) => actions.push(r),
+		});
+		const out = await toolOf(built, "lookup_order").execute({
+			orderNumber: "1001",
+		});
+		expect(out).toMatchObject({ ok: false });
+		expect(actions.at(-1)).toMatchObject({ tool: "lookup_order", ok: false });
+	});
+});

--- a/apps/api/src/lib/integration-tools.test.ts
+++ b/apps/api/src/lib/integration-tools.test.ts
@@ -79,7 +79,7 @@ describe("calcom tools", () => {
 		const built = buildIntegrationTools({
 			rows: [CAL_ROW],
 			identity: IDENTITY,
-			onAction: (...a) => actions.push(a),
+			onAction: (r) => actions.push(r),
 			now: new Date("2026-07-06T00:00:00Z"),
 		});
 		const out = await toolOf(built, "get_available_slots").execute({
@@ -90,7 +90,12 @@ describe("calcom tools", () => {
 			timeZone: "UTC",
 			slots: ["2026-07-07T09:00:00.000Z"],
 		});
-		expect(actions).toEqual([["calcom", "get_available_slots", true]]);
+		expect(actions).toHaveLength(1);
+		expect(actions[0]).toMatchObject({
+			kind: "calcom",
+			tool: "get_available_slots",
+			ok: true,
+		});
 	});
 
 	it("book_meeting falls back to the conversation identity for name/email", async () => {
@@ -142,13 +147,18 @@ describe("calcom tools", () => {
 		const built = buildIntegrationTools({
 			rows: [CAL_ROW],
 			identity: IDENTITY,
-			onAction: (...a) => actions.push(a),
+			onAction: (r) => actions.push(r),
 		});
 		const out = await toolOf(built, "book_meeting").execute({
 			start: "2026-07-07T09:00:00.000Z",
 		});
 		expect(out).toEqual({ ok: false, error: "slot_taken" });
-		expect(actions).toEqual([["calcom", "book_meeting", false]]);
+		expect(actions).toHaveLength(1);
+		expect(actions[0]).toMatchObject({
+			kind: "calcom",
+			tool: "book_meeting",
+			ok: false,
+		});
 	});
 });
 

--- a/apps/api/src/lib/integration-tools.ts
+++ b/apps/api/src/lib/integration-tools.ts
@@ -10,6 +10,15 @@
 //   server-side (see shopify-admin.ts) — an order number alone never leaks.
 // - The model never carries internal ids between turns: create_return re-looks
 //   the order up itself rather than trusting a model-supplied gid.
+// - book_meeting's attendee is BOUND to the conversation's on-file identity
+//   email (never a model-chosen address) so the agent can't be steered into
+//   sending a team calendar invite to an arbitrary third party.
+// - Side-effecting actions (book_meeting, create_return) run through injectable
+//   `guards` (per-project action rate/quota + create_return idempotency) and
+//   every call is surfaced via `onAction` for the durable operator audit log.
+// - Upstream base URLs come ONLY from trusted, server-set `baseOverrides`
+//   (env/test), never from the untrusted stored config — closing the SSRF /
+//   credential-exfiltration vector the old `apiBase` config field opened.
 
 import { tool, type ToolSet } from "ai";
 import { z } from "zod";
@@ -31,6 +40,30 @@ import {
 export interface IntegrationRowInput {
 	kind: string;
 	config: string;
+}
+
+/** A single agent action, handed to the caller for the durable audit log +
+ * analytics. Params carry the visitor-supplied inputs (order number, email,
+ * slot, item titles) — NEVER credentials. */
+export interface IntegrationActionRecord {
+	kind: IntegrationKind;
+	tool: string;
+	ok: boolean;
+	/** Short human summary for the operator audit trail. */
+	detail?: string;
+	/** Sanitized tool inputs — never secrets. */
+	params?: Record<string, unknown>;
+}
+
+/** Server-side guards the caller wires to STATE. Optional — when absent the
+ * tools run unguarded (unit tests / self-host without a state binding). */
+export interface IntegrationGuards {
+	/** Return false to BLOCK a side-effecting action (per-project action
+	 * rate + daily quota). Checked before book_meeting / create_return fire. */
+	actionLimit?: (kind: IntegrationKind, tool: string) => Promise<boolean>;
+	/** Return false when this exact action was JUST performed (idempotency);
+	 * true reserves the key. Guards create_return against double-filing. */
+	once?: (key: string) => Promise<boolean>;
 }
 
 export interface BuiltIntegrationTools {
@@ -76,16 +109,33 @@ function toolError(
 export function buildIntegrationTools(opts: {
 	rows: IntegrationRowInput[];
 	identity: { name?: string | null; email?: string | null };
-	onAction?: (kind: IntegrationKind, toolName: string, ok: boolean) => void;
+	onAction?: (record: IntegrationActionRecord) => void;
+	guards?: IntegrationGuards;
+	/** TRUSTED per-kind base-URL overrides (env / unit test only — NEVER the
+	 * untrusted stored config). Absent ⇒ the pinned upstream host is used. */
+	baseOverrides?: { calcom?: string; shopify?: string };
+	/** Scopes the create_return idempotency key to this conversation. */
+	conversationId?: string;
 	now?: Date;
 }): BuiltIntegrationTools | null {
 	const tools: ToolSet = {};
 	const notes: string[] = [];
-	const report = (kind: IntegrationKind, toolName: string, ok: boolean) => {
+	const convScope = opts.conversationId ?? "nc";
+	const report = (record: IntegrationActionRecord) => {
 		try {
-			opts.onAction?.(kind, toolName, ok);
+			opts.onAction?.(record);
 		} catch {
-			// analytics must never break a tool round-trip
+			// analytics / audit must never break a tool round-trip
+		}
+	};
+	// Rate/quota gate for a side-effecting action. Absent guard ⇒ allowed;
+	// a guard FAULT closes the gate (never silently opens a write path).
+	const allowAction = async (kind: IntegrationKind, toolName: string) => {
+		if (!opts.guards?.actionLimit) return true;
+		try {
+			return await opts.guards.actionLimit(kind, toolName);
+		} catch {
+			return false;
 		}
 	};
 
@@ -97,6 +147,7 @@ export function buildIntegrationTools(opts: {
 				continue;
 			}
 			const cfg = parsed.data;
+			const calBase = opts.baseOverrides?.calcom;
 
 			tools.get_available_slots = tool({
 				description:
@@ -116,18 +167,31 @@ export function buildIntegrationTools(opts: {
 						const end = new Date(
 							start.getTime() + Math.min(days, MAX_SLOT_DAYS) * 86_400_000,
 						);
-						const slots = await calcomGetSlots(cfg, {
-							start: isoDay(start),
-							end: isoDay(end),
+						const slots = await calcomGetSlots(
+							cfg,
+							{ start: isoDay(start), end: isoDay(end) },
+							calBase,
+						);
+						report({
+							kind: "calcom",
+							tool: "get_available_slots",
+							ok: true,
+							params: { days },
+							detail: `listed ${slots.length} open slot(s)`,
 						});
-						report("calcom", "get_available_slots", true);
 						return {
 							ok: true as const,
 							timeZone: cfg.timeZone,
 							slots: slots.map((s) => s.start),
 						};
 					} catch (err) {
-						report("calcom", "get_available_slots", false);
+						report({
+							kind: "calcom",
+							tool: "get_available_slots",
+							ok: false,
+							params: { days },
+							detail: "availability lookup failed",
+						});
 						return toolError(err, "could not load available times");
 					}
 				},
@@ -135,20 +199,13 @@ export function buildIntegrationTools(opts: {
 
 			tools.book_meeting = tool({
 				description:
-					"Book a call at one of the offered slots. Only call AFTER the visitor explicitly confirmed a specific time, and only with a slot returned by get_available_slots. Requires the visitor's email.",
+					"Book a call at one of the offered slots. Only call AFTER the visitor explicitly confirmed a specific time, and only with a slot returned by get_available_slots. The call is booked for the email already on file for this conversation — you cannot book on behalf of a different address.",
 				inputSchema: z.object({
 					start: z
 						.string()
 						.max(64)
 						.describe(
 							"The exact slot start time as returned by get_available_slots",
-						),
-					email: z
-						.string()
-						.max(254)
-						.optional()
-						.describe(
-							"Visitor's email — omit if it is already on file for this conversation",
 						),
 					name: z.string().max(120).optional(),
 					notes: z
@@ -157,35 +214,77 @@ export function buildIntegrationTools(opts: {
 						.optional()
 						.describe("Short context for the team, in the visitor's words"),
 				}),
-				execute: async ({ start, email, name, notes }) => {
-					const attendeeEmail = email?.trim() || opts.identity.email?.trim();
+				execute: async ({ start, name, notes: meetingNotes }) => {
+					// SECURITY: the attendee is ALWAYS the conversation's on-file email.
+					// A model-supplied address is deliberately not accepted, so the agent
+					// cannot be steered into inviting an arbitrary third party ("book for
+					// victim@x.com"). Mirrors the Shopify tools' server-side email binding.
+					const attendeeEmail = opts.identity.email?.trim();
 					if (!attendeeEmail) {
-						report("calcom", "book_meeting", false);
+						report({
+							kind: "calcom",
+							tool: "book_meeting",
+							ok: false,
+							params: { start },
+							detail: "refused: no email on file",
+						});
 						return {
 							ok: false as const,
 							error:
-								"the visitor's email is required to book — ask for it first",
+								"I need the visitor's email on file before booking — ask them to share it so it's saved to this conversation, then book.",
+						};
+					}
+					if (!(await allowAction("calcom", "book_meeting"))) {
+						report({
+							kind: "calcom",
+							tool: "book_meeting",
+							ok: false,
+							params: { start, email: attendeeEmail },
+							detail: "blocked: action rate/quota limit",
+						});
+						return {
+							ok: false as const,
+							error:
+								"We've reached the booking limit for now — please try again later or ask to speak with a human.",
 						};
 					}
 					try {
-						const booking = await calcomCreateBooking(cfg, {
-							start,
-							email: attendeeEmail,
-							name:
-								name?.trim() || opts.identity.name?.trim() || "Website visitor",
-							notes,
+						const booking = await calcomCreateBooking(
+							cfg,
+							{
+								start,
+								email: attendeeEmail,
+								name:
+									name?.trim() ||
+									opts.identity.name?.trim() ||
+									"Website visitor",
+								notes: meetingNotes,
+							},
+							calBase,
+						);
+						report({
+							kind: "calcom",
+							tool: "book_meeting",
+							ok: true,
+							params: { start, email: attendeeEmail },
+							detail: `booked ${booking.start} for ${attendeeEmail}${booking.uid ? ` (${booking.uid})` : ""}`,
 						});
-						report("calcom", "book_meeting", true);
 						return { ok: true as const, booking };
 					} catch (err) {
-						report("calcom", "book_meeting", false);
+						report({
+							kind: "calcom",
+							tool: "book_meeting",
+							ok: false,
+							params: { start, email: attendeeEmail },
+							detail: "booking failed upstream",
+						});
 						return toolError(err, "the booking could not be completed");
 					}
 				},
 			});
 
 			notes.push(
-				`- Scheduling: you can check availability (get_available_slots) and book a call (book_meeting). Times are in ${cfg.timeZone}. Offer a few concrete slots, let the visitor pick, confirm the exact time and their email, then book. After booking, share the confirmed time and the join link if one is returned.`,
+				`- Scheduling: you can check availability (get_available_slots) and book a call (book_meeting). Times are in ${cfg.timeZone}. The booking uses the email already on file for this conversation — if none is on file, ask the visitor to share their email first. Offer a few concrete slots, let the visitor pick, confirm the exact time, then book. After booking, share the confirmed time and the join link if one is returned.`,
 			);
 		}
 
@@ -196,6 +295,7 @@ export function buildIntegrationTools(opts: {
 				continue;
 			}
 			const cfg = parsed.data;
+			const shopBase = opts.baseOverrides?.shopify;
 
 			const emailFor = (provided?: string) =>
 				provided?.trim() || opts.identity.email?.trim() || "";
@@ -219,7 +319,13 @@ export function buildIntegrationTools(opts: {
 				execute: async ({ orderNumber, email }) => {
 					const addr = emailFor(email);
 					if (!addr) {
-						report("shopify", "lookup_order", false);
+						report({
+							kind: "shopify",
+							tool: "lookup_order",
+							ok: false,
+							params: { orderNumber },
+							detail: "refused: no email provided",
+						});
 						return {
 							ok: false as const,
 							error:
@@ -227,11 +333,20 @@ export function buildIntegrationTools(opts: {
 						};
 					}
 					try {
-						const order = await shopifyLookupOrder(cfg, {
-							orderNumber,
-							email: addr,
+						const order = await shopifyLookupOrder(
+							cfg,
+							{ orderNumber, email: addr },
+							shopBase,
+						);
+						report({
+							kind: "shopify",
+							tool: "lookup_order",
+							ok: !!order,
+							params: { orderNumber, email: addr },
+							detail: order
+								? `looked up order ${order.name}`
+								: `no order for ${orderNumber} + that email`,
 						});
-						report("shopify", "lookup_order", !!order);
 						if (!order) {
 							return {
 								ok: false as const,
@@ -243,7 +358,13 @@ export function buildIntegrationTools(opts: {
 						const { id: _id, ...visible } = order;
 						return { ok: true as const, order: visible };
 					} catch (err) {
-						report("shopify", "lookup_order", false);
+						report({
+							kind: "shopify",
+							tool: "lookup_order",
+							ok: false,
+							params: { orderNumber, email: addr },
+							detail: "order lookup failed upstream",
+						});
 						return toolError(err, "the order lookup failed");
 					}
 				},
@@ -271,28 +392,59 @@ export function buildIntegrationTools(opts: {
 				execute: async ({ orderNumber, email, itemTitles, reason }) => {
 					const addr = emailFor(email);
 					if (!addr) {
-						report("shopify", "create_return", false);
+						report({
+							kind: "shopify",
+							tool: "create_return",
+							ok: false,
+							params: { orderNumber },
+							detail: "refused: no email provided",
+						});
 						return {
 							ok: false as const,
 							error:
 								"the email on the order is required — ask the visitor for it",
 						};
 					}
+					if (!(await allowAction("shopify", "create_return"))) {
+						report({
+							kind: "shopify",
+							tool: "create_return",
+							ok: false,
+							params: { orderNumber, email: addr },
+							detail: "blocked: action rate/quota limit",
+						});
+						return {
+							ok: false as const,
+							error:
+								"We've reached the returns limit for now — please try again later or ask to speak with a human.",
+						};
+					}
 					try {
 						// Re-verify ownership fresh — never act on a model-carried id.
-						const order = await shopifyLookupOrder(cfg, {
-							orderNumber,
-							email: addr,
-						});
+						const order = await shopifyLookupOrder(
+							cfg,
+							{ orderNumber, email: addr },
+							shopBase,
+						);
 						if (!order) {
-							report("shopify", "create_return", false);
+							report({
+								kind: "shopify",
+								tool: "create_return",
+								ok: false,
+								params: { orderNumber, email: addr },
+								detail: "refused: order/email mismatch",
+							});
 							return {
 								ok: false as const,
 								error:
 									"no order found for that order number and email combination",
 							};
 						}
-						const returnable = await shopifyReturnableItems(cfg, order.id);
+						const returnable = await shopifyReturnableItems(
+							cfg,
+							order.id,
+							shopBase,
+						);
 						const wanted = itemTitles?.length
 							? returnable.filter((r) =>
 									itemTitles.some((t) =>
@@ -301,7 +453,13 @@ export function buildIntegrationTools(opts: {
 								)
 							: returnable;
 						if (wanted.length === 0) {
-							report("shopify", "create_return", false);
+							report({
+								kind: "shopify",
+								tool: "create_return",
+								ok: false,
+								params: { orderNumber, email: addr, itemTitles },
+								detail: "nothing returnable",
+							});
 							return {
 								ok: false as const,
 								error: itemTitles?.length
@@ -309,15 +467,59 @@ export function buildIntegrationTools(opts: {
 									: "nothing on this order is returnable right now",
 							};
 						}
-						const created = await shopifyCreateReturn(cfg, {
-							orderId: order.id,
-							items: wanted.map((w) => ({
-								fulfillmentLineItemId: w.fulfillmentLineItemId,
-								quantity: w.quantity,
-							})),
-							reasonNote: reason,
+						// Idempotency: a committed-but-lost response or a double-fire must
+						// not file the return twice. Keyed on (conversation, order, items)
+						// and reserved right before the state-changing mutation.
+						const dedupeKey = `return:${convScope}:${order.name}:${wanted
+							.map((w) => w.fulfillmentLineItemId)
+							// eslint-disable-next-line unicorn/no-array-sort -- fresh mapped array; toSorted() is not in the api's TS lib target
+							.sort()
+							.join(",")}`;
+						if (opts.guards?.once) {
+							let fresh = false;
+							try {
+								fresh = await opts.guards.once(dedupeKey);
+							} catch {
+								fresh = false; // fail safe: treat as a possible duplicate
+							}
+							if (!fresh) {
+								report({
+									kind: "shopify",
+									tool: "create_return",
+									ok: false,
+									params: { orderNumber, email: addr, itemTitles },
+									detail: "blocked: duplicate return (idempotency)",
+								});
+								return {
+									ok: false as const,
+									error:
+										"That return was just filed for this order — you'll get a confirmation by email. I won't file it a second time.",
+								};
+							}
+						}
+						const created = await shopifyCreateReturn(
+							cfg,
+							{
+								orderId: order.id,
+								items: wanted.map((w) => ({
+									fulfillmentLineItemId: w.fulfillmentLineItemId,
+									quantity: w.quantity,
+								})),
+								reasonNote: reason,
+							},
+							shopBase,
+						);
+						report({
+							kind: "shopify",
+							tool: "create_return",
+							ok: true,
+							params: {
+								orderNumber,
+								email: addr,
+								itemTitles: wanted.map((w) => w.title),
+							},
+							detail: `filed return ${created.name ?? created.status} on order ${order.name} for ${addr}`,
 						});
-						report("shopify", "create_return", true);
 						return {
 							ok: true as const,
 							return: {
@@ -330,7 +532,13 @@ export function buildIntegrationTools(opts: {
 							},
 						};
 					} catch (err) {
-						report("shopify", "create_return", false);
+						report({
+							kind: "shopify",
+							tool: "create_return",
+							ok: false,
+							params: { orderNumber, email: addr, itemTitles },
+							detail: "return failed upstream",
+						});
 						return toolError(err, "the return could not be filed");
 					}
 				},

--- a/apps/api/src/lib/kv.ts
+++ b/apps/api/src/lib/kv.ts
@@ -75,6 +75,49 @@ export async function rateLimit(
 	}
 }
 
+// How long a reserved idempotency key blocks a repeat of the same action.
+const ONCE_TTL_SECONDS = 300; // ~5 min
+
+/**
+ * Single-flight reservation for a side-effecting action (create_return). Returns
+ * true the FIRST time a key is seen within the TTL window (and reserves it),
+ * false on any repeat — so a committed-but-lost response or a double-fire can't
+ * file the same return twice. Backed by STATE with value-tracked expiry, same
+ * get/set pattern as rateLimit. FAILS CLOSED (returns false) on a STATE outage:
+ * on a money-touching write path a possible duplicate must be blocked, not waved
+ * through.
+ */
+export async function reserveOnce(
+	env: Env,
+	key: string,
+	ttlSeconds: number = ONCE_TTL_SECONDS,
+): Promise<boolean> {
+	const cacheKey = `once:${key}`;
+	const now = Math.floor(Date.now() / 1000);
+	try {
+		const raw = await env.STATE.get(cacheKey);
+		if (raw) {
+			try {
+				const parsed = JSON.parse(raw) as { resetAt?: number };
+				if ((parsed.resetAt ?? 0) > now) return false; // still reserved
+			} catch {
+				// Malformed entry — treat as expired and re-reserve below.
+			}
+		}
+		await env.STATE.set(
+			cacheKey,
+			JSON.stringify({ resetAt: now + ttlSeconds }),
+		);
+		return true;
+	} catch (err) {
+		console.error(
+			"reserveOnce: state store unavailable, denying (fail-closed)",
+			err,
+		);
+		return false;
+	}
+}
+
 // One escalation "holding" acknowledgement per this window — so a waiting visitor
 // who sends several messages isn't spammed the same canned line each time.
 const HOLD_COOLDOWN_SECONDS = 300; // ~5 min

--- a/apps/api/src/lib/shopify-admin.test.ts
+++ b/apps/api/src/lib/shopify-admin.test.ts
@@ -86,11 +86,25 @@ describe("shopifyLookupOrder", () => {
 		).toBeNull();
 	});
 
-	it("honors the apiBase override", async () => {
+	it("pins the host to the shopDomain — the config cannot redirect it (SSRF fix)", async () => {
+		// The stored config has no apiBase field any more; even a stray one is
+		// ignored, so the access token can only ever be sent to the shop domain.
 		const calls = stubGraphql({ orders: { nodes: [] } });
 		await shopifyLookupOrder(
-			{ ...CFG, apiBase: "http://127.0.0.1:9099" },
+			{ ...CFG, apiBase: "http://evil.example" } as ShopifyConfig,
 			{ orderNumber: "1001", email: "a@b.co" },
+		);
+		expect(calls[0]!.url).toBe(
+			"https://acme-tools.myshopify.com/admin/api/2025-01/graphql.json",
+		);
+	});
+
+	it("uses a TRUSTED baseOverride param (tests / self-hosters / demo mock)", async () => {
+		const calls = stubGraphql({ orders: { nodes: [] } });
+		await shopifyLookupOrder(
+			CFG,
+			{ orderNumber: "1001", email: "a@b.co" },
+			"http://127.0.0.1:9099",
 		);
 		expect(calls[0]!.url).toBe(
 			"http://127.0.0.1:9099/admin/api/2025-01/graphql.json",

--- a/apps/api/src/lib/shopify-admin.ts
+++ b/apps/api/src/lib/shopify-admin.ts
@@ -13,8 +13,14 @@ const API_VERSION = "2025-01";
 /** Upstream failure with a visitor-safe message (no token, no shop URLs). */
 export class ShopifyError extends Error {}
 
-function endpoint(cfg: ShopifyConfig): string {
-	const base = (cfg.apiBase ?? `https://${cfg.shopDomain}`).replace(/\/$/, "");
+// The endpoint host is ALWAYS derived from the regex-validated shopDomain — the
+// untrusted, admin-writable config can no longer smuggle an arbitrary host (the
+// old `apiBase` field that let a stored value exfiltrate the access token).
+// `baseOverride` is a TRUSTED, server-set value (a CALCOM_/SHOPIFY_API_BASE env
+// var or a unit-test argument) threaded from the worker — never from the config
+// blob — so tests and self-hosters keep a mock-upstream path with no SSRF hole.
+function endpoint(cfg: ShopifyConfig, baseOverride?: string): string {
+	const base = (baseOverride ?? `https://${cfg.shopDomain}`).replace(/\/$/, "");
 	return `${base}/admin/api/${API_VERSION}/graphql.json`;
 }
 
@@ -22,11 +28,12 @@ async function shopifyGraphql<T>(
 	cfg: ShopifyConfig,
 	query: string,
 	variables: Record<string, unknown>,
+	baseOverride?: string,
 ): Promise<T> {
 	// Typed off fetch itself — the workerd Response type and lib.dom's disagree.
 	let res: Awaited<ReturnType<typeof fetch>>;
 	try {
-		res = await fetch(endpoint(cfg), {
+		res = await fetch(endpoint(cfg, baseOverride), {
 			method: "POST",
 			headers: {
 				"content-type": "application/json",
@@ -110,6 +117,7 @@ function normalizeOrderNumber(orderNumber: string): string {
 export async function shopifyLookupOrder(
 	cfg: ShopifyConfig,
 	opts: { orderNumber: string; email: string },
+	baseOverride?: string,
 ): Promise<ShopifyOrderSummary | null> {
 	const num = normalizeOrderNumber(opts.orderNumber);
 	if (!num) return null;
@@ -138,7 +146,7 @@ export async function shopifyLookupOrder(
 				}[];
 			}[];
 		};
-	}>(cfg, ORDER_QUERY, { q });
+	}>(cfg, ORDER_QUERY, { q }, baseOverride);
 
 	const order = data.orders.nodes[0];
 	if (!order) return null;
@@ -203,6 +211,7 @@ const RETURNABLE_QUERY = /* GraphQL */ `
 export async function shopifyReturnableItems(
 	cfg: ShopifyConfig,
 	orderId: string,
+	baseOverride?: string,
 ): Promise<ReturnableItem[]> {
 	const data = await shopifyGraphql<{
 		returnableFulfillments: {
@@ -222,7 +231,7 @@ export async function shopifyReturnableItems(
 				};
 			}[];
 		};
-	}>(cfg, RETURNABLE_QUERY, { orderId });
+	}>(cfg, RETURNABLE_QUERY, { orderId }, baseOverride);
 
 	return data.returnableFulfillments.edges.flatMap((f) =>
 		f.node.returnableFulfillmentLineItems.edges.map((e) => ({
@@ -267,25 +276,31 @@ export async function shopifyCreateReturn(
 		items: { fulfillmentLineItemId: string; quantity: number }[];
 		reasonNote?: string;
 	},
+	baseOverride?: string,
 ): Promise<CreatedReturn> {
 	const data = await shopifyGraphql<{
 		returnCreate: {
 			return: { id: string; status: string; name?: string | null } | null;
 			userErrors: { field: string[] | null; message: string }[];
 		};
-	}>(cfg, RETURN_CREATE_MUTATION, {
-		returnInput: {
-			orderId: opts.orderId,
-			returnLineItems: opts.items.map((i) => ({
-				fulfillmentLineItemId: i.fulfillmentLineItemId,
-				quantity: i.quantity,
-				returnReason: "OTHER",
-				...(opts.reasonNote
-					? { returnReasonNote: opts.reasonNote.slice(0, 255) }
-					: {}),
-			})),
+	}>(
+		cfg,
+		RETURN_CREATE_MUTATION,
+		{
+			returnInput: {
+				orderId: opts.orderId,
+				returnLineItems: opts.items.map((i) => ({
+					fulfillmentLineItemId: i.fulfillmentLineItemId,
+					quantity: i.quantity,
+					returnReason: "OTHER",
+					...(opts.reasonNote
+						? { returnReasonNote: opts.reasonNote.slice(0, 255) }
+						: {}),
+				})),
+			},
 		},
-	});
+		baseOverride,
+	);
 
 	const err = data.returnCreate.userErrors[0];
 	if (err || !data.returnCreate.return) {

--- a/apps/api/src/routes/chat.ts
+++ b/apps/api/src/routes/chat.ts
@@ -14,7 +14,12 @@ import {
 	holdingStreamResponse,
 } from "@/lib/holding";
 import { buildIntegrationTools } from "@/lib/integration-tools";
-import { publicLookupRateLimit, rateLimit, shouldSendHolding } from "@/lib/kv";
+import {
+	publicLookupRateLimit,
+	rateLimit,
+	reserveOnce,
+	shouldSendHolding,
+} from "@/lib/kv";
 import { streamChat, summarizeForVisitor } from "@/lib/llm";
 import { isResponseBlocked, resolveAccess } from "@/lib/plan";
 import { captureEvent, captureInBackground } from "@/lib/posthog";
@@ -23,6 +28,7 @@ import { sendEscalationSlack } from "@/lib/slack";
 import { reportMeterEvent } from "@/lib/stripe";
 
 import {
+	agentAction,
 	and as andWhere,
 	conversation,
 	eq,
@@ -99,6 +105,15 @@ const resolveBody = z.object({
 
 const RATE_LIMIT_MAX = 20;
 const RATE_LIMIT_WINDOW = 60 * 60;
+// Side-effecting agent actions (book_meeting, create_return) are more dangerous
+// than chat turns, so they get their OWN, tighter budget on top of the chat
+// limit: a per-(project,IP) hourly cap AND a per-project daily aggregate cap
+// (bounds a distributed/IP-rotating attacker — the gap tracked in task #114,
+// applied here at the action layer). Fail CLOSED (see the guard wiring).
+const ACTION_RATE_MAX = 8;
+const ACTION_RATE_WINDOW = 60 * 60;
+const ACTION_DAILY_MAX = 40;
+const ACTION_DAILY_WINDOW = 24 * 60 * 60;
 // Escalations trigger notification emails — keep the budget much tighter.
 const ESCALATE_RATE_LIMIT_MAX = 5;
 // Visitor-resolve is a cheap idempotent DB write (no email/Slack); modest cap.
@@ -202,6 +217,20 @@ export const chat = new Hono<AppContext>()
 				userAgent: c.req.header("user-agent") ?? "",
 			});
 
+		// Capture a first-seen email onto the conversation identity so an action
+		// bound to the on-file email (book_meeting) has it available. Only FILLS a
+		// null — never overwrites an established identity mid-conversation, so a
+		// visitor can't retarget an existing conversation's bound email.
+		if (email && !conv.email) {
+			conv.email = email;
+			c.executionCtx.waitUntil(
+				db(c.env)
+					.update(conversation)
+					.set({ email, updatedAt: new Date() })
+					.where(eq(conversation.id, conv.id)),
+			);
+		}
+
 		c.executionCtx.waitUntil(
 			(async () => {
 				if (convCreated) {
@@ -298,18 +327,70 @@ export const chat = new Hono<AppContext>()
 		const built = buildIntegrationTools({
 			rows: integrationRows,
 			identity: { name: conv.name, email: conv.email },
-			onAction: (kind, toolName, ok) =>
+			conversationId: conv.id,
+			// Trusted, server-set upstream base overrides for tests/self-hosters —
+			// NEVER from the untrusted stored config (that was the apiBase SSRF hole).
+			baseOverrides: {
+				calcom: c.env.vars.CALCOM_API_BASE,
+				shopify: c.env.vars.SHOPIFY_API_BASE,
+			},
+			// Action-scoped guards: a rate/quota bucket distinct from (and tighter
+			// than) the 20/hr chat limit, plus create_return idempotency — actions
+			// are more dangerous than messages.
+			guards: {
+				actionLimit: async () => {
+					const perProjectIp = await rateLimit(
+						c.env,
+						`action:${project.id}:${ip}`,
+						ACTION_RATE_MAX,
+						ACTION_RATE_WINDOW,
+						{ failClosed: true },
+					);
+					if (!perProjectIp.ok) return false;
+					const perProjectDaily = await rateLimit(
+						c.env,
+						`action-daily:${project.id}`,
+						ACTION_DAILY_MAX,
+						ACTION_DAILY_WINDOW,
+						{ failClosed: true },
+					);
+					return perProjectDaily.ok;
+				},
+				once: (key) => reserveOnce(c.env, key),
+			},
+			onAction: (record) => {
+				// (1) Durable, operator-visible audit row — the "what did the agent
+				// do, on whose behalf" record the inbox thread renders.
+				c.executionCtx.waitUntil(
+					db(c.env)
+						.insert(agentAction)
+						.values({
+							conversationId: conv.id,
+							projectId: project.id,
+							workspaceId: project.workspaceId,
+							kind: record.kind,
+							tool: record.tool,
+							ok: record.ok,
+							detail: record.detail ?? null,
+							params: JSON.stringify(record.params ?? {}),
+						})
+						.catch((err) =>
+							console.error("chat: agent_action persist failed", err),
+						),
+				);
+				// (2) Analytics (unchanged) — PII-free counters.
 				captureInBackground(c, {
 					event: ANALYTICS_EVENTS.integrationActionUsed,
 					distinctId: clientId,
 					properties: {
 						project_id: project.id,
 						workspace_id: project.workspaceId,
-						kind,
-						tool: toolName,
-						ok,
+						kind: record.kind,
+						tool: record.tool,
+						ok: record.ok,
 					},
-				}),
+				});
+			},
 		});
 
 		// Guard the live bot against a project stuck on a model that's no longer

--- a/apps/api/src/routes/conversations.test.ts
+++ b/apps/api/src/routes/conversations.test.ts
@@ -63,6 +63,8 @@ interface State {
 	conv?: Row;
 	/** Rows the thread message window query returns (relational findMany). */
 	threadMessages?: Row[];
+	/** Agent-action audit rows the thread endpoint returns. */
+	agentActionRows?: Row[];
 	/** Batched per-page tag rows (conversation_tag ⨝ tag) for the list response. */
 	tagRows?: {
 		conversationId: string;
@@ -184,6 +186,9 @@ function mockDb(state: State) {
 			},
 			message: {
 				findMany: async () => state.threadMessages ?? [],
+			},
+			agentAction: {
+				findMany: async () => state.agentActionRows ?? [],
 			},
 			tag: {
 				findFirst: async () => state.tag,

--- a/apps/api/src/routes/conversations.ts
+++ b/apps/api/src/routes/conversations.ts
@@ -456,11 +456,29 @@ export const conversations = new Hono<AppContext>()
 				firstHitSequence = hit?.sequence ?? null;
 			}
 
+			// Durable audit trail of agent-taken actions on this conversation
+			// (bookings, order lookups, returns) — operator visibility into what the
+			// bot DID, so a mistaken/abusive action can be seen and reversed upstream.
+			const actions = await db(c.env).query.agentAction.findMany({
+				where: (a, { eq: e }) => e(a.conversationId, id),
+				orderBy: (a, { asc: ascOp }) => ascOp(a.createdAt),
+				limit: 200,
+			});
+			const agentActions = actions.map((a) => ({
+				id: a.id,
+				kind: a.kind,
+				tool: a.tool,
+				ok: a.ok,
+				detail: a.detail,
+				createdAt: a.createdAt,
+			}));
+
 			return c.json({
 				conversation: conv,
 				messages,
 				hasOlder,
 				firstHitSequence,
+				agentActions,
 			});
 		},
 	)

--- a/apps/dashboard/src/app/inbox/_components/MessageThread.tsx
+++ b/apps/dashboard/src/app/inbox/_components/MessageThread.tsx
@@ -16,7 +16,7 @@ import { cn } from "@/lib/utils";
 import { formatMessageTime } from "./format";
 import { Highlighted } from "./highlight";
 import { PromoteToKnowledge } from "./PromoteToKnowledge";
-import type { Message } from "./types";
+import type { AgentActionEntry, Message } from "./types";
 
 /** Context for the "Add to knowledge" action on admin replies. Absent (e.g. in
  * tests, or before a project/workspace resolves) ⇒ the action isn't rendered. */
@@ -191,6 +191,7 @@ function LoadOlder({
 
 export function MessageThread({
 	messages,
+	agentActions = [],
 	search = "",
 	hasOlder = false,
 	onLoadOlder,
@@ -198,6 +199,10 @@ export function MessageThread({
 	knowledge,
 }: {
 	messages: Message[];
+	/** Durable audit trail of actions the agent took on this conversation
+	 * (bookings, order lookups, returns) — operator visibility into what the bot
+	 * DID, so a mistaken/abusive action can be seen and reversed upstream. */
+	agentActions?: AgentActionEntry[];
 	/** Active inbox search term. When set, every occurrence is highlighted in the
 	 * thread and the first matching message is scrolled into view on open. */
 	search?: string;
@@ -285,6 +290,29 @@ export function MessageThread({
 					loading={loadingOlder}
 					scrollRef={containerRef}
 				/>
+			)}
+			{agentActions.length > 0 && (
+				<div className="rounded-md border border-ck-border/70 bg-ck-paper2/40 px-3 py-2 text-xs">
+					<div className="mb-1 font-medium text-ck-faint">
+						Agent actions ({agentActions.length})
+					</div>
+					<ul className="flex flex-col gap-0.5">
+						{agentActions.map((a) => (
+							<li key={a.id} className="flex items-baseline gap-2">
+								<span
+									aria-hidden
+									className={a.ok ? "text-ck-good" : "text-ck-warn"}
+								>
+									{a.ok ? "✓" : "✕"}
+								</span>
+								<span className="text-ck-muted">
+									<span className="font-mono">{a.tool}</span>
+									{a.detail ? ` — ${a.detail}` : ""}
+								</span>
+							</li>
+						))}
+					</ul>
+				</div>
 			)}
 			{messages.map((m) =>
 				m.role === "system" ? (

--- a/apps/dashboard/src/app/inbox/_components/thread-window.test.ts
+++ b/apps/dashboard/src/app/inbox/_components/thread-window.test.ts
@@ -42,6 +42,7 @@ function window(
 		messages,
 		hasOlder: false,
 		firstHitSequence: null,
+		agentActions: [],
 		...extra,
 	};
 }

--- a/apps/dashboard/src/app/inbox/_components/thread-window.ts
+++ b/apps/dashboard/src/app/inbox/_components/thread-window.ts
@@ -1,4 +1,4 @@
-import type { Conversation, Message } from "./types";
+import type { AgentActionEntry, Conversation, Message } from "./types";
 
 /** Page size for the message thread. Also the threshold: a conversation with
  * this many messages or fewer loads in one shot (hasOlder=false) and behaves
@@ -13,6 +13,9 @@ export interface ThreadResponse {
 	messages: Message[];
 	hasOlder: boolean;
 	firstHitSequence?: number | null;
+	/** Durable agent-action audit trail for this conversation (full set per
+	 * fetch, bounded server-side). Absent on older clients / empty conversations. */
+	agentActions?: AgentActionEntry[];
 }
 
 /** The contiguous window the inbox holds for the open conversation. */
@@ -23,6 +26,8 @@ export interface ThreadWindow {
 	/** Sequence of the first search hit (null = none / not searching). Preserved
 	 * across poll/load-older merges; only a fresh search fetch updates it. */
 	firstHitSequence: number | null;
+	/** Agent-action audit trail, refreshed from the latest fetch. */
+	agentActions: AgentActionEntry[];
 }
 
 function sortBySequence(messages: Message[]): Message[] {
@@ -51,6 +56,7 @@ export function toWindow(res: ThreadResponse): ThreadWindow {
 		messages: sortBySequence(res.messages),
 		hasOlder: res.hasOlder,
 		firstHitSequence: res.firstHitSequence ?? null,
+		agentActions: res.agentActions ?? [],
 	};
 }
 
@@ -67,6 +73,9 @@ export function appendNewer(
 		...prev,
 		conversation: res.conversation,
 		messages: unionById(prev.messages, res.messages),
+		// The endpoint returns the full per-conversation action set each fetch, so
+		// the newest poll response carries any action taken since the last tick.
+		agentActions: res.agentActions ?? prev.agentActions,
 	};
 }
 

--- a/apps/dashboard/src/app/inbox/_components/types.ts
+++ b/apps/dashboard/src/app/inbox/_components/types.ts
@@ -66,3 +66,15 @@ export interface Message {
 	 * = unrated. Distinct from per-conversation CSAT. */
 	rating?: "up" | "down" | null;
 }
+
+/** A durable record of an action the AGENT took on this conversation (Cal.com
+ * booking, Shopify order lookup / return). Operator-visible audit trail so a
+ * mistaken or abusive action can be seen (and reversed in Shopify/Cal.com). */
+export interface AgentActionEntry {
+	id: string;
+	kind: "calcom" | "shopify";
+	tool: string;
+	ok: boolean;
+	detail: string | null;
+	createdAt: number;
+}

--- a/apps/dashboard/src/app/inbox/_components/useThreadMessages.ts
+++ b/apps/dashboard/src/app/inbox/_components/useThreadMessages.ts
@@ -151,6 +151,7 @@ export function useThreadMessages({
 	return {
 		conversation: data?.conversation ?? null,
 		messages: data?.messages ?? [],
+		agentActions: data?.agentActions ?? [],
 		hasOlder: data?.hasOlder ?? false,
 		loadOlder,
 		loadingOlder,

--- a/apps/dashboard/src/app/inbox/page.tsx
+++ b/apps/dashboard/src/app/inbox/page.tsx
@@ -707,6 +707,7 @@ function InboxPageInner() {
 					) : (
 						<MessageThread
 							messages={thread.messages}
+							agentActions={thread.agentActions}
 							search={debouncedSearch}
 							hasOlder={thread.hasOlder}
 							onLoadOlder={thread.loadOlder}

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -341,6 +341,38 @@ export const integration = sqliteTable(
 	(t) => [uniqueIndex("integration_project_kind").on(t.projectId, t.kind)],
 );
 
+// Durable, operator-visible audit trail of every action the AGENT took on a
+// visitor's behalf (Cal.com booking, Shopify order lookup / return). Append-only.
+// `params` is the sanitized tool input (order number, email, slot, item titles)
+// — NEVER credentials. `ok` records whether the upstream action succeeded; a
+// blocked/refused attempt is logged with ok=false so abuse is visible. Surfaced
+// in the dashboard conversation thread so a mistaken or abusive return/booking
+// can be seen (and reversed in Shopify/Cal.com) instead of being invisible.
+export const agentAction = sqliteTable(
+	"agent_action",
+	{
+		id: id(),
+		conversationId: text()
+			.notNull()
+			.references(() => conversation.id, { onDelete: "cascade" }),
+		projectId: text()
+			.notNull()
+			.references(() => project.id, { onDelete: "cascade" }),
+		workspaceId: text()
+			.notNull()
+			.references(() => workspace.id, { onDelete: "cascade" }),
+		kind: text({ enum: ["calcom", "shopify"] }).notNull(),
+		tool: text().notNull(),
+		ok: integer({ mode: "boolean" }).notNull(),
+		// Short human summary for the operator ("filed return #1001-R1 …").
+		detail: text(),
+		// Sanitized tool inputs as JSON — never secrets.
+		params: text().notNull().default("{}"),
+		createdAt: createdAt(),
+	},
+	(t) => [index("agent_action_conv").on(t.conversationId, t.createdAt)],
+);
+
 export const message = sqliteTable(
 	"message",
 	{

--- a/packages/shared/src/integrations.ts
+++ b/packages/shared/src/integrations.ts
@@ -27,8 +27,12 @@ export const calcomConfigSchema = z.object({
 	eventTypeId: z.number().int().positive(),
 	/** IANA time zone slots are quoted in (visitors see these times). */
 	timeZone: z.string().min(1).max(64).default("UTC"),
-	/** Override for tests/self-hosters — defaults to https://api.cal.com. */
-	apiBase: z.url().optional(),
+	// NOTE: there is deliberately NO `apiBase` here. A stored, admin-writable
+	// base URL is an SSRF + credential-exfiltration vector — the agent attaches
+	// the raw Bearer key to every request, so a config-supplied host could
+	// exfiltrate it. The Cal.com host is pinned to api.cal.com in calcom.ts; a
+	// trusted, server-set env override (CALCOM_API_BASE) exists for tests/
+	// self-hosters and is NOT part of this untrusted config blob.
 });
 export type CalcomConfig = z.infer<typeof calcomConfigSchema>;
 
@@ -49,8 +53,10 @@ export const shopifyConfigSchema = z.object({
 		),
 	/** Admin API access token (shpat_…/shpca_…) — server-side only. */
 	accessToken: z.string().min(6).max(256),
-	/** Override for tests — defaults to https://<shopDomain>. */
-	apiBase: z.url().optional(),
+	// NOTE: there is deliberately NO `apiBase` here. See calcomConfigSchema —
+	// same SSRF/token-exfiltration reasoning. The Shopify host is always derived
+	// from the regex-validated `shopDomain` (shopify-admin.ts); a trusted,
+	// server-set env override (SHOPIFY_API_BASE) exists for tests/self-hosters.
 });
 export type ShopifyConfig = z.infer<typeof shopifyConfigSchema>;
 


### PR DESCRIPTION
## What

Merge-blocking security hardening for the agentic actions in #128, stacked onto
`feat/agent-integrations`. Addresses the four conditions from the security
review's **GO-WITH-CONDITIONS** verdict. **Do not merge #128 without these.**

## The four fixes

- **SSRF / credential-exfiltration (C1).** Dropped `apiBase` from the stored
  integration config schema. The Shopify host is now always derived from the
  regex-validated `shopDomain`, and Cal.com is pinned to `api.cal.com`. A mock
  upstream is reachable only via a **trusted, server-set** `SHOPIFY_API_BASE` /
  `CALCOM_API_BASE` env (or a unit-test param) — a workspace admin can no longer
  write a config that sends the raw access token / Bearer key to an arbitrary host.
- **Operator audit visibility (C2).** New `agent_action` table (migration `0019`)
  records **every** tool call — kind, tool, ok/blocked, a human detail, and
  sanitized params (order #, email — never credentials). Surfaced on the
  authenticated conversation-thread endpoint and rendered as an "Agent actions"
  strip in the inbox, so a mistaken or abusive booking/return is visible and can
  be reversed upstream.
- **Cal.com ownership binding (C3).** `book_meeting`'s attendee is now **always**
  the conversation's on-file identity email — the model-chosen email param is
  gone, closing the "book a call for victim@x.com" vector. `chat.ts` captures a
  body email onto an anonymous conversation so identified visitors can still book.
- **Return-gate hardening + action rate limiting (C4).** An action-scoped rate
  bucket (per project+IP) **plus** a per-project daily cap, both **fail-closed**
  and separate from the 20/hr chat limit; `create_return` idempotency via
  `reserveOnce` (STATE, fail-closed) prevents double-filing. Email-possession
  proof / OTP on `create_return` is a tracked fast-follow (needs an email
  round-trip + multi-turn state).

## Testing (adversarial-first)

New `apps/api/src/lib/integration-hardening.test.ts` (10 tests) attacks the
**hardened** code and proves each vector is blocked, then confirms the happy
path and the audit capture:

- "book for victim@x.com" → invite goes to the on-file address; the tool schema
  exposes no email field.
- config `apiBase=evil` → stripped; token reaches only the shop domain.
- action spam (book / return) → refused before any upstream call.
- duplicate return → filed exactly once.
- cross-tenant order access (mismatched email) → still `null`.
- happy path: legit booking + legit return work; a trusted override still redirects.
- audit: a filed return logs `ok:true` with detail and **no** token in params.

`api` **557** + `dashboard` **442** tests pass; `tsc` and `oxlint` clean;
migration `0019` DDL validated. No new required prod config — the override envs
are optional (unset ⇒ pinned hosts); only migration `0019` needs to apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018pJJgDHCnnNeEqEAApxFcQ
