### PR TITLE
feat(db): add message.reply_to_message_id column (migration only)

### DIFF
--- a/apps/api/migrations/0022_message_reply_to.sql
+++ b/apps/api/migrations/0022_message_reply_to.sql
@@ -1,0 +1,22 @@
+-- Quote-reply: the earlier message in the SAME conversation that this message is
+-- replying to (the widget's "Replying to:" affordance). Nullable: NULL = not a
+-- reply, which is every existing row. Bare `text` column with NO inline FK
+-- clause, matching 0009/0015 on this table — the self-reference is validated in
+-- application code (/v1/chat resolves it with and(id, conversationId), so a
+-- foreign or unknown id can never be stored), never by a DB constraint, and we
+-- never rely on FK cascade (see lib/workspace-deletion.ts). A dangling id (the
+-- quoted message was deleted with its conversation) is therefore harmless: both
+-- clients resolve the target from the already-loaded thread and fall back to a
+-- neutral "earlier message" chip. No index — resolution is in-memory over the
+-- loaded window, never a lookup by this column.
+--
+-- PHASE 1 of 2 (deliberate migrate-before-serve split, mirroring 0014/0015).
+-- Ploy's deploy ordering between "apply migrations" and "new Worker serves
+-- traffic" is undocumented, so this PR ships ONLY the column — schema.ts is
+-- intentionally NOT changed, so the live Worker never SELECTs a column that might
+-- not exist yet (drizzle projects every column of `message`, and /v1/chat +
+-- /v1/messages read it on the hottest paths; no read can 500 under any ordering).
+-- The schema field, the /v1/chat validation + persistence, the /v1/messages
+-- serializer, and the widget/dashboard UI land in a follow-up PR once this column
+-- is live in prod.
+ALTER TABLE `message` ADD COLUMN `reply_to_message_id` text;


### PR DESCRIPTION
## What

Phase 1 of 2 for **quote-reply** (visitor replies to a specific earlier message in the widget). This PR ships **only** migration `0022_message_reply_to.sql` — one additive `ALTER TABLE`. `schema.ts` is deliberately untouched; nothing reads or writes the column yet.

```sql
ALTER TABLE `message` ADD COLUMN `reply_to_message_id` text;
```

## Why it's split

Deliberate **migrate-before-serve** split, mirroring the 0014/0015 precedent. Ploy's deploy ordering between "apply migrations" and "new Worker serves traffic" is undocumented, and drizzle projects *every* column of `message` on the hottest read paths (`/v1/chat` persistence, `/v1/messages`). Adding the field to `schema.ts` in the same PR risks a Worker SELECTing a column that doesn't exist yet — and reliably 500s preview deploys, which skip migrations entirely.

So: column first, code second.

## Design notes (baked into the file header)

- **Nullable, bare `text`, no inline FK clause** — matches `0009_message_rating` / `0015_conversation_resolved_by` on this same table. The self-reference is validated in application code (`/v1/chat` resolves it with `and(eq(id), eq(conversationId))`, so a foreign or unknown id can never be stored), never by a DB constraint.
- **No cascade reliance.** Per `lib/workspace-deletion.ts`, FK cascade is unreliable across the D1 emulator vs prod. A dangling id (quoted message deleted with its conversation) is harmless by design: both clients resolve the target from the already-loaded thread and fall back to a neutral "earlier message" chip.
- **No index** — resolution is in-memory over the loaded window, never a lookup by this column.

## Follow-up (PR-B)

`schema.ts` field, `/v1/chat` validation + persistence, `/v1/messages` serializer, fenced prompt annotation, widget + dashboard quote chips.

## Gates

- `pnpm format` — clean
- `pnpm lint` — 11/11 tasks pass, 0 errors
- `pnpm test` — 7/7 tasks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018pJJgDHCnnNeEqEAApxFcQ