### PR TITLE
fix(widget): honor the project's configured welcomeMessage as the greeting (#113)

### DIFF
--- a/apps/api/src/routes/widget-config.test.ts
+++ b/apps/api/src/routes/widget-config.test.ts
@@ -30,6 +30,7 @@ describe("GET /config/:key — public widget config", () => {
 			workspaceId: "ws1",
 			privacyPolicyUrl: null,
 			suggestedQuestions: ["Pricing?", "Refunds?"],
+			welcomeMessage: "Welcome to Acme!",
 		});
 		const res = await widgetConfig.request("/config/pk_x", {}, ENV);
 		expect(res.status).toBe(200);
@@ -38,7 +39,21 @@ describe("GET /config/:key — public widget config", () => {
 			privacyPolicyUrl: null,
 			suggestedQuestions: ["Pricing?", "Refunds?"],
 			collectIdentity: false,
+			welcomeMessage: "Welcome to Acme!",
 		});
+	});
+
+	it("returns the configured welcomeMessage; degrades a legacy row to null", async () => {
+		mockProject({
+			workspaceId: "ws1",
+			privacyPolicyUrl: null,
+			suggestedQuestions: [],
+			// Legacy row predating the column → the endpoint must not 500.
+			welcomeMessage: undefined,
+		});
+		const res = await widgetConfig.request("/config/pk_x", {}, ENV);
+		expect(res.status).toBe(200);
+		expect(await res.json()).toMatchObject({ welcomeMessage: null });
 	});
 
 	it("reports collectIdentity when the project enables the pre-chat form", async () => {

--- a/apps/api/src/routes/widget-config.ts
+++ b/apps/api/src/routes/widget-config.ts
@@ -23,6 +23,7 @@ export const widgetConfig = new Hono<AppContext>().get(
 				privacyPolicyUrl: true,
 				suggestedQuestions: true,
 				collectIdentity: true,
+				welcomeMessage: true,
 			},
 		});
 		if (!project) {
@@ -43,6 +44,13 @@ export const widgetConfig = new Hono<AppContext>().get(
 			// Whether the widget asks for name/email before chatting. Off by
 			// default — the widget opens straight into the conversation.
 			collectIdentity: project.collectIdentity === true,
+			// The operator-configured greeting shown before the first message.
+			// Guarded: a non-string/legacy value degrades to null, and the widget
+			// then falls back to its built-in default greeting.
+			welcomeMessage:
+				typeof project.welcomeMessage === "string"
+					? project.welcomeMessage
+					: null,
 		});
 	},
 );

--- a/packages/widget/src/widget-config.ts
+++ b/packages/widget/src/widget-config.ts
@@ -13,6 +13,9 @@ export interface WidgetConfig {
 	/** Whether the widget asks for the visitor's name/email before chatting.
 	 * Defaults to false: the widget opens straight into the conversation. */
 	collectIdentity: boolean;
+	/** Operator-configured greeting shown before the first message, or null to
+	 * use the widget's built-in default. */
+	welcomeMessage: string | null;
 }
 
 /**
@@ -33,6 +36,7 @@ export function useWidgetConfig(
 		privacyPolicyUrl: null,
 		suggestedQuestions: [],
 		collectIdentity: false,
+		welcomeMessage: null,
 	});
 	useEffect(() => {
 		let active = true;
@@ -45,6 +49,7 @@ export function useWidgetConfig(
 						privacyPolicyUrl?: unknown;
 						suggestedQuestions?: unknown;
 						collectIdentity?: unknown;
+						welcomeMessage?: unknown;
 					} | null,
 				) => {
 					if (!active || !data) return;
@@ -66,6 +71,10 @@ export function useWidgetConfig(
 							typeof data.collectIdentity === "boolean"
 								? data.collectIdentity
 								: prev.collectIdentity,
+						welcomeMessage:
+							typeof data.welcomeMessage === "string"
+								? data.welcomeMessage
+								: prev.welcomeMessage,
 					}));
 				},
 			)

--- a/packages/widget/src/widget.tsx
+++ b/packages/widget/src/widget.tsx
@@ -216,6 +216,7 @@ function LiveWidget({
 		privacyPolicyUrl,
 		suggestedQuestions,
 		collectIdentity,
+		welcomeMessage,
 	} = useWidgetConfig(apiUrl, projectKey);
 	// The pre-chat name/email form is opt-in per project (collectIdentity).
 	// Off (the default), the widget opens straight into the conversation; a
@@ -524,7 +525,11 @@ function LiveWidget({
 				<>
 					<MessageList
 						greeting={
-							name ? `Hi ${name}! How can I help?` : "Hi! How can I help?"
+							// The operator's configured welcomeMessage wins once the server
+							// config resolves; until then (or if unset) fall back to the
+							// built-in default, personalized when we already know the name.
+							welcomeMessage?.trim() ||
+							(name ? `Hi ${name}! How can I help?` : "Hi! How can I help?")
 						}
 						messages={displayMessages}
 						typing={loading}

--- a/packages/widget/src/widget.welcome.test.tsx
+++ b/packages/widget/src/widget.welcome.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// Keep the live widget off the network/model and drive the server-authoritative
+// config through a mutable ref so each case can vary welcomeMessage.
+const { config } = vi.hoisted(() => ({
+	config: {
+		current: {
+			showBranding: false,
+			privacyPolicyUrl: null as string | null,
+			suggestedQuestions: [] as string[],
+			collectIdentity: false,
+			welcomeMessage: null as string | null,
+		},
+	},
+}));
+vi.mock("ai", () => ({ DefaultChatTransport: class {} }));
+vi.mock("@ai-sdk/react", () => ({
+	Chat: class {},
+	useChat: () => ({
+		messages: [],
+		sendMessage: vi.fn(async () => {}),
+		status: "ready",
+		error: null,
+	}),
+}));
+vi.mock("./widget-config", () => ({
+	useWidgetConfig: () => config.current,
+}));
+
+import * as serverMessages from "./useServerMessages";
+import { Widget } from "./widget";
+
+afterEach(() => {
+	vi.restoreAllMocks();
+	sessionStorage.clear();
+	localStorage.clear();
+	config.current.welcomeMessage = null;
+});
+
+function mountLive() {
+	vi.spyOn(serverMessages, "useServerMessages").mockReturnValue({
+		serverMessages: [],
+		conversationId: null,
+		csatRating: null,
+		escalatedAt: null,
+		archivedAt: null,
+		refresh: vi.fn(),
+	});
+	render(
+		<Widget
+			widgetMode="live"
+			projectKey="pk"
+			apiUrl="http://x"
+			brandColor="#4f46e5"
+			mode="inline"
+		/>,
+	);
+}
+
+describe("LiveWidget — greeting honors the configured welcomeMessage", () => {
+	it("renders the operator's welcomeMessage as the opening greeting", () => {
+		config.current.welcomeMessage = "Welcome to Acme Tools — how can I help?";
+		mountLive();
+		expect(
+			screen.getByText("Welcome to Acme Tools — how can I help?"),
+		).toBeInTheDocument();
+	});
+
+	it("falls back to the built-in default when no welcomeMessage is configured", () => {
+		config.current.welcomeMessage = null;
+		mountLive();
+		expect(screen.getByText("Hi! How can I help?")).toBeInTheDocument();
+	});
+
+	it("treats a blank/whitespace welcomeMessage as unset", () => {
+		config.current.welcomeMessage = "   ";
+		mountLive();
+		expect(screen.getByText("Hi! How can I help?")).toBeInTheDocument();
+	});
+});


### PR DESCRIPTION
## Problem
The live widget hardcoded its opening greeting (`"Hi! How can I help?"`) and ignored each project's configured `welcomeMessage` (#113).

## Root cause
Two parts: the public `/v1/config/:key` endpoint never exposed `welcomeMessage`, and `widget.tsx` hardcoded the greeting string.

## Fix
- `apps/api/src/routes/widget-config.ts` — endpoint returns `welcomeMessage` (guarded → `null` on legacy rows; never 500s)
- `packages/widget/src/widget-config.ts` — `useWidgetConfig` parses it into the resolved config
- `packages/widget/src/widget.tsx` — greeting uses the configured `welcomeMessage`, falling back to the built-in default when unset/blank (personalized with the visitor's name only in the fallback)

## Tests
- API: endpoint returns the configured value + degrades a legacy row to `null`
- Widget: new `widget.welcome.test.tsx` — renders configured / blank / unset greeting
- Full gates: API 596/596, widget 189/189, prettier + oxlint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018pJJgDHCnnNeEqEAApxFcQ
