### PR TITLE
feat(widget): dark/light mode support (light | dark | auto | host)

### DIFF
--- a/apps/api/src/lib/embed-page.test.ts
+++ b/apps/api/src/lib/embed-page.test.ts
@@ -4,6 +4,7 @@ import {
 	renderEmbedPage,
 	safeBrandColor,
 	safeEscalationThreshold,
+	safeTheme,
 } from "./embed-page";
 
 const base = {
@@ -91,5 +92,33 @@ describe("safeEscalationThreshold", () => {
 		expect(safeEscalationThreshold(0)).toBe(3);
 		expect(safeEscalationThreshold(-2)).toBe(3);
 		expect(safeEscalationThreshold(2.5)).toBe(3);
+	});
+});
+
+describe("embed theme passthrough", () => {
+	it("safeTheme constrains to the widget vocabulary (default light)", () => {
+		expect(safeTheme("dark")).toBe("dark");
+		expect(safeTheme("auto")).toBe("auto");
+		expect(safeTheme("light")).toBe("light");
+		expect(safeTheme(undefined)).toBe("light");
+		expect(safeTheme('"><script>')).toBe("light");
+	});
+
+	it("emits data-theme and a matching dark page background", () => {
+		const html = renderEmbedPage({ ...base, theme: "dark" });
+		expect(html).toContain('data-theme="dark"');
+		expect(html).toContain("background:#111827");
+	});
+
+	it("auto keeps a light background with a prefers-color-scheme override", () => {
+		const html = renderEmbedPage({ ...base, theme: "auto" });
+		expect(html).toContain('data-theme="auto"');
+		expect(html).toContain("@media (prefers-color-scheme: dark)");
+	});
+
+	it("defaults to light with the original white background", () => {
+		const html = renderEmbedPage({ ...base });
+		expect(html).toContain('data-theme="light"');
+		expect(html).toContain("background:#fff");
 	});
 });

--- a/apps/api/src/lib/embed-page.ts
+++ b/apps/api/src/lib/embed-page.ts
@@ -8,6 +8,15 @@ export interface EmbedPageInput {
 	publicKey: string;
 	brandColor: string;
 	escalationThreshold: number;
+	/** Widget color scheme; anything unrecognized collapses to "light". */
+	theme?: string;
+}
+
+/** Constrain the ?theme= passthrough to the widget's own vocabulary. */
+export function safeTheme(
+	value: string | undefined,
+): "light" | "dark" | "auto" {
+	return value === "dark" || value === "auto" ? value : "light";
 }
 
 /** Brand color for inline interpolation — anything but a hex literal falls back. */
@@ -34,7 +43,18 @@ export function renderEmbedPage({
 	publicKey,
 	brandColor,
 	escalationThreshold,
+	theme,
 }: EmbedPageInput): string {
+	const safe = safeTheme(theme);
+	// The page background tracks the widget scheme so a dark iframe never
+	// flashes/frames white. "auto" defers to the visitor's OS via the media
+	// query; the widget itself resolves auto the same way (prefers-color-scheme).
+	const background =
+		safe === "dark"
+			? "html,body{margin:0;height:100%;background:#111827}"
+			: safe === "auto"
+				? "html,body{margin:0;height:100%;background:#fff}@media (prefers-color-scheme: dark){html,body{background:#111827}}"
+				: "html,body{margin:0;height:100%;background:#fff}";
 	return `<!doctype html>
 <html lang="en">
 <head>
@@ -42,10 +62,10 @@ export function renderEmbedPage({
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <meta name="robots" content="noindex" />
 <title>${escapeHtml(projectName)} — Chat</title>
-<style>html,body{margin:0;height:100%;background:#fff}</style>
+<style>${background}</style>
 </head>
 <body>
-<script src="/widget.js" data-project="${escapeHtml(publicKey)}" data-brand="${safeBrandColor(brandColor)}" data-escalation-threshold="${safeEscalationThreshold(escalationThreshold)}" data-mode="inline" defer></script>
+<script src="/widget.js" data-project="${escapeHtml(publicKey)}" data-brand="${safeBrandColor(brandColor)}" data-escalation-threshold="${safeEscalationThreshold(escalationThreshold)}" data-mode="inline" data-theme="${safe}" defer></script>
 </body>
 </html>`;
 }

--- a/apps/api/src/routes/embed.ts
+++ b/apps/api/src/routes/embed.ts
@@ -24,6 +24,9 @@ export const embed = new Hono<AppContext>().get("/embed/:key", async (c) => {
 		publicKey: project.publicKey,
 		brandColor: project.brandColor,
 		escalationThreshold: project.escalationThreshold,
+		// ?theme=dark|auto lets the embedding page match its own scheme;
+		// validated down to the widget's vocabulary (default light).
+		theme: c.req.query("theme"),
 	});
 
 	// Framing by any site is the point of this page; everything else is locked

--- a/apps/dashboard/src/app/layout.tsx
+++ b/apps/dashboard/src/app/layout.tsx
@@ -110,6 +110,7 @@ export default function RootLayout({
 					data-project="pk_adadae5c42fbc58d2e4927cac84a2131ae3bf042d8032187"
 					data-api="https://api.clankersupport.com"
 					data-brand="#6366F1"
+					data-theme="host"
 					async
 				/>
 			</body>

--- a/apps/marketing/src/app/layout.tsx
+++ b/apps/marketing/src/app/layout.tsx
@@ -146,6 +146,7 @@ export default function RootLayout({
 					data-project="pk_adadae5c42fbc58d2e4927cac84a2131ae3bf042d8032187"
 					data-api="https://api.clankersupport.com"
 					data-brand="#2E6BFF"
+					data-theme="host"
 					async
 				/>
 			</body>

--- a/apps/showcase/src/components/WidgetMount.tsx
+++ b/apps/showcase/src/components/WidgetMount.tsx
@@ -22,6 +22,8 @@ export function WidgetMount() {
 			projectKey: WIDGET_PROJECT_KEY,
 			apiUrl: apiBaseUrl(),
 			brandColor: BRAND_COLOR,
+			// Mirror the showcase site's own next-themes toggle (html class).
+			theme: "host",
 		});
 		return () => {
 			unmount();

--- a/packages/widget/src/components/WidgetFrame.test.tsx
+++ b/packages/widget/src/components/WidgetFrame.test.tsx
@@ -73,3 +73,17 @@ describe("WidgetFrame — inline layout", () => {
 		).not.toBeInTheDocument();
 	});
 });
+
+describe("WidgetFrame — theme", () => {
+	it("defaults to light: no dark class on the root", () => {
+		renderFrame({ open: true });
+		const root = screen.getByText("panel body").closest(".llmchat");
+		expect(root).not.toHaveClass("llmchat--dark");
+	});
+
+	it("applies the dark palette class when theme=dark", () => {
+		renderFrame({ open: true, theme: "dark" });
+		const root = screen.getByText("panel body").closest(".llmchat");
+		expect(root).toHaveClass("llmchat--dark");
+	});
+});

--- a/packages/widget/src/components/WidgetFrame.tsx
+++ b/packages/widget/src/components/WidgetFrame.tsx
@@ -23,6 +23,7 @@ function prefersReducedMotion(): boolean {
 export function WidgetFrame({
 	inline,
 	brandColor,
+	theme = "light",
 	open,
 	onOpenChange,
 	badge,
@@ -32,6 +33,8 @@ export function WidgetFrame({
 }: {
 	inline: boolean;
 	brandColor: string;
+	/** Resolved color scheme (auto is resolved by the caller via useEffectiveTheme). */
+	theme?: "light" | "dark";
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
 	/** Optional header adornment, e.g. the showcase "Demo mode" pill. */
@@ -84,7 +87,10 @@ export function WidgetFrame({
 	const closing = !inline && mounted && !open;
 
 	return (
-		<div className="llmchat" style={{ ["--brand" as string]: brandColor }}>
+		<div
+			className={theme === "dark" ? "llmchat llmchat--dark" : "llmchat"}
+			style={{ ["--brand" as string]: brandColor }}
+		>
 			{!inline && (
 				<button
 					ref={launcherRef}

--- a/packages/widget/src/config.ts
+++ b/packages/widget/src/config.ts
@@ -1,8 +1,14 @@
+import { parseTheme } from "./theme";
+
+import type { WidgetTheme } from "./theme";
+
 export interface BootConfig {
 	projectKey: string;
 	apiUrl: string;
 	brandColor: string;
 	mode: "bubble" | "inline";
+	/** Color scheme: light (default) | dark | auto (follows the OS). */
+	theme: WidgetTheme;
 	/** Messages before the human-handoff prompt appears; undefined → widget default. */
 	escalationThreshold?: number;
 }
@@ -20,6 +26,8 @@ export function resolveConfig(script: HTMLScriptElement | null): BootConfig {
 		(script?.src ? new URL(script.src).origin : window.location.origin);
 	const brandColor = script?.dataset.brand ?? "#111827";
 	const mode = script?.dataset.mode === "inline" ? "inline" : "bubble";
+	// data-theme → light | dark | auto; anything else (or absent) stays light.
+	const theme = parseTheme(script?.dataset.theme);
 	if (!projectKey) {
 		throw new Error("[llmchat] missing data-project on widget script tag");
 	}
@@ -32,5 +40,5 @@ export function resolveConfig(script: HTMLScriptElement | null): BootConfig {
 	const escalationThreshold = Number.isFinite(parsedThreshold)
 		? parsedThreshold
 		: undefined;
-	return { projectKey, apiUrl, brandColor, mode, escalationThreshold };
+	return { projectKey, apiUrl, brandColor, mode, theme, escalationThreshold };
 }

--- a/packages/widget/src/styles.ts
+++ b/packages/widget/src/styles.ts
@@ -2,6 +2,72 @@
 // string so it can be consumed from both Vite (IIFE bundle) and Next.js
 // (server-rendered host page) without bundler-specific `?inline` syntax.
 export const widgetStyles = `
+/* ── Theme tokens ──────────────────────────────────────────────────────
+   Light is the default palette (existing embeds render unchanged); the
+   .llmchat--dark class — set by WidgetFrame from the resolved theme
+   (data-theme: light | dark | auto) — overrides the same custom properties.
+   On-brand surfaces (header, visitor bubbles, send) keep literal #fff text
+   on var(--brand) in both themes, so they are deliberately not tokenized. */
+:host,
+.llmchat {
+	/* Surfaces */
+	--sf: #fff;
+	--sf-2: #f3f4f6;
+	--sf-3: #f9fafb;
+	/* Ink */
+	--tx: #111827;
+	--tx-2: #374151;
+	--tx-3: #4b5563;
+	--tx-4: #6b7280;
+	--tx-5: #9ca3af;
+	/* Lines */
+	--ln: #e5e7eb;
+	--ln-2: #d1d5db;
+	--ln-soft: #f1f5f9;
+	/* Operator (admin) replies */
+	--ok-bg: #ecfdf5;
+	--ok-tx: #065f46;
+	--ok-ln: #a7f3d0;
+	/* Informational band (demo note) */
+	--info-bg: #eef2ff;
+	--info-tx: #4338ca;
+	--info-ln: #e0e7ff;
+	--err: #b91c1c;
+	/* Markdown chrome (code, quotes, tables) */
+	--code-bg: rgba(0, 0, 0, 0.06);
+	--pre-bg: rgba(0, 0, 0, 0.05);
+	--md-ln: rgba(0, 0, 0, 0.12);
+	--md-hr: rgba(0, 0, 0, 0.1);
+	--th-bg: rgba(0, 0, 0, 0.04);
+	color-scheme: light;
+}
+.llmchat--dark {
+	--sf: #111827;
+	--sf-2: #1f2937;
+	--sf-3: #1f2937;
+	--tx: #f9fafb;
+	--tx-2: #d1d5db;
+	--tx-3: #d1d5db;
+	--tx-4: #9ca3af;
+	--tx-5: #6b7280;
+	--ln: #374151;
+	--ln-2: #4b5563;
+	--ln-soft: #1f2937;
+	--ok-bg: #022c22;
+	--ok-tx: #6ee7b7;
+	--ok-ln: #065f46;
+	--info-bg: #1e1b4b;
+	--info-tx: #a5b4fc;
+	--info-ln: #312e81;
+	--err: #f87171;
+	--code-bg: rgba(255, 255, 255, 0.09);
+	--pre-bg: rgba(255, 255, 255, 0.07);
+	--md-ln: rgba(255, 255, 255, 0.16);
+	--md-hr: rgba(255, 255, 255, 0.12);
+	--th-bg: rgba(255, 255, 255, 0.05);
+	color-scheme: dark;
+}
+
 :host,
 .llmchat {
 	font-family:
@@ -9,7 +75,7 @@ export const widgetStyles = `
 		-apple-system,
 		Segoe UI,
 		sans-serif;
-	color: #111827;
+	color: var(--tx);
 	/* Pin inherited properties so the host page's typography can't leak across
 	   the shadow boundary and distort the widget. Dimensions are px throughout
 	   (never rem): rem resolves against the HOST page's root font-size even
@@ -91,7 +157,7 @@ export const widgetStyles = `
 	max-width: calc(100vw - 32px);
 	height: 544px;
 	max-height: calc(100vh - 112px);
-	background: #fff;
+	background: var(--sf);
 	border-radius: 16px;
 	display: flex;
 	flex-direction: column;
@@ -241,7 +307,7 @@ export const widgetStyles = `
 .llmchat-identify-sub {
 	margin: 0;
 	font-size: 14px;
-	color: #6b7280;
+	color: var(--tx-4);
 }
 .llmchat-field {
 	display: flex;
@@ -251,18 +317,18 @@ export const widgetStyles = `
 .llmchat-field-label {
 	font-size: 12.48px;
 	font-weight: 600;
-	color: #6b7280;
+	color: var(--tx-4);
 }
 .llmchat-identify input,
 .llmchat-input textarea {
 	width: 100%;
-	border: 1px solid #d1d5db;
+	border: 1px solid var(--ln-2);
 	border-radius: 10px;
 	padding: 8.8px 12px;
 	font: inherit;
 	font-size: 14.4px;
-	color: #111827;
-	background: #fff;
+	color: var(--tx);
+	background: var(--sf);
 	resize: none;
 	transition:
 		border-color 0.15s ease,
@@ -270,7 +336,7 @@ export const widgetStyles = `
 }
 .llmchat-identify input::placeholder,
 .llmchat-input textarea::placeholder {
-	color: #9ca3af;
+	color: var(--tx-5);
 }
 .llmchat-identify input:focus,
 .llmchat-input textarea:focus {
@@ -315,9 +381,9 @@ export const widgetStyles = `
 	display: flex;
 	flex-direction: column;
 	gap: 8px;
-	background: #fff;
+	background: var(--sf);
 	scrollbar-width: thin;
-	scrollbar-color: #d1d5db transparent;
+	scrollbar-color: var(--ln-2) transparent;
 }
 /* Bottom spacer that lets the latest visitor message reach the top of the
    viewport; its height is set imperatively by useAnchoredScroll (0 by default). */
@@ -329,9 +395,9 @@ export const widgetStyles = `
 	width: 8px;
 }
 .llmchat-messages::-webkit-scrollbar-thumb {
-	background: #d1d5db;
+	background: var(--ln-2);
 	border-radius: 9999px;
-	border: 2px solid #fff;
+	border: 2px solid var(--sf);
 }
 /* "Scroll to latest": sticky so it floats at the bottom of the scroll area
    while the visitor reads earlier messages during a streaming reply. */
@@ -377,8 +443,8 @@ export const widgetStyles = `
 	}
 }
 .llmchat-msg-assistant {
-	background: #f3f4f6;
-	color: #111827;
+	background: var(--sf-2);
+	color: var(--tx);
 	align-self: flex-start;
 	border-bottom-left-radius: 4px;
 }
@@ -389,16 +455,16 @@ export const widgetStyles = `
 	border-bottom-right-radius: 4px;
 }
 .llmchat-msg-admin {
-	background: #ecfdf5;
-	color: #065f46;
+	background: var(--ok-bg);
+	color: var(--ok-tx);
 	align-self: flex-start;
-	border: 1px solid #a7f3d0;
+	border: 1px solid var(--ok-ln);
 	border-bottom-left-radius: 4px;
 }
 .llmchat-msg-system {
 	align-self: center;
-	background: #f3f4f6;
-	color: #6b7280;
+	background: var(--sf-2);
+	color: var(--tx-4);
 	font-size: 12.48px;
 	border-radius: 9999px;
 	padding: 4px 12px;
@@ -442,7 +508,7 @@ export const widgetStyles = `
 	margin: 2.4px 0;
 }
 .llmchat-md li::marker {
-	color: #9ca3af;
+	color: var(--tx-5);
 }
 .llmchat-md strong {
 	font-weight: 600;
@@ -473,14 +539,14 @@ export const widgetStyles = `
 .llmchat-md code {
 	font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
 	font-size: 0.85em;
-	background: rgba(0, 0, 0, 0.06);
+	background: var(--code-bg);
 	padding: 0.1em 0.32em;
 	border-radius: 4.8px;
 }
 .llmchat-md pre {
 	margin: 0 0 8px;
 	padding: 9.6px 11.2px;
-	background: rgba(0, 0, 0, 0.05);
+	background: var(--pre-bg);
 	border-radius: 8px;
 	overflow-x: auto;
 	font-size: 0.85em;
@@ -495,12 +561,12 @@ export const widgetStyles = `
 .llmchat-md blockquote {
 	margin: 0 0 8px;
 	padding-left: 11.2px;
-	border-left: 3px solid rgba(0, 0, 0, 0.12);
+	border-left: 3px solid var(--md-ln);
 	opacity: 0.85;
 }
 .llmchat-md hr {
 	border: none;
-	border-top: 1px solid rgba(0, 0, 0, 0.1);
+	border-top: 1px solid var(--md-hr);
 	margin: 9.6px 0;
 }
 .llmchat-md table {
@@ -511,13 +577,13 @@ export const widgetStyles = `
 }
 .llmchat-md th,
 .llmchat-md td {
-	border: 1px solid rgba(0, 0, 0, 0.12);
+	border: 1px solid var(--md-ln);
 	padding: 4.8px 7.2px;
 	text-align: left;
 }
 .llmchat-md th {
 	font-weight: 600;
-	background: rgba(0, 0, 0, 0.04);
+	background: var(--th-bg);
 }
 .llmchat-md img {
 	max-width: 100%;
@@ -553,15 +619,15 @@ export const widgetStyles = `
 	border-radius: 6px;
 	background: transparent;
 	border: none;
-	color: #9ca3af;
+	color: var(--tx-5);
 	cursor: pointer;
 	transition:
 		background 0.15s ease,
 		color 0.15s ease;
 }
 .llmchat-rate-btn:hover {
-	background: #f3f4f6;
-	color: #4b5563;
+	background: var(--sf-2);
+	color: var(--tx-3);
 }
 /* Pressed = unmistakable: fill the thumb (this CSS fill overrides the inline
    fill="none" on the outline icons) and tint the button, so a registered vote
@@ -577,8 +643,8 @@ export const widgetStyles = `
    "noted" state — the filled thumb registers the vote without reading as
    celebratory, and the darker tint keeps it clearly apart from the brand thumb. */
 .llmchat-rate-btn[aria-label="Not helpful"][aria-pressed="true"] {
-	color: #4b5563;
-	background: #e5e7eb;
+	color: var(--tx-3);
+	background: var(--ln);
 }
 .llmchat-rate-btn:focus-visible {
 	outline: none;
@@ -604,7 +670,7 @@ export const widgetStyles = `
 	margin: 0;
 	font-size: 16.8px;
 	font-weight: 600;
-	color: #111827;
+	color: var(--tx);
 }
 .llmchat-csat-stars {
 	display: flex;
@@ -635,7 +701,7 @@ export const widgetStyles = `
 .llmchat-csat-skip {
 	background: transparent;
 	border: none;
-	color: #6b7280;
+	color: var(--tx-4);
 	font: inherit;
 	font-size: 13.6px;
 	cursor: pointer;
@@ -643,7 +709,7 @@ export const widgetStyles = `
 	border-radius: 6px;
 }
 .llmchat-csat-skip:hover {
-	color: #111827;
+	color: var(--tx);
 	text-decoration: underline;
 }
 .llmchat-csat-skip:focus-visible {
@@ -662,7 +728,7 @@ export const widgetStyles = `
 	width: 6.4px;
 	height: 6.4px;
 	border-radius: 9999px;
-	background: #9ca3af;
+	background: var(--tx-5);
 	animation: llmchat-bounce 1.2s infinite ease-in-out;
 }
 .llmchat-dot:nth-child(2) {
@@ -676,7 +742,7 @@ export const widgetStyles = `
 .llmchat-typing-label {
 	margin-left: 4px;
 	font-size: 12px;
-	color: #6b7280;
+	color: var(--tx-4);
 }
 @keyframes llmchat-bounce {
 	0%,
@@ -708,11 +774,11 @@ export const widgetStyles = `
 	margin-left: 4px;
 }
 .llmchat-demo-note {
-	background: #eef2ff;
-	color: #4338ca;
+	background: var(--info-bg);
+	color: var(--info-tx);
 	font-size: 12.48px;
 	padding: 8px 14px;
-	border-bottom: 1px solid #e0e7ff;
+	border-bottom: 1px solid var(--info-ln);
 }
 /* "Powered by Clanker Support" attribution at the foot of the panel (plan-gated). */
 .llmchat-powered-by {
@@ -720,20 +786,20 @@ export const widgetStyles = `
 	text-align: center;
 	padding: 6.4px 14px 8.8px;
 	font-size: 11.2px;
-	color: #9ca3af;
+	color: var(--tx-5);
 	text-decoration: none;
-	border-top: 1px solid #f1f5f9;
-	background: #fff;
+	border-top: 1px solid var(--ln-soft);
+	background: var(--sf);
 }
 .llmchat-powered-by:hover {
-	color: #6b7280;
+	color: var(--tx-4);
 }
 .llmchat-powered-by-name {
 	font-weight: 600;
-	color: #6b7280;
+	color: var(--tx-4);
 }
 .llmchat-error {
-	color: #b91c1c;
+	color: var(--err);
 	font-size: 13.6px;
 	margin: 0;
 	padding: 4px 8px 0;
@@ -743,7 +809,7 @@ export const widgetStyles = `
 .llmchat-escalate,
 .llmchat-escalated {
 	padding: 10px 14px;
-	border-top: 1px solid #e5e7eb;
+	border-top: 1px solid var(--ln);
 	font-size: 13.6px;
 	flex-shrink: 0;
 }
@@ -772,8 +838,8 @@ export const widgetStyles = `
 	cursor: default;
 }
 .llmchat-escalated {
-	color: #4b5563;
-	background: #f9fafb;
+	color: var(--tx-3);
+	background: var(--sf-3);
 	display: flex;
 	flex-direction: column;
 	gap: 8px;
@@ -820,7 +886,7 @@ export const widgetStyles = `
 	padding: 8px 10px;
 	border-radius: 10px;
 	border: 1px solid color-mix(in srgb, var(--brand) 22%, transparent);
-	background: color-mix(in srgb, var(--brand) 6%, #fff);
+	background: color-mix(in srgb, var(--brand) 6%, var(--sf));
 	animation: llmchat-msg-in 0.2s ease;
 }
 .llmchat-summary-label {
@@ -842,7 +908,7 @@ export const widgetStyles = `
 	margin: 0;
 	font-size: 13.6px;
 	line-height: 1.4;
-	color: #374151;
+	color: var(--tx-2);
 	word-break: break-word;
 }
 
@@ -855,8 +921,8 @@ export const widgetStyles = `
 	align-items: center;
 	gap: 8px;
 	padding: 8px 8px 8px 14px;
-	background: #fff;
-	border-top: 1px solid #e5e7eb;
+	background: var(--sf);
+	border-top: 1px solid var(--ln);
 }
 .llmchat-privacy-text {
 	margin: 0;
@@ -865,7 +931,7 @@ export const widgetStyles = `
 	font-size: 11.52px;
 	line-height: 1.4;
 	text-align: left;
-	color: #6b7280;
+	color: var(--tx-4);
 }
 .llmchat-privacy a {
 	color: var(--brand);
@@ -888,15 +954,15 @@ export const widgetStyles = `
 	border: none;
 	border-radius: 6px;
 	background: transparent;
-	color: #9ca3af;
+	color: var(--tx-5);
 	cursor: pointer;
 	transition:
 		background 0.15s ease,
 		color 0.15s ease;
 }
 .llmchat-privacy-dismiss:hover {
-	background: #f3f4f6;
-	color: #4b5563;
+	background: var(--sf-2);
+	color: var(--tx-3);
 }
 .llmchat-privacy-dismiss:focus-visible {
 	outline: none;
@@ -915,12 +981,12 @@ export const widgetStyles = `
 
 /* ── Composer ──────────────────────────────────────────────────────── */
 .llmchat-input {
-	border-top: 1px solid #e5e7eb;
+	border-top: 1px solid var(--ln);
 	padding: 10px 12px;
 	display: flex;
 	gap: 8px;
 	align-items: flex-end;
-	background: #fff;
+	background: var(--sf);
 	flex-shrink: 0;
 }
 .llmchat-input textarea {

--- a/packages/widget/src/theme.test.ts
+++ b/packages/widget/src/theme.test.ts
@@ -1,0 +1,87 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { parseTheme, resolveEffectiveTheme, useEffectiveTheme } from "./theme";
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+});
+
+describe("parseTheme", () => {
+	it("accepts the widget vocabulary", () => {
+		expect(parseTheme("light")).toBe("light");
+		expect(parseTheme("dark")).toBe("dark");
+		expect(parseTheme("auto")).toBe("auto");
+	});
+
+	it("falls back to light for anything else — a typo can never flip a site dark", () => {
+		expect(parseTheme(undefined)).toBe("light");
+		expect(parseTheme(null)).toBe("light");
+		expect(parseTheme("")).toBe("light");
+		expect(parseTheme("DARK")).toBe("light");
+		expect(parseTheme("midnight")).toBe("light");
+	});
+});
+
+describe("resolveEffectiveTheme", () => {
+	it("explicit light/dark ignore the OS preference", () => {
+		expect(resolveEffectiveTheme("light", true)).toBe("light");
+		expect(resolveEffectiveTheme("dark", false)).toBe("dark");
+	});
+
+	it("auto follows the OS preference", () => {
+		expect(resolveEffectiveTheme("auto", true)).toBe("dark");
+		expect(resolveEffectiveTheme("auto", false)).toBe("light");
+	});
+});
+
+/** matchMedia stub: reports `matches` and lets the test fire a change. */
+function stubMatchMedia(initialMatches: boolean) {
+	let listener: ((e: { matches: boolean }) => void) | null = null;
+	const mql = {
+		matches: initialMatches,
+		addEventListener: (_: string, cb: (e: { matches: boolean }) => void) => {
+			listener = cb;
+		},
+		removeEventListener: () => {
+			listener = null;
+		},
+	};
+	vi.stubGlobal(
+		"matchMedia",
+		vi.fn(() => mql),
+	);
+	return {
+		fireChange(matches: boolean) {
+			mql.matches = matches;
+			listener?.({ matches });
+		},
+	};
+}
+
+describe("useEffectiveTheme", () => {
+	it("renders dark immediately when auto and the OS prefers dark", () => {
+		stubMatchMedia(true);
+		const { result } = renderHook(() => useEffectiveTheme("auto"));
+		expect(result.current).toBe("dark");
+	});
+
+	it("follows a live OS scheme change in auto", () => {
+		const media = stubMatchMedia(false);
+		const { result } = renderHook(() => useEffectiveTheme("auto"));
+		expect(result.current).toBe("light");
+		act(() => media.fireChange(true));
+		expect(result.current).toBe("dark");
+		act(() => media.fireChange(false));
+		expect(result.current).toBe("light");
+	});
+
+	it("explicit dark never subscribes to the OS scheme", () => {
+		const media = stubMatchMedia(false);
+		const { result } = renderHook(() => useEffectiveTheme("dark"));
+		expect(result.current).toBe("dark");
+		act(() => media.fireChange(true));
+		act(() => media.fireChange(false));
+		expect(result.current).toBe("dark");
+	});
+});

--- a/packages/widget/src/theme.test.ts
+++ b/packages/widget/src/theme.test.ts
@@ -1,7 +1,12 @@
 import { act, renderHook } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { parseTheme, resolveEffectiveTheme, useEffectiveTheme } from "./theme";
+import {
+	parseTheme,
+	resolveEffectiveTheme,
+	resolveHostDark,
+	useEffectiveTheme,
+} from "./theme";
 
 afterEach(() => {
 	vi.unstubAllGlobals();
@@ -82,6 +87,67 @@ describe("useEffectiveTheme", () => {
 		expect(result.current).toBe("dark");
 		act(() => media.fireChange(true));
 		act(() => media.fireChange(false));
+		expect(result.current).toBe("dark");
+	});
+});
+
+describe("parseTheme — host", () => {
+	it("accepts host", () => {
+		expect(parseTheme("host")).toBe("host");
+	});
+});
+
+describe("resolveHostDark", () => {
+	it("follows the host's dark/light class (next-themes attribute=class)", () => {
+		expect(resolveHostDark("dark", null, false)).toBe(true);
+		expect(resolveHostDark("some other dark classes", null, false)).toBe(true);
+		expect(resolveHostDark("light", null, true)).toBe(false);
+	});
+
+	it("follows a data-theme attribute", () => {
+		expect(resolveHostDark("", "dark", false)).toBe(true);
+		expect(resolveHostDark("", "light", true)).toBe(false);
+	});
+
+	it("never matches substrings of other class names", () => {
+		expect(resolveHostDark("darkroom skylight", null, false)).toBe(false);
+	});
+
+	it("defers to the OS when the host declares nothing", () => {
+		expect(resolveHostDark("", null, true)).toBe(true);
+		expect(resolveHostDark("", null, false)).toBe(false);
+	});
+});
+
+describe("useEffectiveTheme — host mode", () => {
+	afterEach(() => {
+		document.documentElement.className = "";
+		document.documentElement.removeAttribute("data-theme");
+	});
+
+	it("mirrors the host <html> class and follows a live toggle", async () => {
+		stubMatchMedia(false);
+		document.documentElement.className = "dark";
+		const { result } = renderHook(() => useEffectiveTheme("host"));
+		expect(result.current).toBe("dark");
+
+		// The site's theme toggle flips the class — the widget must follow.
+		await act(async () => {
+			document.documentElement.className = "light";
+			await new Promise((r) => setTimeout(r, 0)); // MutationObserver flush
+		});
+		expect(result.current).toBe("light");
+
+		await act(async () => {
+			document.documentElement.setAttribute("data-theme", "dark");
+			await new Promise((r) => setTimeout(r, 0));
+		});
+		expect(result.current).toBe("dark");
+	});
+
+	it("falls back to the OS scheme when the host declares nothing", () => {
+		stubMatchMedia(true);
+		const { result } = renderHook(() => useEffectiveTheme("host"));
 		expect(result.current).toBe("dark");
 	});
 });

--- a/packages/widget/src/theme.ts
+++ b/packages/widget/src/theme.ts
@@ -1,0 +1,63 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Widget color scheme. "light" is the default (and the pre-theming look, so
+ * existing embeds render unchanged), "dark" forces the dark palette, and
+ * "auto" follows the visitor's OS preference live via prefers-color-scheme.
+ */
+export type WidgetTheme = "light" | "dark" | "auto";
+
+/** Parse a `data-theme` / prop value; anything unrecognized falls back to
+ * "light" so a typo can never flip a customer's site to dark. */
+export function parseTheme(raw: string | null | undefined): WidgetTheme {
+	return raw === "dark" || raw === "auto" ? raw : "light";
+}
+
+/** The concrete scheme to render for a preference. Pure so it's unit-tested;
+ * the hook below owns the matchMedia subscription. */
+export function resolveEffectiveTheme(
+	pref: WidgetTheme,
+	prefersDark: boolean,
+): "light" | "dark" {
+	if (pref === "auto") {
+		return prefersDark ? "dark" : "light";
+	}
+	return pref;
+}
+
+const DARK_QUERY = "(prefers-color-scheme: dark)";
+
+function prefersDarkNow(): boolean {
+	return (
+		typeof window !== "undefined" &&
+		(window.matchMedia?.(DARK_QUERY)?.matches ?? false)
+	);
+}
+
+/**
+ * The scheme the widget should render, kept live: in "auto" it re-renders when
+ * the OS scheme changes (matchMedia change event); for explicit "light"/"dark"
+ * the subscription is skipped entirely. SSR-safe — first render assumes
+ * no-dark, which only matters for "auto" and corrects on mount.
+ */
+export function useEffectiveTheme(pref: WidgetTheme): "light" | "dark" {
+	const [prefersDark, setPrefersDark] = useState(
+		() => pref === "auto" && prefersDarkNow(),
+	);
+
+	useEffect(() => {
+		if (pref !== "auto" || typeof window === "undefined") {
+			return;
+		}
+		const mq = window.matchMedia?.(DARK_QUERY);
+		if (!mq) {
+			return;
+		}
+		setPrefersDark(mq.matches);
+		const onChange = (e: MediaQueryListEvent) => setPrefersDark(e.matches);
+		mq.addEventListener?.("change", onChange);
+		return () => mq.removeEventListener?.("change", onChange);
+	}, [pref]);
+
+	return resolveEffectiveTheme(pref, prefersDark);
+}

--- a/packages/widget/src/theme.ts
+++ b/packages/widget/src/theme.ts
@@ -2,27 +2,52 @@ import { useEffect, useState } from "react";
 
 /**
  * Widget color scheme. "light" is the default (and the pre-theming look, so
- * existing embeds render unchanged), "dark" forces the dark palette, and
- * "auto" follows the visitor's OS preference live via prefers-color-scheme.
+ * existing embeds render unchanged), "dark" forces the dark palette, "auto"
+ * follows the visitor's OS via prefers-color-scheme, and "host" mirrors the
+ * embedding page's own theme — the `dark`/`light` class or `data-theme`
+ * attribute on <html> that next-themes and most site toggles maintain —
+ * updating live when the host flips, and falling back to the OS scheme when
+ * the host declares nothing.
  */
-export type WidgetTheme = "light" | "dark" | "auto";
+export type WidgetTheme = "light" | "dark" | "auto" | "host";
 
 /** Parse a `data-theme` / prop value; anything unrecognized falls back to
  * "light" so a typo can never flip a customer's site to dark. */
 export function parseTheme(raw: string | null | undefined): WidgetTheme {
-	return raw === "dark" || raw === "auto" ? raw : "light";
+	return raw === "dark" || raw === "auto" || raw === "host" ? raw : "light";
 }
 
-/** The concrete scheme to render for a preference. Pure so it's unit-tested;
- * the hook below owns the matchMedia subscription. */
+/** The concrete scheme for a non-host preference. Pure so it's unit-tested;
+ * the hook below owns the matchMedia/observer subscriptions. */
 export function resolveEffectiveTheme(
-	pref: WidgetTheme,
+	pref: "light" | "dark" | "auto",
 	prefersDark: boolean,
 ): "light" | "dark" {
 	if (pref === "auto") {
 		return prefersDark ? "dark" : "light";
 	}
 	return pref;
+}
+
+/**
+ * Whether the host page declares dark — via the class conventions ("dark" /
+ * "light" on <html>, as next-themes' attribute="class" writes) or a
+ * data-theme attribute. No declaration at all defers to the OS preference.
+ * Pure so it's unit-tested.
+ */
+export function resolveHostDark(
+	className: string,
+	dataTheme: string | null,
+	prefersDark: boolean,
+): boolean {
+	const classes = className.split(/\s+/);
+	if (classes.includes("dark") || dataTheme === "dark") {
+		return true;
+	}
+	if (classes.includes("light") || dataTheme === "light") {
+		return false;
+	}
+	return prefersDark;
 }
 
 const DARK_QUERY = "(prefers-color-scheme: dark)";
@@ -34,30 +59,69 @@ function prefersDarkNow(): boolean {
 	);
 }
 
+function hostDarkNow(): boolean {
+	if (typeof document === "undefined") {
+		return false;
+	}
+	const root = document.documentElement;
+	return resolveHostDark(
+		root.className,
+		root.getAttribute("data-theme"),
+		prefersDarkNow(),
+	);
+}
+
+function initialDark(pref: WidgetTheme): boolean {
+	if (pref === "dark") {
+		return true;
+	}
+	if (pref === "auto") {
+		return prefersDarkNow();
+	}
+	if (pref === "host") {
+		return hostDarkNow();
+	}
+	return false;
+}
+
 /**
- * The scheme the widget should render, kept live: in "auto" it re-renders when
- * the OS scheme changes (matchMedia change event); for explicit "light"/"dark"
- * the subscription is skipped entirely. SSR-safe — first render assumes
- * no-dark, which only matters for "auto" and corrects on mount.
+ * The scheme the widget should render, kept live: "auto" re-renders on OS
+ * scheme changes (matchMedia), "host" additionally observes the host page's
+ * <html> class / data-theme mutations so a site theme toggle flips the widget
+ * instantly. Explicit "light"/"dark" subscribe to nothing. SSR-safe — the
+ * first render assumes no-dark and corrects on mount.
  */
 export function useEffectiveTheme(pref: WidgetTheme): "light" | "dark" {
-	const [prefersDark, setPrefersDark] = useState(
-		() => pref === "auto" && prefersDarkNow(),
-	);
+	const [isDark, setIsDark] = useState(() => initialDark(pref));
 
 	useEffect(() => {
-		if (pref !== "auto" || typeof window === "undefined") {
+		if (typeof window === "undefined") {
 			return;
 		}
-		const mq = window.matchMedia?.(DARK_QUERY);
-		if (!mq) {
+		if (pref === "light" || pref === "dark") {
+			setIsDark(pref === "dark");
 			return;
 		}
-		setPrefersDark(mq.matches);
-		const onChange = (e: MediaQueryListEvent) => setPrefersDark(e.matches);
-		mq.addEventListener?.("change", onChange);
-		return () => mq.removeEventListener?.("change", onChange);
+		const mq = window.matchMedia?.(DARK_QUERY) ?? null;
+		const compute = () =>
+			setIsDark(pref === "host" ? hostDarkNow() : (mq?.matches ?? false));
+		compute();
+		// OS scheme feeds both modes ("host" uses it as the no-declaration fallback).
+		const onMq = () => compute();
+		mq?.addEventListener?.("change", onMq);
+		let observer: MutationObserver | undefined;
+		if (pref === "host" && typeof MutationObserver !== "undefined") {
+			observer = new MutationObserver(compute);
+			observer.observe(document.documentElement, {
+				attributes: true,
+				attributeFilter: ["class", "data-theme"],
+			});
+		}
+		return () => {
+			mq?.removeEventListener?.("change", onMq);
+			observer?.disconnect();
+		};
 	}, [pref]);
 
-	return resolveEffectiveTheme(pref, prefersDark);
+	return isDark ? "dark" : "light";
 }

--- a/packages/widget/src/widget.tsx
+++ b/packages/widget/src/widget.tsx
@@ -29,10 +29,12 @@ import {
 import { mergeMessages } from "./messages-sync";
 import { rateMessage, useMessageRatings } from "./rating";
 import { ShowcaseChat } from "./ShowcaseChat";
+import { useEffectiveTheme } from "./theme";
 import { useServerMessages } from "./useServerMessages";
 import { useWidgetConfig } from "./widget-config";
 
 import type { Rating } from "./rating";
+import type { WidgetTheme } from "./theme";
 
 /** How long the "Thanks!" screen shows before the conversation view returns. */
 const CSAT_THANKS_MS = 1200;
@@ -54,6 +56,8 @@ export type WidgetLayout = "bubble" | "inline";
 interface BaseWidgetProps {
 	brandColor: string;
 	mode?: WidgetLayout;
+	/** Color scheme: "light" (default) | "dark" | "auto" (follows the OS). */
+	theme?: WidgetTheme;
 }
 
 interface LiveWidgetProps extends BaseWidgetProps {
@@ -74,18 +78,30 @@ export type WidgetProps = LiveWidgetProps | ShowcaseWidgetProps;
 
 export function Widget(props: WidgetProps) {
 	if (props.widgetMode === "showcase") {
-		return <ShowcaseWidget brandColor={props.brandColor} mode={props.mode} />;
+		return (
+			<ShowcaseWidget
+				brandColor={props.brandColor}
+				mode={props.mode}
+				theme={props.theme}
+			/>
+		);
 	}
 	return <LiveWidget {...props} />;
 }
 
-function ShowcaseWidget({ brandColor, mode = "bubble" }: BaseWidgetProps) {
+function ShowcaseWidget({
+	brandColor,
+	mode = "bubble",
+	theme = "light",
+}: BaseWidgetProps) {
 	const inline = mode === "inline";
 	const [open, setOpen] = useState(inline);
+	const resolvedTheme = useEffectiveTheme(theme);
 	return (
 		<WidgetFrame
 			inline={inline}
 			brandColor={brandColor}
+			theme={resolvedTheme}
 			open={open}
 			onOpenChange={setOpen}
 			badge={<span className="llmchat-demo-badge">Demo mode</span>}
@@ -140,10 +156,12 @@ function LiveWidget({
 	apiUrl,
 	brandColor,
 	mode = "bubble",
+	theme = "light",
 	escalationThreshold,
 }: LiveWidgetProps) {
 	const inline = mode === "inline";
 	const [open, setOpen] = useState(inline);
+	const resolvedTheme = useEffectiveTheme(theme);
 	const [text, setText] = useState("");
 	// Hydrate identity from localStorage on first render (lazy init → no flash of
 	// the form on reload). The widget mounts client-side only, and getStoredIdentity
@@ -470,6 +488,7 @@ function LiveWidget({
 		<WidgetFrame
 			inline={inline}
 			brandColor={brandColor}
+			theme={resolvedTheme}
 			open={open}
 			onOpenChange={handleOpenChange}
 			actions={


### PR DESCRIPTION
## What

The widget now supports color schemes: `data-theme="light" | "dark" | "auto" | "host"` on the embed script (and a `theme` prop on the `Widget` component). Default stays **light** — existing embeds render pixel-identical.

- **auto** — follows the visitor's OS via `prefers-color-scheme`, live (matchMedia subscription).
- **host** — mirrors the embedding page's own theme: observes the `<html>` `class` / `data-theme` attribute (the conventions next-themes and most site toggles write) with a MutationObserver, so flipping the site theme flips the widget instantly; no declaration falls back to the OS.
- Unknown values collapse to light, so a typo can never flip a customer's site dark.

## How

- The shadow-DOM stylesheet's gray/semantic palette (58 hardcoded occurrences) is tokenized into CSS custom properties; `.llmchat--dark` overrides them (panel, bubbles, markdown chrome, operator-reply greens, demo-note indigos, error reds, scrollbars, `color-scheme`). On-brand surfaces stay white-on-brand in both themes.
- `theme.ts`: `parseTheme`, `resolveEffectiveTheme`, `resolveHostDark` (pure, word-boundary class matching — "darkroom"/"skylight" never match), `useEffectiveTheme` hook owning the matchMedia/observer subscriptions.
- `/embed/:key?theme=dark|auto` passes through (validated) with a matching page background so a dark inline chat never flashes white.
- Self-dogfooding: marketing + dashboard script tags and the showcase `WidgetMount` now use `host` — all three sites run next-themes toggles. The attribute is inert against the currently-deployed widget.js and activates on this deploy.

## Testing

- 13 new unit/hook tests (parse, resolution, host mirroring incl. live class flips via MutationObserver), WidgetFrame class tests, embed passthrough tests. Full repo suite green (widget 186, api 595, dashboard 447, +).
- Verified live against the seeded stack with Playwright: explicit dark with a real AI conversation, default light (pixel-identical regression check), auto under both emulated OS schemes, dark embed page, and a host page with a working toggle button flipping the widget both ways.

🤖 Generated with [Claude Code](https://claude.com/claude-code)