### PR TITLE
feat(api): possession-proof (emailed OTP) before filing a Shopify return (#131)

### DIFF
--- a/apps/api/src/lib/integration-tools.test.ts
+++ b/apps/api/src/lib/integration-tools.test.ts
@@ -162,27 +162,27 @@ describe("calcom tools", () => {
 	});
 });
 
-describe("shopify tools", () => {
-	const ORDER = {
-		orders: {
-			nodes: [
-				{
-					id: "gid://shopify/Order/1",
-					name: "#1001",
-					email: "ada@example.com",
-					createdAt: "2026-06-20T00:00:00Z",
-					displayFinancialStatus: "PAID",
-					displayFulfillmentStatus: "FULFILLED",
-					totalPriceSet: {
-						shopMoney: { amount: "49.00", currencyCode: "USD" },
-					},
-					lineItems: { nodes: [{ title: "Wrench", quantity: 1 }] },
-					fulfillments: [],
+const ORDER = {
+	orders: {
+		nodes: [
+			{
+				id: "gid://shopify/Order/1",
+				name: "#1001",
+				email: "ada@example.com",
+				createdAt: "2026-06-20T00:00:00Z",
+				displayFinancialStatus: "PAID",
+				displayFulfillmentStatus: "FULFILLED",
+				totalPriceSet: {
+					shopMoney: { amount: "49.00", currencyCode: "USD" },
 				},
-			],
-		},
-	};
+				lineItems: { nodes: [{ title: "Wrench", quantity: 1 }] },
+				fulfillments: [],
+			},
+		],
+	},
+};
 
+describe("shopify tools", () => {
 	it("lookup_order uses the identity email and strips the internal gid", async () => {
 		vi.stubGlobal(
 			"fetch",
@@ -277,6 +277,13 @@ describe("shopify tools", () => {
 		expect(returnCall.variables.returnInput.returnLineItems).toHaveLength(1);
 	});
 
+	it("create_return without a returnVerification guard files directly (unguarded mode)", async () => {
+		// Covered in depth by the suite below; this pins the unguarded default.
+		expect(
+			buildIntegrationTools({ rows: [SHOP_ROW], identity: IDENTITY })!.tools,
+		).not.toHaveProperty("verify_return_code");
+	});
+
 	it("create_return reports 'nothing returnable' instead of filing empty returns", async () => {
 		vi.stubGlobal(
 			"fetch",
@@ -298,5 +305,305 @@ describe("shopify tools", () => {
 		});
 		expect(out).toMatchObject({ ok: false });
 		expect((out as { error: string }).error).toContain("returnable");
+	});
+});
+
+describe("return possession-proof (returnVerification guard, #131)", () => {
+	/** Standard shopify upstream: order lookup + one returnable item + create. */
+	const stubShopifyFetch = () => {
+		const fetchSpy = vi.fn(async (_url: string, init: RequestInit) => {
+			const { query } = JSON.parse(init.body as string) as { query: string };
+			if (query.includes("LookupOrder")) return Response.json({ data: ORDER });
+			if (query.includes("ReturnableItems")) {
+				return Response.json({
+					data: {
+						returnableFulfillments: {
+							edges: [
+								{
+									node: {
+										returnableFulfillmentLineItems: {
+											edges: [
+												{
+													node: {
+														quantity: 1,
+														fulfillmentLineItem: {
+															id: "fli1",
+															lineItem: { title: "Wrench" },
+														},
+													},
+												},
+											],
+										},
+									},
+								},
+							],
+						},
+					},
+				});
+			}
+			return Response.json({
+				data: {
+					returnCreate: {
+						return: { id: "r1", status: "OPEN", name: "#1001-R1" },
+						userErrors: [],
+					},
+				},
+			});
+		});
+		vi.stubGlobal("fetch", fetchSpy);
+		return fetchSpy;
+	};
+
+	const rvMock = (over?: {
+		check?: () => Promise<boolean>;
+		start?: () => Promise<"sent" | "limited" | "unavailable">;
+		confirm?: () => Promise<
+			"verified" | "invalid" | "expired" | "locked" | "unavailable"
+		>;
+	}) => ({
+		check: vi.fn(over?.check ?? (async () => false)),
+		start: vi.fn(over?.start ?? (async () => "sent" as const)),
+		confirm: vi.fn(over?.confirm ?? (async () => "verified" as const)),
+	});
+
+	it("exposes verify_return_code only when the guard is wired", () => {
+		const built = buildIntegrationTools({
+			rows: [SHOP_ROW],
+			identity: IDENTITY,
+			guards: { returnVerification: rvMock() },
+		});
+		expect(Object.keys(built!.tools)).toContain("verify_return_code");
+		expect(built!.actionsBlock).toContain("verify_return_code");
+	});
+
+	it("unverified create_return sends a code and refuses — nothing is filed", async () => {
+		const fetchSpy = stubShopifyFetch();
+		const rv = rvMock();
+		const actions: Record<string, unknown>[] = [];
+		const built = buildIntegrationTools({
+			rows: [SHOP_ROW],
+			identity: IDENTITY,
+			guards: { returnVerification: rv },
+			onAction: (r) => actions.push(r as unknown as Record<string, unknown>),
+		});
+		const out = await toolOf(built, "create_return").execute({
+			orderNumber: "1001",
+		});
+		expect(out).toMatchObject({ ok: false });
+		expect((out as { error: string }).error).toContain("verification_required");
+		// Recipient is the order-verified address; key is the normalized order name.
+		expect(rv.start).toHaveBeenCalledWith("1001", "ada@example.com");
+		// Lookup + returnable ran; the ReturnCreate mutation never fired.
+		expect(fetchSpy).toHaveBeenCalledTimes(2);
+		expect(actions.at(-1)).toMatchObject({
+			tool: "create_return",
+			ok: false,
+			detail: "verification code sent to the order email",
+		});
+	});
+
+	it("verified create_return files as normal and never re-sends a code", async () => {
+		const fetchSpy = stubShopifyFetch();
+		const rv = rvMock({ check: async () => true });
+		const built = buildIntegrationTools({
+			rows: [SHOP_ROW],
+			identity: IDENTITY,
+			guards: { returnVerification: rv },
+		});
+		const out = (await toolOf(built, "create_return").execute({
+			orderNumber: "1001",
+		})) as { ok: boolean };
+		expect(out.ok).toBe(true);
+		expect(rv.check).toHaveBeenCalledWith("1001", "ada@example.com");
+		expect(rv.start).not.toHaveBeenCalled();
+		expect(fetchSpy).toHaveBeenCalledTimes(3);
+	});
+
+	it("send-limit and outages keep the gate shut with honest copy", async () => {
+		stubShopifyFetch();
+		for (const [outcome, needle] of [
+			["limited", "Too many verification codes"],
+			["unavailable", "temporarily unavailable"],
+		] as const) {
+			const built = buildIntegrationTools({
+				rows: [SHOP_ROW],
+				identity: IDENTITY,
+				guards: {
+					returnVerification: rvMock({ start: async () => outcome }),
+				},
+			});
+			const out = await toolOf(built, "create_return").execute({
+				orderNumber: "1001",
+			});
+			expect(out).toMatchObject({ ok: false });
+			expect((out as { error: string }).error).toContain(needle);
+		}
+	});
+
+	it("a throwing check fails closed (treated as unverified)", async () => {
+		stubShopifyFetch();
+		const rv = rvMock({
+			check: async () => {
+				throw new Error("state down");
+			},
+		});
+		const built = buildIntegrationTools({
+			rows: [SHOP_ROW],
+			identity: IDENTITY,
+			guards: { returnVerification: rv },
+		});
+		const out = await toolOf(built, "create_return").execute({
+			orderNumber: "1001",
+		});
+		expect(out).toMatchObject({ ok: false });
+		expect(rv.start).toHaveBeenCalled();
+	});
+
+	it("a throwing start fails closed as unavailable (no return filed)", async () => {
+		const fetchSpy = stubShopifyFetch();
+		const rv = rvMock({
+			start: async () => {
+				throw new Error("state down");
+			},
+		});
+		const built = buildIntegrationTools({
+			rows: [SHOP_ROW],
+			identity: IDENTITY,
+			guards: { returnVerification: rv },
+		});
+		const out = await toolOf(built, "create_return").execute({
+			orderNumber: "1001",
+		});
+		expect(out).toMatchObject({ ok: false });
+		expect((out as { error: string }).error).toContain(
+			"temporarily unavailable",
+		);
+		expect(fetchSpy).toHaveBeenCalledTimes(2); // lookup + returnable, no ReturnCreate
+	});
+
+	it("keys the code on the visitor's order reference, not the canonical name (prefix stores)", async () => {
+		// A store whose canonical order name carries a suffix the customer never types.
+		const prefixed = {
+			orders: {
+				nodes: [{ ...ORDER.orders.nodes[0], name: "#1001-A" }],
+			},
+		};
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async (_url: string, init: RequestInit) => {
+				const { query } = JSON.parse(init.body as string) as { query: string };
+				if (query.includes("LookupOrder"))
+					return Response.json({ data: prefixed });
+				return Response.json({
+					data: {
+						returnableFulfillments: {
+							edges: [
+								{
+									node: {
+										returnableFulfillmentLineItems: {
+											edges: [
+												{
+													node: {
+														quantity: 1,
+														fulfillmentLineItem: {
+															id: "fli1",
+															lineItem: { title: "Wrench" },
+														},
+													},
+												},
+											],
+										},
+									},
+								},
+							],
+						},
+					},
+				});
+			}),
+		);
+		const rv = rvMock();
+		const built = buildIntegrationTools({
+			rows: [SHOP_ROW],
+			identity: IDENTITY,
+			guards: { returnVerification: rv },
+		});
+		await toolOf(built, "create_return").execute({ orderNumber: "1001" });
+		// The key must be the visitor's "1001", NOT the canonical "1001-a" —
+		// otherwise verify_return_code (which keys on visitor input) never matches.
+		expect(rv.check).toHaveBeenCalledWith("1001", "ada@example.com");
+		expect(rv.start).toHaveBeenCalledWith("1001", "ada@example.com");
+	});
+
+	it("verify_return_code is bounded by the fail-closed action limiter", async () => {
+		const rv = rvMock();
+		const actions: Record<string, unknown>[] = [];
+		const built = buildIntegrationTools({
+			rows: [SHOP_ROW],
+			identity: IDENTITY,
+			guards: {
+				returnVerification: rv,
+				actionLimit: async () => false, // over the quota
+			},
+			onAction: (r) => actions.push(r as unknown as Record<string, unknown>),
+		});
+		const out = await toolOf(built, "verify_return_code").execute({
+			orderNumber: "1001",
+			code: "123456",
+		});
+		expect(out).toMatchObject({ ok: false });
+		expect((out as { error: string }).error).toContain(
+			"verification attempt limit",
+		);
+		// The guess never reached confirm — the limiter short-circuited it.
+		expect(rv.confirm).not.toHaveBeenCalled();
+		expect(actions.at(-1)).toMatchObject({
+			tool: "verify_return_code",
+			ok: false,
+			detail: "blocked: verification attempt rate/quota limit",
+		});
+	});
+
+	it("verify_return_code normalizes the order, audits without the code, and maps outcomes", async () => {
+		const rv = rvMock();
+		const actions: Record<string, unknown>[] = [];
+		const built = buildIntegrationTools({
+			rows: [SHOP_ROW],
+			identity: IDENTITY,
+			guards: { returnVerification: rv },
+			onAction: (r) => actions.push(r as unknown as Record<string, unknown>),
+		});
+		const verify = toolOf(built, "verify_return_code");
+
+		const ok = await verify.execute({ orderNumber: "#1001", code: "123456" });
+		expect(ok).toMatchObject({ ok: true, verified: true });
+		expect(rv.confirm).toHaveBeenCalledWith("1001", "123456");
+		expect(actions.at(-1)).toMatchObject({
+			tool: "verify_return_code",
+			ok: true,
+		});
+		// The code must never reach the audit log.
+		expect(JSON.stringify(actions.at(-1)!.params)).not.toContain("123456");
+
+		for (const [outcome, needle] of [
+			["invalid", "doesn't match"],
+			["expired", "expired"],
+			["locked", "locked"],
+			["unavailable", "temporarily unavailable"],
+		] as const) {
+			rv.confirm.mockResolvedValueOnce(outcome);
+			const out = await verify.execute({
+				orderNumber: "1001",
+				code: "000000",
+			});
+			expect(out).toMatchObject({ ok: false });
+			expect((out as { error: string }).error).toContain(needle);
+		}
+
+		rv.confirm.mockRejectedValueOnce(new Error("state down"));
+		const down = await verify.execute({ orderNumber: "1001", code: "9" });
+		expect(down).toMatchObject({ ok: false });
+		expect((down as { error: string }).error).toContain(
+			"temporarily unavailable",
+		);
 	});
 });

--- a/apps/api/src/lib/integration-tools.ts
+++ b/apps/api/src/lib/integration-tools.ts
@@ -31,6 +31,11 @@ import {
 
 import { CalcomError, calcomCreateBooking, calcomGetSlots } from "./calcom";
 import {
+	normalizeOrderKey,
+	type ConfirmOutcome,
+	type StartOutcome,
+} from "./order-verification";
+import {
 	ShopifyError,
 	shopifyCreateReturn,
 	shopifyLookupOrder,
@@ -64,6 +69,21 @@ export interface IntegrationGuards {
 	/** Return false when this exact action was JUST performed (idempotency);
 	 * true reserves the key. Guards create_return against double-filing. */
 	once?: (key: string) => Promise<boolean>;
+	/** Possession-proof for return filing (issue #131): an order number +
+	 * email identifies, it doesn't authenticate — both appear on packing slips.
+	 * When wired, create_return refuses until the visitor redeems a one-time
+	 * code emailed to the address on the order (verify_return_code). Absent ⇒
+	 * unguarded (unit tests / self-host without a state binding), matching the
+	 * other guards. */
+	returnVerification?: {
+		/** Email a fresh code for (order, email). The email is ALWAYS the
+		 * order-verified address the tool resolved — never model-chosen. */
+		start: (orderKey: string, email: string) => Promise<StartOutcome>;
+		/** Redeem a visitor-supplied code for this order. */
+		confirm: (orderKey: string, code: string) => Promise<ConfirmOutcome>;
+		/** Already verified for this (order, email)? MUST fail closed. */
+		check: (orderKey: string, email: string) => Promise<boolean>;
+	};
 }
 
 export interface BuiltIntegrationTools {
@@ -467,6 +487,70 @@ export function buildIntegrationTools(opts: {
 									: "nothing on this order is returnable right now",
 							};
 						}
+						// Possession proof: the order number + email pair identifies the
+						// order but doesn't prove the requester controls that mailbox.
+						// Before anything is filed, the visitor must redeem a one-time
+						// code emailed to the address on the order. The recipient is the
+						// order-verified `addr` (never model-chosen), and only checked
+						// AFTER the returnable-items pass so hopeless requests never
+						// trigger an email. A guard fault keeps the gate SHUT.
+						if (opts.guards?.returnVerification) {
+							const rv = opts.guards.returnVerification;
+							// Key the possession proof on the visitor's OWN order
+							// reference (what they'll also type into verify_return_code),
+							// NOT the canonical order.name — stores with configured
+							// order-name prefixes/suffixes make those differ, which would
+							// strand a legit visitor whose emailed code can never match.
+							// The real security binding is (conversation, order-verified
+							// email); orderKey is just a per-order sub-scope and MUST be
+							// derived identically here and in verify_return_code.
+							const orderKey = normalizeOrderKey(orderNumber);
+							let verified = false;
+							try {
+								verified = await rv.check(orderKey, addr);
+							} catch {
+								verified = false;
+							}
+							if (!verified) {
+								let outcome: StartOutcome = "unavailable";
+								try {
+									outcome = await rv.start(orderKey, addr);
+								} catch {
+									outcome = "unavailable";
+								}
+								report({
+									kind: "shopify",
+									tool: "create_return",
+									ok: false,
+									params: { orderNumber, email: addr },
+									detail:
+										outcome === "sent"
+											? "verification code sent to the order email"
+											: outcome === "limited"
+												? "blocked: verification send limit"
+												: "blocked: verification unavailable",
+								});
+								if (outcome === "sent") {
+									return {
+										ok: false as const,
+										error:
+											"verification_required — a 6-digit code was just emailed to the address on this order. Ask the visitor for the code from that email, redeem it with verify_return_code, then call create_return again.",
+									};
+								}
+								if (outcome === "limited") {
+									return {
+										ok: false as const,
+										error:
+											"Too many verification codes have been sent for this conversation — please try again later or ask to speak with a human.",
+									};
+								}
+								return {
+									ok: false as const,
+									error:
+										"Return verification is temporarily unavailable — please try again shortly or ask to speak with a human.",
+								};
+							}
+						}
 						// Idempotency: a committed-but-lost response or a double-fire must
 						// not file the return twice. Keyed on (conversation, order, items)
 						// and reserved right before the state-changing mutation.
@@ -544,8 +628,110 @@ export function buildIntegrationTools(opts: {
 				},
 			});
 
+			if (opts.guards?.returnVerification) {
+				const rv = opts.guards.returnVerification;
+				tools.verify_return_code = tool({
+					description:
+						"Redeem the 6-digit verification code that create_return emailed to the address on the order. Call this once the visitor reads the code back — never guess, invent, or ask to skip the code. After it succeeds, call create_return again.",
+					inputSchema: z.object({
+						orderNumber: z
+							.string()
+							.max(32)
+							.describe("The order the code was requested for"),
+						code: z
+							.string()
+							.min(4)
+							.max(12)
+							.describe("The 6-digit code from the visitor's email"),
+					}),
+					execute: async ({ orderNumber, code }) => {
+						const orderKey = normalizeOrderKey(orderNumber);
+						// Bound total guesses with the SAME fail-closed action limiter
+						// create_return uses. This is the real global brute-force bound
+						// (per-project + per-IP, survives clientId/IP rotation), so the
+						// per-code lockout's non-atomic STATE counter can never be raced
+						// into relevance — even if concurrency overshoots the 5-attempt
+						// lockout, total guesses stay capped at the daily action quota.
+						if (!(await allowAction("shopify", "verify_return_code"))) {
+							report({
+								kind: "shopify",
+								tool: "verify_return_code",
+								ok: false,
+								params: { orderNumber },
+								detail: "blocked: verification attempt rate/quota limit",
+							});
+							return {
+								ok: false as const,
+								error:
+									"We've reached the verification attempt limit for now — please try again later or ask to speak with a human.",
+							};
+						}
+						let outcome: ConfirmOutcome = "unavailable";
+						try {
+							outcome = await rv.confirm(orderKey, code);
+						} catch {
+							outcome = "unavailable";
+						}
+						// Audited like every action — but the code itself is NEVER
+						// logged (it stays redeemable for a short window on failure).
+						report({
+							kind: "shopify",
+							tool: "verify_return_code",
+							ok: outcome === "verified",
+							params: { orderNumber },
+							detail:
+								outcome === "verified"
+									? `verified return eligibility for order ${orderNumber}`
+									: outcome === "invalid"
+										? "wrong verification code"
+										: outcome === "expired"
+											? "verification code expired or not issued"
+											: outcome === "locked"
+												? "verification locked (too many wrong codes)"
+												: "verification unavailable",
+						});
+						switch (outcome) {
+							case "verified":
+								return {
+									ok: true as const,
+									verified: true,
+									message:
+										"Verified — call create_return again to file the return.",
+								};
+							case "invalid":
+								return {
+									ok: false as const,
+									error:
+										"That code doesn't match — ask the visitor to re-check the email. Attempts are limited.",
+								};
+							case "expired":
+								return {
+									ok: false as const,
+									error:
+										"That code is expired or no code is active for this order — call create_return again to email a fresh one.",
+								};
+							case "locked":
+								return {
+									ok: false as const,
+									error:
+										"Too many wrong codes — verification for this order is locked for now. Offer to connect the visitor with a human instead.",
+								};
+							default:
+								return {
+									ok: false as const,
+									error:
+										"Verification is temporarily unavailable — please try again shortly or ask to speak with a human.",
+								};
+						}
+					},
+				});
+			}
+
 			notes.push(
-				"- Store orders: you can look up the visitor's own order (lookup_order) and file a return (create_return). Both need the order number AND the email on the order — ask for whichever is missing, and never guess either. Before filing a return, confirm exactly which items and that the visitor wants it filed. Report tool errors honestly and offer to escalate to a human instead of retrying endlessly.",
+				"- Store orders: you can look up the visitor's own order (lookup_order) and file a return (create_return). Both need the order number AND the email on the order — ask for whichever is missing, and never guess either. Before filing a return, confirm exactly which items and that the visitor wants it filed. Report tool errors honestly and offer to escalate to a human instead of retrying endlessly." +
+					(opts.guards?.returnVerification
+						? " Filing a return also requires proof the visitor controls the email on the order: create_return will answer verification_required and email them a 6-digit code — ask for that code, redeem it with verify_return_code, then call create_return again. Never ask the visitor to skip verification, and never guess a code."
+						: ""),
 			);
 		}
 	}

--- a/apps/api/src/lib/order-verification.test.ts
+++ b/apps/api/src/lib/order-verification.test.ts
@@ -1,0 +1,277 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { Env } from "@/env";
+
+import type { SendArgs } from "./email";
+import {
+	confirmReturnVerification,
+	generateVerificationCode,
+	isReturnVerified,
+	normalizeOrderKey,
+	startReturnVerification,
+} from "./order-verification";
+
+function fakeEnv() {
+	const store = new Map<string, string>();
+	const env = {
+		STATE: {
+			get: vi.fn(async (k: string) => store.get(k) ?? null),
+			set: vi.fn(async (k: string, v: string) => {
+				store.set(k, v);
+			}),
+		},
+		vars: {},
+	} as unknown as Env;
+	return { env, store };
+}
+
+const OPTS = {
+	conversationId: "conv1",
+	orderKey: "1001",
+	email: "ada@example.com",
+	projectName: "Acme Tools",
+};
+
+/** Start a verification and capture the emailed code. */
+async function startAndCapture(env: Env) {
+	const send = vi.fn(async (_env: Env, _args: SendArgs) => ({ id: "test" }));
+	const outcome = await startReturnVerification(env, OPTS, send);
+	const args = send.mock.calls[0]?.[1];
+	const code = args?.text?.match(/(\d{6})/)?.[1];
+	return { outcome, send, code };
+}
+
+afterEach(() => {
+	vi.useRealTimers();
+});
+
+describe("normalizeOrderKey", () => {
+	it("strips the #, trims, and lowercases", () => {
+		expect(normalizeOrderKey("#1001")).toBe("1001");
+		expect(normalizeOrderKey("  #AB-12 ")).toBe("ab-12");
+		expect(normalizeOrderKey("1001")).toBe("1001");
+	});
+});
+
+describe("generateVerificationCode", () => {
+	it("always yields exactly six digits", () => {
+		for (let i = 0; i < 50; i++) {
+			expect(generateVerificationCode()).toMatch(/^\d{6}$/);
+		}
+	});
+});
+
+describe("startReturnVerification", () => {
+	it("emails the code and stores only its hash", async () => {
+		const { env, store } = fakeEnv();
+		const { outcome, send, code } = await startAndCapture(env);
+		expect(outcome).toBe("sent");
+		expect(code).toMatch(/^\d{6}$/);
+		expect(send).toHaveBeenCalledOnce();
+		const sendArgs = send.mock.calls[0]![1];
+		expect(sendArgs.to).toBe("ada@example.com");
+		expect(sendArgs.subject).toContain("Acme Tools");
+		const stored = store.get("overif:conv1:1001")!;
+		expect(stored).toBeTruthy();
+		expect(stored).not.toContain(code); // hash only, never the plaintext
+		expect(JSON.parse(stored)).toMatchObject({
+			email: "ada@example.com",
+			attempts: 0,
+		});
+	});
+
+	it("caps code sends per conversation (limited, no email)", async () => {
+		const { env } = fakeEnv();
+		const send = vi.fn(async () => ({ id: "t" }));
+		for (let i = 0; i < 3; i++) {
+			expect(await startReturnVerification(env, OPTS, send)).toBe("sent");
+		}
+		expect(await startReturnVerification(env, OPTS, send)).toBe("limited");
+		expect(send).toHaveBeenCalledTimes(3);
+	});
+
+	it("a failed email does NOT consume the send budget (Resend outage)", async () => {
+		const { env } = fakeEnv();
+		const throwing = vi.fn(
+			async (_env: Env, _args: SendArgs): Promise<{ id: string }> => {
+				throw new Error("resend 503");
+			},
+		);
+		// Three failed sends during an outage...
+		for (let i = 0; i < 3; i++) {
+			expect(await startReturnVerification(env, OPTS, throwing)).toBe(
+				"unavailable",
+			);
+		}
+		// ...leave the budget intact, so recovery still lets a real code through.
+		const ok = vi.fn(async () => ({ id: "t" }));
+		expect(await startReturnVerification(env, OPTS, ok)).toBe("sent");
+	});
+
+	it("fails closed as unavailable on a STATE outage", async () => {
+		const { env } = fakeEnv();
+		(env.STATE.get as ReturnType<typeof vi.fn>).mockRejectedValue(
+			new Error("down"),
+		);
+		const send = vi.fn(async () => ({ id: "t" }));
+		expect(await startReturnVerification(env, OPTS, send)).toBe("unavailable");
+		expect(send).not.toHaveBeenCalled();
+	});
+
+	it("re-issuing replaces the old code", async () => {
+		const { env } = fakeEnv();
+		const first = await startAndCapture(env);
+		const second = await startAndCapture(env);
+		expect(
+			await confirmReturnVerification(env, {
+				conversationId: "conv1",
+				orderKey: "1001",
+				code: first.code!,
+			}),
+		).toBe("invalid");
+		expect(
+			await confirmReturnVerification(env, {
+				conversationId: "conv1",
+				orderKey: "1001",
+				code: second.code!,
+			}),
+		).toBe("verified");
+	});
+});
+
+describe("confirmReturnVerification", () => {
+	it("verifies the right code, binds the email, and burns the code", async () => {
+		const { env } = fakeEnv();
+		const { code } = await startAndCapture(env);
+		const outcome = await confirmReturnVerification(env, {
+			conversationId: "conv1",
+			orderKey: "1001",
+			code: ` ${code} `, // visitor whitespace tolerated
+		});
+		expect(outcome).toBe("verified");
+		await expect(
+			isReturnVerified(env, {
+				conversationId: "conv1",
+				orderKey: "1001",
+				email: "ADA@example.com", // case-insensitive match
+			}),
+		).resolves.toBe(true);
+		// The verified flag never authorizes a different address.
+		await expect(
+			isReturnVerified(env, {
+				conversationId: "conv1",
+				orderKey: "1001",
+				email: "mallory@example.com",
+			}),
+		).resolves.toBe(false);
+		// A redeemed code is burned.
+		expect(
+			await confirmReturnVerification(env, {
+				conversationId: "conv1",
+				orderKey: "1001",
+				code: code!,
+			}),
+		).toBe("expired");
+	});
+
+	it("counts wrong attempts and locks after five", async () => {
+		const { env } = fakeEnv();
+		const { code } = await startAndCapture(env);
+		for (let i = 0; i < 5; i++) {
+			expect(
+				await confirmReturnVerification(env, {
+					conversationId: "conv1",
+					orderKey: "1001",
+					code: "000000",
+				}),
+			).toBe(i < 4 ? "invalid" : "locked");
+		}
+		// Even the RIGHT code is refused once locked.
+		expect(
+			await confirmReturnVerification(env, {
+				conversationId: "conv1",
+				orderKey: "1001",
+				code: code!,
+			}),
+		).toBe("locked");
+		await expect(
+			isReturnVerified(env, {
+				conversationId: "conv1",
+				orderKey: "1001",
+				email: "ada@example.com",
+			}),
+		).resolves.toBe(false);
+	});
+
+	it("reports expired for missing and stale codes", async () => {
+		const { env, store } = fakeEnv();
+		expect(
+			await confirmReturnVerification(env, {
+				conversationId: "conv1",
+				orderKey: "1001",
+				code: "123456",
+			}),
+		).toBe("expired");
+		const { code } = await startAndCapture(env);
+		vi.useFakeTimers();
+		vi.setSystemTime(Date.now() + 11 * 60_000); // past the 10-min TTL
+		expect(
+			await confirmReturnVerification(env, {
+				conversationId: "conv1",
+				orderKey: "1001",
+				code: code!,
+			}),
+		).toBe("expired");
+		expect(store.has("overif-ok:conv1:1001")).toBe(false);
+	});
+
+	it("fails closed as unavailable on a STATE outage", async () => {
+		const { env } = fakeEnv();
+		const { code } = await startAndCapture(env);
+		(env.STATE.get as ReturnType<typeof vi.fn>).mockRejectedValue(
+			new Error("down"),
+		);
+		expect(
+			await confirmReturnVerification(env, {
+				conversationId: "conv1",
+				orderKey: "1001",
+				code: code!,
+			}),
+		).toBe("unavailable");
+	});
+});
+
+describe("isReturnVerified", () => {
+	it("expires the verified flag after its TTL", async () => {
+		const { env } = fakeEnv();
+		const { code } = await startAndCapture(env);
+		await confirmReturnVerification(env, {
+			conversationId: "conv1",
+			orderKey: "1001",
+			code: code!,
+		});
+		vi.useFakeTimers();
+		vi.setSystemTime(Date.now() + 31 * 60_000); // past the 30-min TTL
+		await expect(
+			isReturnVerified(env, {
+				conversationId: "conv1",
+				orderKey: "1001",
+				email: "ada@example.com",
+			}),
+		).resolves.toBe(false);
+	});
+
+	it("fails closed on a STATE outage", async () => {
+		const { env } = fakeEnv();
+		(env.STATE.get as ReturnType<typeof vi.fn>).mockRejectedValue(
+			new Error("down"),
+		);
+		await expect(
+			isReturnVerified(env, {
+				conversationId: "conv1",
+				orderKey: "1001",
+				email: "ada@example.com",
+			}),
+		).resolves.toBe(false);
+	});
+});

--- a/apps/api/src/lib/order-verification.ts
+++ b/apps/api/src/lib/order-verification.ts
@@ -1,0 +1,275 @@
+// Possession-proof for return filing (issue #131): before create_return files
+// anything, the visitor must prove control of the mailbox on the order by
+// echoing back a one-time code we email to that address. Knowing an order
+// number + email (both of which appear together on packing slips, forwarded
+// receipts, and shared screenshots) is identification, not authentication —
+// filing a return changes order state, so it gets the stronger check.
+//
+// Shape mirrors lib/kv.ts: STATE get/set with value-tracked expiry (the
+// deployed binding exposes no put/expirationTtl). All outcomes are explicit
+// strings so callers can map them to honest visitor-facing copy. Every path
+// that would open the write gate FAILS CLOSED on a STATE outage — a possession
+// proof that silently passes during an outage is no proof at all.
+
+import type { Env } from "@/env";
+
+import { sendEmail, escapeHtml } from "./email";
+
+/** How long an emailed code stays redeemable. */
+const CODE_TTL_SECONDS = 600; // 10 min
+/** How long a successful verification authorizes filings for that order. */
+const VERIFIED_TTL_SECONDS = 1800; // 30 min
+/** Wrong-code attempts before the code is burned (locked). Defense-in-depth,
+ * NOT the global brute-force bound — that is the fail-closed per-project action
+ * limiter gating verify_return_code (see integration-tools.ts). STATE has no
+ * atomic ops (lib/kv.ts), so concurrent confirms can lost-update this counter
+ * and overshoot the lockout by the in-flight width; the action limiter is what
+ * keeps total guesses bounded regardless. */
+const MAX_ATTEMPTS = 5;
+/** Successful code sends per conversation per window — a mailbox-spam limiter,
+ * NOT a brute-force bound (clientId is attacker-chosen, so this resets on a new
+ * conversation; the per-project action limiter is the anti-rotation bound). */
+const SEND_MAX = 3;
+const SEND_WINDOW_SECONDS = 3600;
+
+export type StartOutcome = "sent" | "limited" | "unavailable";
+export type ConfirmOutcome =
+	| "verified"
+	| "invalid"
+	| "expired"
+	| "locked"
+	| "unavailable";
+
+interface CodeRecord {
+	/** SHA-256 hex of the code — the plaintext never touches STATE. */
+	hash: string;
+	/** The address the code was emailed to; the verified flag is bound to it. */
+	email: string;
+	attempts: number;
+	expiresAt: number; // unix seconds
+}
+
+interface VerifiedRecord {
+	email: string;
+	expiresAt: number;
+}
+
+interface SendBucket {
+	count: number;
+	resetAt: number;
+}
+
+/** One key per (conversation, order): a visitor verifies each order once. */
+const codeKey = (conversationId: string, orderKey: string) =>
+	`overif:${conversationId}:${orderKey}`;
+const verifiedKey = (conversationId: string, orderKey: string) =>
+	`overif-ok:${conversationId}:${orderKey}`;
+const sendKey = (conversationId: string) => `overif-send:${conversationId}`;
+
+/** Normalize an order name/number so "#1001", "1001", " 1001 " collide. */
+export function normalizeOrderKey(orderNumber: string): string {
+	return orderNumber.trim().replace(/^#/, "").toLowerCase();
+}
+
+/** 6-digit code from the CSPRNG. Rejection-sampled so every code is uniform
+ * (a plain modulo would bias the low range). */
+export function generateVerificationCode(): string {
+	const buf = new Uint32Array(1);
+	// 4_294_000_000 is the largest multiple of 1e6 below 2^32 (4_294_967_296);
+	// resampling values at/above it makes `% 1_000_000` exactly uniform (no
+	// modulo bias). The bound MUST remain a multiple of 1e6 — do not "round" it.
+	for (;;) {
+		crypto.getRandomValues(buf);
+		const v = buf[0]!;
+		if (v < 4_294_000_000) {
+			return String(v % 1_000_000).padStart(6, "0");
+		}
+	}
+}
+
+async function sha256Hex(value: string): Promise<string> {
+	const digest = await crypto.subtle.digest(
+		"SHA-256",
+		new TextEncoder().encode(value),
+	);
+	return [...new Uint8Array(digest)]
+		.map((b) => b.toString(16).padStart(2, "0"))
+		.join("");
+}
+
+/** Constant-time compare of two equal-length hex strings. */
+function timingSafeEqualHex(a: string, b: string): boolean {
+	if (a.length !== b.length) return false;
+	let diff = 0;
+	for (let i = 0; i < a.length; i++) {
+		diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+	}
+	return diff === 0;
+}
+
+const now = () => Math.floor(Date.now() / 1000);
+
+/**
+ * Email a fresh one-time code to `email` (the address ALREADY verified against
+ * the order by the caller — this module never picks recipients) and store its
+ * hash for (conversation, order). Re-issuing replaces any prior code, so "send
+ * me a new one" always invalidates the old. Send-rate is capped per
+ * conversation and FAILS CLOSED, as does the STATE write: on any fault the
+ * caller must treat verification as not started.
+ */
+export async function startReturnVerification(
+	env: Env,
+	opts: {
+		conversationId: string;
+		orderKey: string;
+		email: string;
+		/** Merchant-facing name for the email copy. */
+		projectName: string;
+	},
+	send: typeof sendEmail = sendEmail,
+): Promise<StartOutcome> {
+	const at = now();
+	try {
+		// Read the send window (same bucket shape as lib/kv.ts). We only COUNT a
+		// send once its email actually goes out (below), so a Resend outage — which
+		// throws before the increment — never burns a legit visitor's budget and
+		// then falsely tells them "too many codes".
+		const rawBucket = await env.STATE.get(sendKey(opts.conversationId));
+		const bucket: SendBucket = { count: 0, resetAt: at + SEND_WINDOW_SECONDS };
+		if (rawBucket) {
+			try {
+				const parsed = JSON.parse(rawBucket) as SendBucket;
+				if (parsed.resetAt > at) {
+					bucket.count = parsed.count;
+					bucket.resetAt = parsed.resetAt;
+				}
+			} catch {
+				// malformed — fresh window
+			}
+		}
+		if (bucket.count >= SEND_MAX) return "limited";
+
+		const code = generateVerificationCode();
+		const record: CodeRecord = {
+			hash: await sha256Hex(code),
+			email: opts.email,
+			attempts: 0,
+			expiresAt: at + CODE_TTL_SECONDS,
+		};
+		// Store the hash BEFORE sending: a stored-but-unsent code is a dead code
+		// (visitor asks again), a sent-but-unstored code is unredeemable support
+		// pain. Prefer the recoverable failure.
+		await env.STATE.set(
+			codeKey(opts.conversationId, opts.orderKey),
+			JSON.stringify(record),
+		);
+
+		const safeName = escapeHtml(opts.projectName);
+		await send(env, {
+			to: opts.email,
+			subject: `${opts.projectName} — your return verification code`,
+			html: [
+				`<p>Someone asked to file a return on your order in a ${safeName} support chat.</p>`,
+				`<p style="font-size:28px;font-weight:bold;letter-spacing:4px;font-family:monospace">${code}</p>`,
+				`<p>Enter this code in the chat to confirm. It expires in 10 minutes.</p>`,
+				`<p>If this wasn't you, ignore this email — nothing is filed without the code.</p>`,
+			].join("\n"),
+			text: `Your ${opts.projectName} return verification code is ${code}. It expires in 10 minutes. If this wasn't you, ignore this email — nothing is filed without the code.`,
+		});
+		// Count the send only now that the email actually went out.
+		bucket.count += 1;
+		await env.STATE.set(sendKey(opts.conversationId), JSON.stringify(bucket));
+		return "sent";
+	} catch (err) {
+		console.error("order-verification: start failed", err);
+		return "unavailable";
+	}
+}
+
+/**
+ * Redeem a visitor-supplied code. On success the (conversation, order, email)
+ * triple is marked verified for VERIFIED_TTL_SECONDS and the code is burned.
+ * Wrong codes count toward MAX_ATTEMPTS and then lock; expiry, lockout, and
+ * STATE faults all keep the gate shut.
+ */
+export async function confirmReturnVerification(
+	env: Env,
+	opts: { conversationId: string; orderKey: string; code: string },
+): Promise<ConfirmOutcome> {
+	const key = codeKey(opts.conversationId, opts.orderKey);
+	try {
+		const raw = await env.STATE.get(key);
+		if (!raw) return "expired";
+		let record: CodeRecord;
+		try {
+			record = JSON.parse(raw) as CodeRecord;
+		} catch {
+			return "expired";
+		}
+		if (record.expiresAt <= now()) return "expired";
+		if (record.attempts >= MAX_ATTEMPTS) return "locked";
+
+		// Count the attempt BEFORE comparing, so a crash between compare and
+		// write can't grant unlimited sequential guesses. Concurrent confirms can
+		// still lost-update this counter (STATE is non-atomic — see lib/kv.ts) and
+		// overshoot MAX_ATTEMPTS by the in-flight width; that is tolerated because
+		// verify_return_code is gated by the fail-closed per-project action limiter
+		// which is the actual global brute-force bound (this lockout is defense-in-
+		// depth, not the sole control).
+		record.attempts += 1;
+		await env.STATE.set(key, JSON.stringify(record));
+
+		const supplied = await sha256Hex(opts.code.trim());
+		if (!timingSafeEqualHex(supplied, record.hash)) {
+			return record.attempts >= MAX_ATTEMPTS ? "locked" : "invalid";
+		}
+
+		// Ordering is deliberate: write the verified flag FIRST, then burn the
+		// code. If the burn write faults we return "unavailable" but the flag is
+		// already durable, so the visitor's retry files correctly — a benign
+		// over-report. The inverse order could burn a code while leaving no flag,
+		// stranding a visitor who genuinely verified. Do not swap these.
+		const verified: VerifiedRecord = {
+			email: record.email,
+			expiresAt: now() + VERIFIED_TTL_SECONDS,
+		};
+		await env.STATE.set(
+			verifiedKey(opts.conversationId, opts.orderKey),
+			JSON.stringify(verified),
+		);
+		// Burn the code — a redeemed code must not be redeemable again.
+		await env.STATE.set(
+			key,
+			JSON.stringify({ ...record, expiresAt: 0 } satisfies CodeRecord),
+		);
+		return "verified";
+	} catch (err) {
+		console.error("order-verification: confirm failed", err);
+		return "unavailable";
+	}
+}
+
+/**
+ * Is this (conversation, order) verified for this email? The email must match
+ * the one the code was sent to — a verified flag earned for one address never
+ * authorizes filings claimed under another. FAILS CLOSED on STATE faults.
+ */
+export async function isReturnVerified(
+	env: Env,
+	opts: { conversationId: string; orderKey: string; email: string },
+): Promise<boolean> {
+	try {
+		const raw = await env.STATE.get(
+			verifiedKey(opts.conversationId, opts.orderKey),
+		);
+		if (!raw) return false;
+		const record = JSON.parse(raw) as VerifiedRecord;
+		return (
+			record.expiresAt > now() &&
+			record.email.toLowerCase() === opts.email.trim().toLowerCase()
+		);
+	} catch (err) {
+		console.error("order-verification: check failed", err);
+		return false;
+	}
+}

--- a/apps/api/src/routes/chat.ts
+++ b/apps/api/src/routes/chat.ts
@@ -21,6 +21,11 @@ import {
 	shouldSendHolding,
 } from "@/lib/kv";
 import { streamChat, summarizeForVisitor } from "@/lib/llm";
+import {
+	confirmReturnVerification,
+	isReturnVerified,
+	startReturnVerification,
+} from "@/lib/order-verification";
 import { isResponseBlocked, resolveAccess } from "@/lib/plan";
 import { captureEvent, captureInBackground } from "@/lib/posthog";
 import { clientIp } from "@/lib/request";
@@ -357,6 +362,30 @@ export const chat = new Hono<AppContext>()
 					return perProjectDaily.ok;
 				},
 				once: (key) => reserveOnce(c.env, key),
+				// Possession-proof for return filing (#131): create_return refuses
+				// until the visitor redeems a one-time code emailed to the address
+				// on the order. STATE-backed, fail-closed in the lib.
+				returnVerification: {
+					start: (orderKey, email) =>
+						startReturnVerification(c.env, {
+							conversationId: conv.id,
+							orderKey,
+							email,
+							projectName: project.name,
+						}),
+					confirm: (orderKey, code) =>
+						confirmReturnVerification(c.env, {
+							conversationId: conv.id,
+							orderKey,
+							code,
+						}),
+					check: (orderKey, email) =>
+						isReturnVerified(c.env, {
+							conversationId: conv.id,
+							orderKey,
+							email,
+						}),
+				},
 			},
 			onAction: (record) => {
 				// (1) Durable, operator-visible audit row — the "what did the agent


### PR DESCRIPTION
## What

Closes the last tracked residual on the Shopify agent actions (#131): before the AI agent files a **return** on a visitor's behalf, the visitor must prove they control the email on the order by redeeming a one-time 6-digit code emailed to that address.

**Why:** an order number + the email on the order together *identify* the order but don't *authenticate* the requester — both appear on packing slips, forwarded receipts, and shared screenshots. `lookup_order` (read) is fine with identification; `create_return` (state-changing) is not, so it now gets the stronger check. `book_meeting` is unaffected (it only invites the on-file address to a call — no third-party harm).

## How

- **`lib/order-verification.ts`** (new): STATE-backed OTP. Code is SHA-256-hashed at rest (plaintext only ever in the email), CSPRNG + rejection-sampled (unbiased), constant-time compared, 10-min code TTL / 30-min verified TTL, 5-attempt lockout. Recipient is always the order-verified address — never model-chosen.
- **`create_return`**: after the fresh ownership re-lookup + returnable-items check (so hopeless requests never send an email), an unverified request refuses with `verification_required` and emails the code. A new **`verify_return_code`** tool redeems it; then `create_return` files as normal.
- **Fail-closed everywhere**: every path that could *open* the gate (check/start/confirm + the call sites) returns closed on a STATE outage or a thrown guard.
- Wired in `routes/chat.ts` scoped to the conversation; no schema change.

## Adversarial review (3-lens security pass, findings verified + fixed in this PR)

I ran an adversarial review (bypass / brute-force / robustness lenses, each finding independently verified against the code). Confirmed findings, all fixed here:

1. **Brute force (high):** the per-code 5-attempt lockout was the *only* guess bound, and its STATE counter is a non-atomic read-modify-write — concurrent confirms could race past it. **Fix:** `verify_return_code` now also runs behind the fail-closed per-project action limiter, so total guesses are globally bounded (survives the race *and* clientId/IP rotation); the per-code lockout is now defense-in-depth.
2. **Correctness (medium):** the OTP was keyed on the canonical `order.name` in `create_return` but the visitor-typed `orderNumber` in `verify_return_code` — on stores with order-name prefixes/suffixes these differ, so a legit customer could never verify. **Fix:** both sides key on the normalized visitor input; the security binding is (conversation, order-verified email).
3. **Robustness (low):** a failed email send burned the visitor's send budget (a Resend outage → misleading "too many codes"). **Fix:** a send is counted only after the email actually goes out. Plus nits: rejection-bound + write-ordering comments corrected.

3 further findings were **refuted** on verification.

## Tests

- 34 unit tests across `order-verification` + `integration-tools` (incl. fail-closed on outage, attempt lockout, email binding, cross-email denial, the prefix-store key fix, and the action-limiter gate).
- Full api suite green: **589 passing**, typecheck clean.

## Sequencing

The Shopify listing (PR #136) references this in its scope justification — this should merge **before** the App Store submission so the "return filing requires possession proof" claim is true in prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018pJJgDHCnnNeEqEAApxFcQ