### PR TITLE
chore(widget): fix pre-existing prettier drift in widget.suggestions.test.tsx

### DIFF
--- a/packages/widget/src/widget.suggestions.test.tsx
+++ b/packages/widget/src/widget.suggestions.test.tsx
@@ -21,7 +21,10 @@ vi.mock("./widget-config", () => ({
 	useWidgetConfig: () => ({
 		showBranding: false,
 		privacyPolicyUrl: null,
-		suggestedQuestions: ["What are your pricing plans?", "How do refunds work?"],
+		suggestedQuestions: [
+			"What are your pricing plans?",
+			"How do refunds work?",
+		],
 	}),
 }));
 


### PR DESCRIPTION
One-file formatting fix. `widget.suggestions.test.tsx` (shipped in PR #135, commit 8ebe397) has prettier drift that currently fails `pnpm lint` at the repo root. `prettier --write`, nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018pJJgDHCnnNeEqEAApxFcQ