### PR TITLE
feat: widget UX — expandable panel, suggested questions, conversation-end CSAT, new conversations

### DIFF
--- a/apps/api/migrations/0020_project_suggested_questions.sql
+++ b/apps/api/migrations/0020_project_suggested_questions.sql
@@ -1,0 +1,1 @@
+ALTER TABLE project ADD COLUMN suggested_questions text NOT NULL DEFAULT '[]';

--- a/apps/api/src/routes/projects.test.ts
+++ b/apps/api/src/routes/projects.test.ts
@@ -362,6 +362,31 @@ describe("PATCH /projects/:id — partial update never clobbers siblings", () =>
 		expect(lastSetData).toEqual({ [field]: value });
 	});
 
+	it("PATCH { suggestedQuestions } writes only that field", async () => {
+		mockDb({ role: "admin", existingProject: { id: "p1" } });
+		const res = await patch({ suggestedQuestions: ["Pricing?", "Refunds?"] });
+		expect(res.status).toBe(200);
+		expect(lastSetData).toEqual({
+			suggestedQuestions: ["Pricing?", "Refunds?"],
+		});
+	});
+
+	it("400s more than 6 suggested questions (public-config payload stays bounded)", async () => {
+		mockDb({ role: "admin", existingProject: { id: "p1" } });
+		const res = await patch({
+			suggestedQuestions: ["a", "b", "c", "d", "e", "f", "g"],
+		});
+		expect(res.status).toBe(400);
+		expect(updateSpy).not.toHaveBeenCalled();
+	});
+
+	it("400s a blank suggested question (trimmed empties are rejected)", async () => {
+		mockDb({ role: "admin", existingProject: { id: "p1" } });
+		const res = await patch({ suggestedQuestions: ["   "] });
+		expect(res.status).toBe(400);
+		expect(updateSpy).not.toHaveBeenCalled();
+	});
+
 	it("favorite toggle writes ONLY favorite (the worst clobber path)", async () => {
 		mockDb({ role: "admin", existingProject: { id: "p1" } });
 		const res = await patch({ favorite: true });

--- a/apps/api/src/routes/projects.ts
+++ b/apps/api/src/routes/projects.ts
@@ -24,6 +24,13 @@ import {
 
 import type { AppContext } from "@/env";
 
+// Starter questions the widget shows as tappable chips. Bounded so a project
+// can't stuff the public config payload: at most 6 questions, 200 chars each,
+// blanks rejected after trimming.
+const suggestedQuestionsInput = z
+	.array(z.string().trim().min(1).max(200))
+	.max(6);
+
 // CREATE keeps the defaults so a project can be made from just `{ name }` — the
 // unspecified columns get sensible starting values on insert.
 const projectCreateInput = z.object({
@@ -38,6 +45,7 @@ const projectCreateInput = z.object({
 	notifyEmail: z.email().nullable().optional(),
 	slackWebhookUrl: z.url().nullable().optional(),
 	privacyPolicyUrl: z.url().nullable().optional(),
+	suggestedQuestions: suggestedQuestionsInput.default([]),
 	favorite: z.boolean().optional(),
 	pinned: z.boolean().optional(),
 });
@@ -61,6 +69,7 @@ const projectUpdateInput = z.object({
 	notifyEmail: z.email().nullable().optional(),
 	slackWebhookUrl: z.url().nullable().optional(),
 	privacyPolicyUrl: z.url().nullable().optional(),
+	suggestedQuestions: suggestedQuestionsInput.optional(),
 	favorite: z.boolean().optional(),
 	pinned: z.boolean().optional(),
 });

--- a/apps/api/src/routes/widget-config.test.ts
+++ b/apps/api/src/routes/widget-config.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { db } from "@/lib/db";
+import { resolveAccess } from "@/lib/plan";
+
+import { widgetConfig } from "./widget-config";
+
+vi.mock("@/lib/db", () => ({ db: vi.fn() }));
+vi.mock("@/lib/plan", () => ({ resolveAccess: vi.fn() }));
+
+const ENV = {} as unknown as Parameters<typeof widgetConfig.request>[2];
+
+function mockProject(
+	project: Record<string, unknown> | undefined,
+	branding: "badge" | "none" = "badge",
+) {
+	vi.mocked(db).mockReturnValue({
+		query: { project: { findFirst: async () => project } },
+	} as unknown as ReturnType<typeof db>);
+	vi.mocked(resolveAccess).mockResolvedValue({
+		entitlements: { branding },
+	} as unknown as Awaited<ReturnType<typeof resolveAccess>>);
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("GET /config/:key — public widget config", () => {
+	it("returns the admin-defined suggested questions", async () => {
+		mockProject({
+			workspaceId: "ws1",
+			privacyPolicyUrl: null,
+			suggestedQuestions: ["Pricing?", "Refunds?"],
+		});
+		const res = await widgetConfig.request("/config/pk_x", {}, ENV);
+		expect(res.status).toBe(200);
+		expect(await res.json()).toEqual({
+			showBranding: true,
+			privacyPolicyUrl: null,
+			suggestedQuestions: ["Pricing?", "Refunds?"],
+		});
+	});
+
+	it("degrades a malformed suggestions column to no chips, never a 500", async () => {
+		mockProject({
+			workspaceId: "ws1",
+			privacyPolicyUrl: null,
+			// A legacy/corrupt value that isn't an array of strings.
+			suggestedQuestions: { bogus: true },
+		});
+		const res = await widgetConfig.request("/config/pk_x", {}, ENV);
+		expect(res.status).toBe(200);
+		expect(await res.json()).toMatchObject({ suggestedQuestions: [] });
+	});
+
+	it("404s an unknown project key", async () => {
+		mockProject(undefined);
+		const res = await widgetConfig.request("/config/nope", {}, ENV);
+		expect(res.status).toBe(404);
+	});
+});

--- a/apps/api/src/routes/widget-config.ts
+++ b/apps/api/src/routes/widget-config.ts
@@ -18,7 +18,11 @@ export const widgetConfig = new Hono<AppContext>().get(
 		const key = c.req.param("key");
 		const project = await db(c.env).query.project.findFirst({
 			where: (pt, { eq: e }) => e(pt.publicKey, key),
-			columns: { workspaceId: true, privacyPolicyUrl: true },
+			columns: {
+				workspaceId: true,
+				privacyPolicyUrl: true,
+				suggestedQuestions: true,
+			},
 		});
 		if (!project) {
 			return c.json({ error: "invalid project key" }, 404);
@@ -30,6 +34,11 @@ export const widgetConfig = new Hono<AppContext>().get(
 			showBranding: entitlements.branding === "badge",
 			// Null → the widget links its privacy notice to its built-in default.
 			privacyPolicyUrl: project.privacyPolicyUrl ?? null,
+			// Starter-question chips the widget offers before the first message.
+			// Guarded: a malformed/legacy column value degrades to no chips.
+			suggestedQuestions: Array.isArray(project.suggestedQuestions)
+				? project.suggestedQuestions.filter((q) => typeof q === "string")
+				: [],
 		});
 	},
 );

--- a/apps/dashboard/src/app/settings/projects/[id]/ChatPreviewCard.tsx
+++ b/apps/dashboard/src/app/settings/projects/[id]/ChatPreviewCard.tsx
@@ -14,12 +14,15 @@ export function ChatPreviewCard({
 	name,
 	welcomeMessage,
 	brandColor,
+	suggestedQuestions = [],
 }: {
 	name: string;
 	welcomeMessage: string;
 	brandColor: string;
+	suggestedQuestions?: string[];
 }) {
 	const color = brandColor || "#000000";
+	const chips = suggestedQuestions.map((q) => q.trim()).filter(Boolean);
 
 	return (
 		<Card id="chat-preview" className="rounded-2xl shadow-sm">
@@ -59,6 +62,24 @@ export function ChatPreviewCard({
 									9:41 AM
 								</span>
 							</div>
+							{/* Suggested-question chips, mirroring the widget's starter chips. */}
+							{chips.length > 0 && (
+								<div className="flex flex-wrap gap-1.5 pt-1">
+									{chips.map((q) => (
+										<span
+											key={q}
+											className="rounded-full border px-2.5 py-1 text-xs font-medium"
+											style={{
+												borderColor: `${color}59`,
+												color,
+												backgroundColor: `${color}14`,
+											}}
+										>
+											{q}
+										</span>
+									))}
+								</div>
+							)}
 						</div>
 						{/* Input */}
 						<div className="flex items-center gap-2 border-t border-border px-4 py-3">

--- a/apps/dashboard/src/app/settings/projects/[id]/_tabs/BehaviorTab.test.tsx
+++ b/apps/dashboard/src/app/settings/projects/[id]/_tabs/BehaviorTab.test.tsx
@@ -22,6 +22,7 @@ function draft(o: Partial<ProjectDraft> = {}): ProjectDraft {
 		notifyEmail: null,
 		slackWebhookUrl: null,
 		privacyPolicyUrl: null,
+		suggestedQuestions: [],
 		...o,
 	};
 }

--- a/apps/dashboard/src/app/settings/projects/[id]/_tabs/GeneralTab.test.tsx
+++ b/apps/dashboard/src/app/settings/projects/[id]/_tabs/GeneralTab.test.tsx
@@ -16,6 +16,7 @@ function draft(): ProjectDraft {
 		notifyEmail: null,
 		slackWebhookUrl: null,
 		privacyPolicyUrl: null,
+		suggestedQuestions: [],
 	};
 }
 

--- a/apps/dashboard/src/app/settings/projects/[id]/_tabs/WidgetTab.test.tsx
+++ b/apps/dashboard/src/app/settings/projects/[id]/_tabs/WidgetTab.test.tsx
@@ -16,6 +16,7 @@ function draft(o: Partial<ProjectDraft> = {}): ProjectDraft {
 		notifyEmail: null,
 		slackWebhookUrl: null,
 		privacyPolicyUrl: null,
+		suggestedQuestions: [],
 		...o,
 	};
 }
@@ -62,5 +63,49 @@ describe("WidgetTab", () => {
 		expect(
 			screen.getByText(/position options are coming/i),
 		).toBeInTheDocument();
+	});
+
+	it("adds a suggested-question row", async () => {
+		render(<WidgetTab draft={draft()} set={set} publicKey="pk_x" />);
+		await userEvent
+			.setup()
+			.click(screen.getByRole("button", { name: /add question/i }));
+		expect(set).toHaveBeenCalledWith("suggestedQuestions", [""]);
+	});
+
+	it("edits and removes an existing suggested question", async () => {
+		const user = userEvent.setup();
+		render(
+			<WidgetTab
+				draft={draft({ suggestedQuestions: ["Pricing?", "Refunds?"] })}
+				set={set}
+				publicKey="pk_x"
+			/>,
+		);
+		await user.type(
+			screen.getByRole("textbox", { name: /^suggested question 1$/i }),
+			"!",
+		);
+		expect(set).toHaveBeenCalledWith("suggestedQuestions", [
+			"Pricing?!",
+			"Refunds?",
+		]);
+		await user.click(
+			screen.getByRole("button", { name: /remove suggested question 2/i }),
+		);
+		expect(set).toHaveBeenCalledWith("suggestedQuestions", ["Pricing?"]);
+	});
+
+	it("caps the list at 6 questions (no Add button at the cap)", () => {
+		render(
+			<WidgetTab
+				draft={draft({ suggestedQuestions: ["a", "b", "c", "d", "e", "f"] })}
+				set={set}
+				publicKey="pk_x"
+			/>,
+		);
+		expect(
+			screen.queryByRole("button", { name: /add question/i }),
+		).not.toBeInTheDocument();
 	});
 });

--- a/apps/dashboard/src/app/settings/projects/[id]/_tabs/WidgetTab.tsx
+++ b/apps/dashboard/src/app/settings/projects/[id]/_tabs/WidgetTab.tsx
@@ -1,10 +1,12 @@
 "use client";
 
-import { Card, dsInputClass, Field } from "@/components/ds";
+import { Plus, X } from "lucide-react";
+
+import { Button, Card, dsInputClass, Field } from "@/components/ds";
 import { EmbedSnippet } from "@/components/embed-snippet";
 
 import { ChatPreviewCard } from "../ChatPreviewCard";
-import type { ProjectDraft } from "../types";
+import { MAX_SUGGESTED_QUESTIONS, type ProjectDraft } from "../types";
 
 export function WidgetTab({
 	draft,
@@ -59,6 +61,66 @@ export function WidgetTab({
 					</Field>
 
 					<Field
+						label="Suggested questions"
+						hint="Tappable chips shown before the visitor's first message — great for FAQs. Up to 6."
+					>
+						{(id) => (
+							<div className="flex flex-col gap-2">
+								{draft.suggestedQuestions.map((q, i) => (
+									// Position-keyed on purpose: rows are editable in place, so
+									// content-keying would remount the input on every keystroke.
+									// eslint-disable-next-line react/no-array-index-key
+									<div key={i} className="flex items-center gap-2">
+										<input
+											id={i === 0 ? id : undefined}
+											className={dsInputClass}
+											value={q}
+											maxLength={200}
+											placeholder="e.g. What are your pricing plans?"
+											aria-label={`Suggested question ${i + 1}`}
+											onChange={(e) => {
+												const next = [...draft.suggestedQuestions];
+												next[i] = e.target.value;
+												set("suggestedQuestions", next);
+											}}
+										/>
+										<Button
+											variant="ghost"
+											size="sm"
+											className="shrink-0 text-ck-faint"
+											aria-label={`Remove suggested question ${i + 1}`}
+											onClick={() =>
+												set(
+													"suggestedQuestions",
+													draft.suggestedQuestions.filter((_, j) => j !== i),
+												)
+											}
+										>
+											<X className="size-4" />
+										</Button>
+									</div>
+								))}
+								{draft.suggestedQuestions.length < MAX_SUGGESTED_QUESTIONS && (
+									<Button
+										variant="outline"
+										size="sm"
+										className="self-start"
+										onClick={() =>
+											set("suggestedQuestions", [
+												...draft.suggestedQuestions,
+												"",
+											])
+										}
+									>
+										<Plus className="size-4" />
+										Add question
+									</Button>
+								)}
+							</div>
+						)}
+					</Field>
+
+					<Field
 						label="Privacy policy URL"
 						hint="Linked from the “you agree to our privacy policy” notice. Leave blank to use the Clanker Support default."
 					>
@@ -96,6 +158,7 @@ export function WidgetTab({
 					name={draft.name}
 					welcomeMessage={draft.welcomeMessage}
 					brandColor={draft.brandColor}
+					suggestedQuestions={draft.suggestedQuestions}
 				/>
 			</div>
 

--- a/apps/dashboard/src/app/settings/projects/[id]/page.test.tsx
+++ b/apps/dashboard/src/app/settings/projects/[id]/page.test.tsx
@@ -49,6 +49,7 @@ const PROJECT: Project = {
 	notifyEmail: null,
 	slackWebhookUrl: null,
 	privacyPolicyUrl: null,
+	suggestedQuestions: [],
 };
 
 beforeEach(() => {

--- a/apps/dashboard/src/app/settings/projects/[id]/page.tsx
+++ b/apps/dashboard/src/app/settings/projects/[id]/page.tsx
@@ -34,6 +34,7 @@ const EDITABLE_KEYS: (keyof ProjectDraft)[] = [
 	"notifyEmail",
 	"slackWebhookUrl",
 	"privacyPolicyUrl",
+	"suggestedQuestions",
 ];
 
 function toDraft(p: Project): ProjectDraft {
@@ -47,7 +48,18 @@ function toDraft(p: Project): ProjectDraft {
 		notifyEmail: p.notifyEmail,
 		slackWebhookUrl: p.slackWebhookUrl,
 		privacyPolicyUrl: p.privacyPolicyUrl,
+		// Fallback: a cached project fetched before the column existed.
+		suggestedQuestions: p.suggestedQuestions ?? [],
 	};
+}
+
+/** Draft-vs-saved equality; arrays (suggestedQuestions) compare by content,
+ * everything else by identity like before. */
+function sameValue(a: unknown, b: unknown): boolean {
+	if (Array.isArray(a) && Array.isArray(b)) {
+		return a.length === b.length && a.every((v, i) => v === b[i]);
+	}
+	return a === b;
 }
 
 type Tab = "general" | "widget" | "behavior" | "integrations" | "members";
@@ -110,7 +122,12 @@ export default function ProjectSettingsPage() {
 		setDraft((d) => (d ? { ...d, [key]: value } : d));
 	}
 
-	const dirtyKeys = EDITABLE_KEYS.filter((k) => draft![k] !== project![k]);
+	// Compare against the normalized saved state (toDraft) so a legacy cached
+	// project without suggestedQuestions doesn't read as permanently dirty.
+	const saved = toDraft(project);
+	const dirtyKeys = EDITABLE_KEYS.filter(
+		(k) => !sameValue(draft![k], saved[k]),
+	);
 	const dirty = dirtyKeys.length > 0;
 
 	function handleSave() {
@@ -118,6 +135,12 @@ export default function ProjectSettingsPage() {
 		const payload: Partial<Project> = {};
 		for (const k of dirtyKeys) {
 			(payload as Record<string, unknown>)[k] = draft[k];
+		}
+		// Drop blank chip rows (the editor allows an empty row while typing).
+		if (payload.suggestedQuestions) {
+			payload.suggestedQuestions = payload.suggestedQuestions
+				.map((q) => q.trim())
+				.filter(Boolean);
 		}
 		// Editing Instructions makes systemPrompt authoritative — clear any active
 		// library prompt that would override it.

--- a/apps/dashboard/src/app/settings/projects/[id]/types.ts
+++ b/apps/dashboard/src/app/settings/projects/[id]/types.ts
@@ -12,6 +12,8 @@ export interface Project {
 	notifyEmail: string | null;
 	slackWebhookUrl: string | null;
 	privacyPolicyUrl: string | null;
+	/** Starter questions the widget offers as tappable chips (max 6). */
+	suggestedQuestions: string[];
 }
 
 export interface Source {
@@ -47,7 +49,11 @@ export type ProjectDraft = Pick<
 	| "notifyEmail"
 	| "slackWebhookUrl"
 	| "privacyPolicyUrl"
+	| "suggestedQuestions"
 >;
+
+/** Widget chip cap — mirrored by the API's validation. */
+export const MAX_SUGGESTED_QUESTIONS = 6;
 
 export const INSTRUCTION_TEMPLATES = {
 	support: `You are a helpful customer support assistant for our website. Answer questions based on the provided sources. Be friendly, concise and professional. If you don't know the answer, suggest contacting our support team.`,

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -167,6 +167,12 @@ export const project = sqliteTable(
 		// Absolute URL the widget's "agree to our privacy policy" notice links to.
 		// Null → the widget falls back to the Clanker Support default policy.
 		privacyPolicyUrl: text(),
+		// Admin-defined starter questions the widget offers as tappable chips
+		// before the visitor's first message. JSON array of strings.
+		suggestedQuestions: text({ mode: "json" })
+			.$type<string[]>()
+			.notNull()
+			.default([]),
 		// Local part for inbound email replies: reply+<inboundEmailLocal>@domain
 		inboundEmailLocal: text().notNull().unique(),
 		createdAt: createdAt(),

--- a/packages/widget/src/components/ResolvedNotice.tsx
+++ b/packages/widget/src/components/ResolvedNotice.tsx
@@ -4,12 +4,18 @@ const RESOLVED_NOTICE = "This conversation has been marked resolved.";
  * One-time post-resolve band shown below the message list (mirrors
  * EscalationNotice; reuses the .llmchat-escalated band). Actor-neutral copy: the
  * widget only knows the conversation is resolved (from the feed's archivedAt),
- * not whether the visitor or an operator resolved it.
+ * not whether the visitor or an operator resolved it. When the caller passes
+ * onStartNew, the band also offers starting a fresh conversation.
  */
-export function ResolvedNotice() {
+export function ResolvedNotice({ onStartNew }: { onStartNew?: () => void }) {
 	return (
 		<div className="llmchat-escalated" role="status">
 			<p className="llmchat-escalated-notice">{RESOLVED_NOTICE}</p>
+			{onStartNew && (
+				<button type="button" className="llmchat-restart" onClick={onStartNew}>
+					Start a new conversation
+				</button>
+			)}
 		</div>
 	);
 }

--- a/packages/widget/src/components/SuggestedQuestions.tsx
+++ b/packages/widget/src/components/SuggestedQuestions.tsx
@@ -1,0 +1,35 @@
+/**
+ * Admin-defined starter questions, rendered as tappable chips between the
+ * message list and the composer. The caller gates visibility (only before the
+ * visitor's first message) and sends the picked question as a normal chat
+ * message — a chip is a shortcut for typing, nothing more.
+ */
+export function SuggestedQuestions({
+	questions,
+	onPick,
+}: {
+	questions: string[];
+	onPick: (question: string) => void;
+}) {
+	if (questions.length === 0) {
+		return null;
+	}
+	return (
+		<div
+			className="llmchat-chips llmchat-suggestions"
+			role="group"
+			aria-label="Suggested questions"
+		>
+			{questions.map((q) => (
+				<button
+					key={q}
+					type="button"
+					className="llmchat-chip"
+					onClick={() => onPick(q)}
+				>
+					{q}
+				</button>
+			))}
+		</div>
+	);
+}

--- a/packages/widget/src/components/WidgetFrame.test.tsx
+++ b/packages/widget/src/components/WidgetFrame.test.tsx
@@ -41,6 +41,25 @@ describe("WidgetFrame — floating bubble layout", () => {
 	});
 });
 
+describe("WidgetFrame — expand toggle", () => {
+	it("expands the panel and toggles back", async () => {
+		renderFrame({ open: true });
+		const panel = screen.getByRole("dialog", { name: /support chat/i });
+		expect(panel.className).not.toContain("llmchat-panel--expanded");
+		await userEvent.click(screen.getByRole("button", { name: /expand chat/i }));
+		expect(panel.className).toContain("llmchat-panel--expanded");
+		await userEvent.click(
+			screen.getByRole("button", { name: /collapse chat/i }),
+		);
+		expect(panel.className).not.toContain("llmchat-panel--expanded");
+	});
+
+	it("renders header actions passed by the conversation variant", () => {
+		renderFrame({ open: true, actions: <button type="button">act</button> });
+		expect(screen.getByRole("button", { name: "act" })).toBeInTheDocument();
+	});
+});
+
 describe("WidgetFrame — inline layout", () => {
 	it("has no launcher and always shows the panel", () => {
 		renderFrame({ inline: true, open: true });
@@ -48,5 +67,9 @@ describe("WidgetFrame — inline layout", () => {
 			screen.queryByRole("button", { name: /open chat/i }),
 		).not.toBeInTheDocument();
 		expect(screen.getByText("panel body")).toBeInTheDocument();
+		// Inline fills its host — no expand toggle.
+		expect(
+			screen.queryByRole("button", { name: /expand chat/i }),
+		).not.toBeInTheDocument();
 	});
 });

--- a/packages/widget/src/components/WidgetFrame.tsx
+++ b/packages/widget/src/components/WidgetFrame.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 
-import { ChatIcon, CloseIcon } from "./icons";
+import { ChatIcon, CloseIcon, CollapseIcon, ExpandIcon } from "./icons";
 
 import type { ReactNode } from "react";
 
@@ -16,8 +16,9 @@ function prefersReducedMotion(): boolean {
 /**
  * Shared chrome for every widget variant: the floating launcher bubble (in
  * bubble layout), the panel, and the branded header. Conversation behavior is
- * composed in via children. Owns the open/close transition, Esc-to-close, and
- * focus management; conversation logic stays in the variant components.
+ * composed in via children. Owns the open/close transition, the expanded
+ * (large-panel) toggle, Esc-to-close, and focus management; conversation logic
+ * stays in the variant components.
  */
 export function WidgetFrame({
 	inline,
@@ -25,6 +26,7 @@ export function WidgetFrame({
 	open,
 	onOpenChange,
 	badge,
+	actions,
 	footer,
 	children,
 }: {
@@ -34,6 +36,9 @@ export function WidgetFrame({
 	onOpenChange: (open: boolean) => void;
 	/** Optional header adornment, e.g. the showcase "Demo mode" pill. */
 	badge?: ReactNode;
+	/** Optional header buttons rendered before the expand/close controls,
+	 * e.g. the "Start a new conversation" action. */
+	actions?: ReactNode;
 	/** Optional panel footer below the conversation, e.g. the "Powered by" badge. */
 	footer?: ReactNode;
 	children: ReactNode;
@@ -43,6 +48,10 @@ export function WidgetFrame({
 	// Keep the panel mounted through its exit animation (bubble layout only).
 	const [mounted, setMounted] = useState(open);
 	const wasOpen = useRef(open);
+	// Large-panel toggle (bubble layout only — inline already fills its host).
+	// Deliberately kept across close/reopen within the session: re-expanding on
+	// every open would fight a visitor who prefers the big panel.
+	const [expanded, setExpanded] = useState(false);
 
 	useEffect(() => {
 		if (open) {
@@ -99,6 +108,7 @@ export function WidgetFrame({
 					className={[
 						"llmchat-panel",
 						inline ? "llmchat-panel-inline" : "",
+						!inline && expanded ? "llmchat-panel--expanded" : "",
 						closing ? "llmchat-panel--closing" : "",
 					]
 						.filter(Boolean)
@@ -118,16 +128,30 @@ export function WidgetFrame({
 							<span className="llmchat-header-text">Support</span>
 						</span>
 						{badge}
-						{!inline && (
-							<button
-								type="button"
-								className="llmchat-icon-btn"
-								onClick={() => onOpenChange(false)}
-								aria-label="Close chat"
-							>
-								<CloseIcon />
-							</button>
-						)}
+						<span className="llmchat-header-actions">
+							{actions}
+							{!inline && (
+								<button
+									type="button"
+									className="llmchat-icon-btn"
+									onClick={() => setExpanded((e) => !e)}
+									aria-label={expanded ? "Collapse chat" : "Expand chat"}
+									aria-pressed={expanded}
+								>
+									{expanded ? <CollapseIcon /> : <ExpandIcon />}
+								</button>
+							)}
+							{!inline && (
+								<button
+									type="button"
+									className="llmchat-icon-btn"
+									onClick={() => onOpenChange(false)}
+									aria-label="Close chat"
+								>
+									<CloseIcon />
+								</button>
+							)}
+						</span>
 					</header>
 					{children}
 					{footer}

--- a/packages/widget/src/components/icons.tsx
+++ b/packages/widget/src/components/icons.tsx
@@ -140,6 +140,64 @@ export function CheckIcon({ className }: IconProps) {
 	);
 }
 
+export function ExpandIcon({ className }: IconProps) {
+	return (
+		<svg
+			className={className}
+			width="18"
+			height="18"
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="2"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			aria-hidden="true"
+		>
+			<path d="M15 3h6v6M9 21H3v-6M21 3l-7 7M3 21l7-7" />
+		</svg>
+	);
+}
+
+export function CollapseIcon({ className }: IconProps) {
+	return (
+		<svg
+			className={className}
+			width="18"
+			height="18"
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="2"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			aria-hidden="true"
+		>
+			<path d="M4 14h6v6M20 10h-6V4M14 10l7-7M3 21l7-7" />
+		</svg>
+	);
+}
+
+export function ComposeIcon({ className }: IconProps) {
+	return (
+		<svg
+			className={className}
+			width="18"
+			height="18"
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="2"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			aria-hidden="true"
+		>
+			<path d="M12 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
+			<path d="M18.375 2.625a2.121 2.121 0 1 1 3 3L12 15l-4 1 1-4Z" />
+		</svg>
+	);
+}
+
 export function AgentIcon({ className }: IconProps) {
 	return (
 		<svg

--- a/packages/widget/src/lib.ts
+++ b/packages/widget/src/lib.ts
@@ -13,6 +13,17 @@ export function getOrCreateClientId(): string {
 	return id;
 }
 
+/**
+ * Start a fresh conversation: mint a new client id and persist it under the
+ * same key, so the new conversation also survives reloads. The previous
+ * conversation stays intact server-side (keyed by the old id) for the inbox.
+ */
+export function rotateClientId(): string {
+	const id = crypto.randomUUID();
+	sessionStorage.setItem(CLIENT_ID_KEY, id);
+	return id;
+}
+
 export interface StoredIdentity {
 	name: string;
 	email: string;

--- a/packages/widget/src/styles.ts
+++ b/packages/widget/src/styles.ts
@@ -103,6 +103,15 @@ export const widgetStyles = `
 		0 0 0 1px rgba(0, 0, 0, 0.06);
 	z-index: 2147483647;
 	animation: llmchat-panel-in 0.24s cubic-bezier(0.16, 1, 0.3, 1);
+	transition:
+		width 0.24s cubic-bezier(0.16, 1, 0.3, 1),
+		height 0.24s cubic-bezier(0.16, 1, 0.3, 1);
+}
+/* Expanded (large) panel — bubble layout only. The base max-width/max-height
+   caps still apply, so small viewports simply fill the available space. */
+.llmchat-panel--expanded {
+	width: 680px;
+	height: 820px;
 }
 .llmchat-panel--closing {
 	animation: llmchat-panel-out 0.18s ease forwards;
@@ -177,8 +186,17 @@ export const widgetStyles = `
 	font-size: 15.2px;
 	letter-spacing: 0.01em;
 }
-.llmchat-icon-btn {
+/* Header buttons (new conversation / expand / close) grouped on the right.
+   The container owns the push-right so multiple buttons stay adjacent instead
+   of each fighting for margin-left: auto. */
+.llmchat-header-actions {
 	margin-left: auto;
+	display: flex;
+	align-items: center;
+	gap: 2px;
+	flex-shrink: 0;
+}
+.llmchat-icon-btn {
 	display: flex;
 	align-items: center;
 	justify-content: center;
@@ -684,8 +702,9 @@ export const widgetStyles = `
 	border-radius: 9999px;
 	padding: 2.4px 8px;
 }
-/* When the demo badge is present the close button shouldn't also push right. */
-.llmchat-demo-badge + .llmchat-icon-btn {
+/* When the demo badge is present it owns the push-right; the action buttons
+   just trail it with a small gap. */
+.llmchat-demo-badge + .llmchat-header-actions {
 	margin-left: 4px;
 }
 .llmchat-demo-note {
@@ -761,6 +780,33 @@ export const widgetStyles = `
 }
 .llmchat-escalated-notice {
 	margin: 0;
+}
+/* "Start a new conversation" inside the resolved band — same treatment as the
+   escalate CTA, scoped separately because it lives in .llmchat-escalated. */
+.llmchat-restart {
+	align-self: flex-start;
+	display: inline-flex;
+	align-items: center;
+	gap: 6.4px;
+	background: transparent;
+	color: var(--brand);
+	border: 1px solid color-mix(in srgb, var(--brand) 35%, transparent);
+	border-radius: 8px;
+	padding: 6.4px 12px;
+	font: inherit;
+	font-size: 13.6px;
+	font-weight: 600;
+	cursor: pointer;
+	transition:
+		background 0.15s ease,
+		border-color 0.15s ease;
+}
+.llmchat-restart:hover {
+	background: color-mix(in srgb, var(--brand) 8%, transparent);
+}
+.llmchat-restart:focus-visible {
+	outline: none;
+	box-shadow: 0 0 0 3px color-mix(in srgb, var(--brand) 30%, transparent);
 }
 
 /* ── Escalation handoff summary card ───────────────────────────────── */

--- a/packages/widget/src/useServerMessages.ts
+++ b/packages/widget/src/useServerMessages.ts
@@ -30,6 +30,17 @@ export function useServerMessages(
 	const [archivedAt, setArchivedAt] = useState<string | number | null>(null);
 	const abortRef = useRef<AbortController | null>(null);
 
+	// A different clientId is a different conversation ("start a new
+	// conversation" rotates it) — drop the old feed immediately instead of
+	// showing stale messages until the first poll of the new id lands.
+	useEffect(() => {
+		setServerMessages([]);
+		setConversationId(null);
+		setCsatRating(null);
+		setEscalatedAt(null);
+		setArchivedAt(null);
+	}, [apiUrl, projectKey, clientId]);
+
 	const load = useCallback(async () => {
 		abortRef.current?.abort();
 		const controller = new AbortController();

--- a/packages/widget/src/widget-config.ts
+++ b/packages/widget/src/widget-config.ts
@@ -7,6 +7,9 @@ export interface WidgetConfig {
 	/** Absolute URL the privacy notice links to, or null to use the widget's
 	 * built-in default (see PrivacyNotice). */
 	privacyPolicyUrl: string | null;
+	/** Admin-defined starter questions offered as tappable chips before the
+	 * visitor's first message. Empty → no chips. */
+	suggestedQuestions: string[];
 }
 
 /**
@@ -25,6 +28,7 @@ export function useWidgetConfig(
 	const [config, setConfig] = useState<WidgetConfig>({
 		showBranding: true,
 		privacyPolicyUrl: null,
+		suggestedQuestions: [],
 	});
 	useEffect(() => {
 		let active = true;
@@ -32,7 +36,11 @@ export function useWidgetConfig(
 			.then((r) => (r.ok ? r.json() : null))
 			.then(
 				(
-					data: { showBranding?: unknown; privacyPolicyUrl?: unknown } | null,
+					data: {
+						showBranding?: unknown;
+						privacyPolicyUrl?: unknown;
+						suggestedQuestions?: unknown;
+					} | null,
 				) => {
 					if (!active || !data) return;
 					setConfig((prev) => ({
@@ -44,6 +52,11 @@ export function useWidgetConfig(
 							typeof data.privacyPolicyUrl === "string"
 								? data.privacyPolicyUrl
 								: prev.privacyPolicyUrl,
+						suggestedQuestions: Array.isArray(data.suggestedQuestions)
+							? data.suggestedQuestions.filter(
+									(q): q is string => typeof q === "string" && q.trim() !== "",
+								)
+							: prev.suggestedQuestions,
 					}));
 				},
 			)

--- a/packages/widget/src/widget.escalated.test.tsx
+++ b/packages/widget/src/widget.escalated.test.tsx
@@ -15,7 +15,11 @@ vi.mock("@ai-sdk/react", () => ({
 	}),
 }));
 vi.mock("./widget-config", () => ({
-	useWidgetConfig: () => ({ showBranding: false, privacyPolicyUrl: null }),
+	useWidgetConfig: () => ({
+		showBranding: false,
+		privacyPolicyUrl: null,
+		suggestedQuestions: [],
+	}),
 }));
 
 import * as serverMessages from "./useServerMessages";

--- a/packages/widget/src/widget.escalation-intent.test.tsx
+++ b/packages/widget/src/widget.escalation-intent.test.tsx
@@ -15,7 +15,11 @@ vi.mock("@ai-sdk/react", () => ({
 	}),
 }));
 vi.mock("./widget-config", () => ({
-	useWidgetConfig: () => ({ showBranding: false, privacyPolicyUrl: null }),
+	useWidgetConfig: () => ({
+		showBranding: false,
+		privacyPolicyUrl: null,
+		suggestedQuestions: [],
+	}),
 }));
 
 import * as serverMessages from "./useServerMessages";

--- a/packages/widget/src/widget.identity.test.tsx
+++ b/packages/widget/src/widget.identity.test.tsx
@@ -14,7 +14,11 @@ vi.mock("@ai-sdk/react", () => ({
 	}),
 }));
 vi.mock("./widget-config", () => ({
-	useWidgetConfig: () => ({ showBranding: false, privacyPolicyUrl: null }),
+	useWidgetConfig: () => ({
+		showBranding: false,
+		privacyPolicyUrl: null,
+		suggestedQuestions: [],
+	}),
 }));
 
 import { setStoredIdentity } from "./lib";

--- a/packages/widget/src/widget.new-conversation.test.tsx
+++ b/packages/widget/src/widget.new-conversation.test.tsx
@@ -1,0 +1,135 @@
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// Keep the live widget off the network/model: stub the chat transport + hook,
+// the branding probe, and the resolve call; drive the feed via a spy.
+vi.mock("ai", () => ({ DefaultChatTransport: class {} }));
+vi.mock("@ai-sdk/react", () => ({
+	Chat: class {},
+	useChat: () => ({
+		messages: [],
+		sendMessage: vi.fn(async () => {}),
+		status: "ready",
+		error: null,
+	}),
+}));
+vi.mock("./widget-config", () => ({
+	useWidgetConfig: () => ({
+		showBranding: false,
+		privacyPolicyUrl: null,
+		suggestedQuestions: [],
+	}),
+}));
+vi.mock("./resolve", () => ({
+	requestResolve: vi.fn(async () => ({ resolved: true })),
+}));
+
+import * as serverMessages from "./useServerMessages";
+import { Widget } from "./widget";
+
+afterEach(() => {
+	vi.restoreAllMocks();
+	sessionStorage.clear();
+	localStorage.clear();
+});
+
+/** A feed with a real exchange so the conversation is CSAT-eligible unless
+ * csatRating says otherwise. */
+function mockFeed(opts: { csatRating?: number | null } = {}) {
+	vi.spyOn(serverMessages, "useServerMessages").mockReturnValue({
+		serverMessages: [
+			{ id: "s1", role: "user", content: "hi", sequence: 1, createdAt: 1 },
+			{
+				id: "s2",
+				role: "assistant",
+				content: "hello",
+				sequence: 2,
+				createdAt: 2,
+			},
+		],
+		conversationId: "c1",
+		csatRating: opts.csatRating ?? null,
+		escalatedAt: null,
+		archivedAt: null,
+		refresh: vi.fn(),
+	});
+}
+
+async function mountIdentified(opts: {
+	csatRating?: number | null;
+	mode?: "inline" | "bubble";
+}) {
+	mockFeed(opts);
+	render(
+		<Widget
+			widgetMode="live"
+			projectKey="pk"
+			apiUrl="http://x"
+			brandColor="#4f46e5"
+			mode={opts.mode ?? "inline"}
+		/>,
+	);
+	if (opts.mode === "bubble") {
+		await userEvent.click(screen.getByRole("button", { name: /open chat/i }));
+	}
+	await userEvent.type(screen.getByPlaceholderText(/your name/i), "Test");
+	await userEvent.click(screen.getByRole("button", { name: /start chat/i }));
+}
+
+describe("LiveWidget — closing the panel never prompts for feedback", () => {
+	it("closes on X without showing the CSAT step, even when eligible", async () => {
+		await mountIdentified({ mode: "bubble" });
+		// The header X, not the launcher (both are labeled "Close chat" while open).
+		const panel = screen.getByRole("dialog", { name: /support chat/i });
+		await userEvent.click(
+			within(panel).getByRole("button", { name: /close chat/i }),
+		);
+		expect(
+			screen.queryByText(/how was your experience/i),
+		).not.toBeInTheDocument();
+	});
+});
+
+describe("LiveWidget — start a new conversation", () => {
+	it("prompts for CSAT when ending an eligible conversation, then resets on skip", async () => {
+		await mountIdentified({});
+		const before = sessionStorage.getItem("llmchat_client_id");
+		await userEvent.click(
+			screen.getByRole("button", { name: /start a new conversation/i }),
+		);
+		// Ending the conversation IS the feedback moment.
+		expect(screen.getByText(/how was your experience/i)).toBeInTheDocument();
+		await userEvent.click(screen.getByRole("button", { name: /skip/i }));
+		// Back to a (fresh) conversation view with a rotated client id.
+		expect(
+			screen.queryByText(/how was your experience/i),
+		).not.toBeInTheDocument();
+		expect(
+			screen.getByRole("textbox", { name: /message/i }),
+		).toBeInTheDocument();
+		expect(sessionStorage.getItem("llmchat_client_id")).not.toBe(before);
+	});
+
+	it("skips the CSAT prompt entirely when the conversation was already rated", async () => {
+		await mountIdentified({ csatRating: 5 });
+		const before = sessionStorage.getItem("llmchat_client_id");
+		await userEvent.click(
+			screen.getByRole("button", { name: /start a new conversation/i }),
+		);
+		expect(
+			screen.queryByText(/how was your experience/i),
+		).not.toBeInTheDocument();
+		expect(sessionStorage.getItem("llmchat_client_id")).not.toBe(before);
+	});
+});
+
+describe("LiveWidget — resolving ends the conversation", () => {
+	it("shows the CSAT prompt after the visitor marks the conversation resolved", async () => {
+		await mountIdentified({});
+		await userEvent.click(
+			screen.getByRole("button", { name: /mark resolved/i }),
+		);
+		expect(screen.getByText(/how was your experience/i)).toBeInTheDocument();
+	});
+});

--- a/packages/widget/src/widget.resolved.test.tsx
+++ b/packages/widget/src/widget.resolved.test.tsx
@@ -15,7 +15,11 @@ vi.mock("@ai-sdk/react", () => ({
 	}),
 }));
 vi.mock("./widget-config", () => ({
-	useWidgetConfig: () => ({ showBranding: false, privacyPolicyUrl: null }),
+	useWidgetConfig: () => ({
+		showBranding: false,
+		privacyPolicyUrl: null,
+		suggestedQuestions: [],
+	}),
 }));
 
 import * as serverMessages from "./useServerMessages";

--- a/packages/widget/src/widget.suggestions.test.tsx
+++ b/packages/widget/src/widget.suggestions.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// Keep the live widget off the network/model: stub the chat transport + hook
+// (with an observable sendMessage) and pin the config to two starter questions.
+const { sendMessage } = vi.hoisted(() => ({
+	sendMessage: vi.fn(async () => {}),
+}));
+vi.mock("ai", () => ({ DefaultChatTransport: class {} }));
+vi.mock("@ai-sdk/react", () => ({
+	Chat: class {},
+	useChat: () => ({
+		messages: [],
+		sendMessage,
+		status: "ready",
+		error: null,
+	}),
+}));
+vi.mock("./widget-config", () => ({
+	useWidgetConfig: () => ({
+		showBranding: false,
+		privacyPolicyUrl: null,
+		suggestedQuestions: ["What are your pricing plans?", "How do refunds work?"],
+	}),
+}));
+
+import * as serverMessages from "./useServerMessages";
+import { Widget } from "./widget";
+
+import type { ServerMessage } from "./messages-sync";
+
+afterEach(() => {
+	vi.restoreAllMocks();
+	sendMessage.mockClear();
+	sessionStorage.clear();
+	localStorage.clear();
+});
+
+function mockFeed(messages: ServerMessage[]) {
+	vi.spyOn(serverMessages, "useServerMessages").mockReturnValue({
+		serverMessages: messages,
+		conversationId: messages.length > 0 ? "c1" : null,
+		csatRating: null,
+		escalatedAt: null,
+		archivedAt: null,
+		refresh: vi.fn(),
+	});
+}
+
+async function mountIdentified(messages: ServerMessage[] = []) {
+	mockFeed(messages);
+	render(
+		<Widget
+			widgetMode="live"
+			projectKey="pk"
+			apiUrl="http://x"
+			brandColor="#4f46e5"
+			mode="inline"
+		/>,
+	);
+	await userEvent.type(screen.getByPlaceholderText(/your name/i), "Test");
+	await userEvent.click(screen.getByRole("button", { name: /start chat/i }));
+}
+
+describe("LiveWidget — suggested-question chips", () => {
+	it("offers the admin-defined questions before the first message and sends the picked one", async () => {
+		await mountIdentified();
+		const chip = screen.getByRole("button", {
+			name: "What are your pricing plans?",
+		});
+		expect(
+			screen.getByRole("group", { name: /suggested questions/i }),
+		).toBeInTheDocument();
+		await userEvent.click(chip);
+		expect(sendMessage).toHaveBeenCalledWith({
+			text: "What are your pricing plans?",
+		});
+	});
+
+	it("hides the chips once the visitor has sent a message", async () => {
+		await mountIdentified([
+			{ id: "s1", role: "user", content: "hi", sequence: 1, createdAt: 1 },
+			{
+				id: "s2",
+				role: "assistant",
+				content: "hello",
+				sequence: 2,
+				createdAt: 2,
+			},
+		]);
+		expect(
+			screen.queryByRole("group", { name: /suggested questions/i }),
+		).not.toBeInTheDocument();
+	});
+});

--- a/packages/widget/src/widget.tsx
+++ b/packages/widget/src/widget.tsx
@@ -6,12 +6,14 @@ import { Composer } from "./components/Composer";
 import { CsatStep } from "./components/CsatStep";
 import { EscalationNotice } from "./components/EscalationNotice";
 import { EscalationSection } from "./components/EscalationSection";
+import { ComposeIcon } from "./components/icons";
 import { IdentifyForm } from "./components/IdentifyForm";
 import { MessageList } from "./components/MessageList";
 import { PoweredBy } from "./components/PoweredBy";
 import { PrivacyNotice } from "./components/PrivacyNotice";
 import { ResolvedNotice } from "./components/ResolvedNotice";
 import { ResolveSection } from "./components/ResolveSection";
+import { SuggestedQuestions } from "./components/SuggestedQuestions";
 import { WidgetFrame } from "./components/WidgetFrame";
 import { rateConversation, shouldPromptCsat } from "./csat";
 import { requestEscalation } from "./escalation";
@@ -21,6 +23,7 @@ import {
 	getOrCreateClientId,
 	getStoredIdentity,
 	getText,
+	rotateClientId,
 	setStoredIdentity,
 } from "./lib";
 import { mergeMessages } from "./messages-sync";
@@ -31,7 +34,7 @@ import { useWidgetConfig } from "./widget-config";
 
 import type { Rating } from "./rating";
 
-/** How long the "Thanks!" screen shows before the panel closes. */
+/** How long the "Thanks!" screen shows before the conversation view returns. */
 const CSAT_THANKS_MS = 1200;
 
 /**
@@ -160,12 +163,16 @@ function LiveWidget({
 		null,
 	);
 	const [clientId, setClientId] = useState("");
-	// CSAT closing screen: "hidden" during chat, "prompt" on close (when
-	// eligible), "thanks" briefly after a rating.
+	// End-of-conversation CSAT screen: "hidden" during chat, "prompt" when the
+	// visitor ends a conversation (resolve / start-a-new-one — NEVER on merely
+	// closing the panel), "thanks" briefly after a rating.
 	const [csatStep, setCsatStep] = useState<"hidden" | "prompt" | "thanks">(
 		"hidden",
 	);
 	const [csatRated, setCsatRated] = useState(false);
+	// True while the CSAT prompt is the exit gate of "start a new conversation":
+	// once rated/skipped, the conversation resets to a fresh one.
+	const [pendingNew, setPendingNew] = useState(false);
 
 	useEffect(() => {
 		setClientId(getOrCreateClientId());
@@ -182,12 +189,11 @@ function LiveWidget({
 	}, [projectKey]);
 
 	// Server decides whether the "Powered by" badge shows (plan-gated, tamper-
-	// proof) and supplies the project's privacy policy URL. Defaults to branded /
-	// built-in privacy link until the server says otherwise.
-	const { showBranding, privacyPolicyUrl } = useWidgetConfig(
-		apiUrl,
-		projectKey,
-	);
+	// proof) and supplies the project's privacy policy URL and admin-defined
+	// starter questions. Defaults to branded / built-in privacy link / no chips
+	// until the server says otherwise.
+	const { showBranding, privacyPolicyUrl, suggestedQuestions } =
+		useWidgetConfig(apiUrl, projectKey);
 
 	const chat = useMemo(
 		() =>
@@ -303,15 +309,44 @@ function LiveWidget({
 		alreadyRated: csatRating != null || csatRated,
 	});
 
-	// Intercept close: when eligible, swap to the CSAT step instead of closing.
-	// A second close (X / Esc / Skip) always closes — never traps the visitor.
-	function handleOpenChange(next: boolean) {
-		if (!next && csatStep === "hidden" && csatEligible) {
+	// Reset to a brand-new conversation: rotate the client id (the old
+	// conversation stays intact server-side for the inbox) and clear every
+	// per-conversation flag. The fresh greeting + suggestion chips return.
+	function resetConversation() {
+		setPendingNew(false);
+		setCsatStep("hidden");
+		setCsatRated(false);
+		setEscalatedLocal(false);
+		setEscalateFailed(false);
+		setResolvedLocal(false);
+		setResolveFailed(false);
+		setEscalationSummary(null);
+		setText("");
+		setClientId(rotateClientId());
+	}
+
+	// The visitor wants a fresh conversation. Ending one is the CSAT moment —
+	// prompt when eligible (real exchange, not yet rated); otherwise reset
+	// immediately.
+	function startNewConversation() {
+		if (csatEligible) {
+			setPendingNew(true);
 			setCsatStep("prompt");
 			return;
 		}
+		resetConversation();
+	}
+
+	// Closing the panel just closes it — never a feedback ambush. If a CSAT
+	// prompt was pending (the visitor was mid "end conversation"), closing counts
+	// as skipping it: finish the reset so reopening starts fresh.
+	function handleOpenChange(next: boolean) {
 		if (!next) {
-			setCsatStep("hidden");
+			if (pendingNew) {
+				resetConversation();
+			} else {
+				setCsatStep("hidden");
+			}
 		}
 		setOpen(next);
 	}
@@ -319,7 +354,7 @@ function LiveWidget({
 	function submitCsat(rating: number) {
 		setCsatRated(true);
 		setCsatStep("thanks");
-		// Best-effort: a failed POST must never trap the visitor — we close anyway.
+		// Best-effort: a failed POST must never trap the visitor — we move on anyway.
 		if (conversationId) {
 			void rateConversation(apiUrl, {
 				projectKey,
@@ -328,15 +363,22 @@ function LiveWidget({
 				rating,
 			}).catch(() => {});
 		}
+		const startFresh = pendingNew;
 		setTimeout(() => {
-			setCsatStep("hidden");
-			setOpen(false);
+			if (startFresh) {
+				resetConversation();
+			} else {
+				setCsatStep("hidden");
+			}
 		}, CSAT_THANKS_MS);
 	}
 
 	function skipCsat() {
+		if (pendingNew) {
+			resetConversation();
+			return;
+		}
 		setCsatStep("hidden");
-		setOpen(false);
 	}
 
 	function handleSend() {
@@ -386,6 +428,12 @@ function LiveWidget({
 			// don't flip local resolved, just re-poll so the escalated state surfaces.
 			if (didResolve) {
 				setResolvedLocal(true);
+				// Resolving ends the conversation — that's the feedback moment
+				// (never the panel close). Prompt when eligible; rating/skip returns
+				// to the resolved view, it doesn't reset the conversation.
+				if (csatEligible) {
+					setCsatStep("prompt");
+				}
 			}
 			refresh();
 		} catch {
@@ -395,12 +443,32 @@ function LiveWidget({
 		}
 	}
 
+	// Header shortcut to end the current conversation and start fresh — only
+	// once there's a conversation worth leaving (or a terminal state to escape).
+	const canStartNew =
+		identified &&
+		csatStep === "hidden" &&
+		(hasRealExchange || resolved || escalated);
+
 	return (
 		<WidgetFrame
 			inline={inline}
 			brandColor={brandColor}
 			open={open}
 			onOpenChange={handleOpenChange}
+			actions={
+				canStartNew ? (
+					<button
+						type="button"
+						className="llmchat-icon-btn"
+						onClick={startNewConversation}
+						aria-label="Start a new conversation"
+						title="Start a new conversation"
+					>
+						<ComposeIcon />
+					</button>
+				) : undefined
+			}
 			footer={showBranding ? <PoweredBy /> : null}
 		>
 			{csatStep !== "hidden" ? (
@@ -436,6 +504,13 @@ function LiveWidget({
 							onEscalate={handleEscalate}
 						/>
 					)}
+					{/* Starter-question chips until the visitor's first message. */}
+					{userMessageCount === 0 && !loading && (
+						<SuggestedQuestions
+							questions={suggestedQuestions}
+							onPick={(q) => void sendMessage({ text: q })}
+						/>
+					)}
 					{showResolve && (
 						<ResolveSection
 							pending={resolving}
@@ -445,7 +520,7 @@ function LiveWidget({
 					)}
 					{/* Resolved wins (terminal) over the escalation notice. */}
 					{resolved ? (
-						<ResolvedNotice />
+						<ResolvedNotice onStartNew={startNewConversation} />
 					) : (
 						escalated && <EscalationNotice summary={escalationSummary} />
 					)}


### PR DESCRIPTION
## What

Four visitor-facing widget improvements plus the operator config to drive them:

### 1. Expandable panel
The bubble-layout panel gets an expand/collapse toggle in the header (680×820 max, capped by the viewport, animated). Inline embeds are unaffected — they already fill their host. The expanded state persists across close/reopen within a session.

### 2. Admin-defined suggested questions
- New `project.suggestedQuestions` column (migration `0020`, JSON array, default `[]`), validated to ≤6 questions / ≤200 chars each, trimmed, blanks rejected.
- `GET /v1/config/:key` serves them publicly; a malformed column degrades to no chips, never a 500.
- Dashboard → Project → **Widget** tab: add/edit/remove rows with a live chat-preview mirror.
- The widget renders them as tappable chips until the visitor's first message; tapping sends the question as a normal chat message.

### 3. CSAT only when a conversation ends
Closing the panel no longer ambushes the visitor with the rating screen. The CSAT prompt now appears exactly when a conversation ends:
- the visitor marks it resolved, or
- the visitor starts a new conversation (rate/skip, then the fresh chat opens).

Closing mid-prompt counts as skip and never traps the visitor. Eligibility rules are unchanged (real exchange, not already rated).

### 4. Visitor-started new conversations
A compose button in the header (and a CTA in the resolved notice) rotates the per-tab `clientId`, clears local conversation state, and drops the polled feed immediately. The old conversation stays intact server-side for the inbox; the fresh chat shows the greeting and suggestion chips again.

## Test plan

- `pnpm test` — 566 api / 445 dashboard / 168 widget tests pass, including new coverage: config route suggestions (+ malformed-column degradation), PATCH validation bounds, WidgetTab editor rows/cap, widget chips render+send+hide, close-never-prompts, end-conversation CSAT prompt/skip/reset, resolve→CSAT, frame expand toggle.
- `pnpm lint`, `pnpm build` pass.
- Verified end-to-end on the seeded local stack (dashboard save → `/v1/config` → chips in the real widget on the showcase; resolve → CSAT → new conversation) and recorded a 43s demo video of the full flow for social.

https://claude.ai/code/session_017usDm1PKg6eWKFvB7TToYZ