### PR TITLE
feat(widget): unread badge on the launcher when a reply lands while the panel is closed

### DIFF
--- a/packages/widget/src/components/WidgetFrame.tsx
+++ b/packages/widget/src/components/WidgetFrame.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 
+import { badgeLabel, launcherLabel } from "../unread";
 import { ChatIcon, CloseIcon, CollapseIcon, ExpandIcon } from "./icons";
 
 import type { ReactNode } from "react";
@@ -27,6 +28,7 @@ export function WidgetFrame({
 	open,
 	onOpenChange,
 	badge,
+	unreadCount = 0,
 	actions,
 	footer,
 	children,
@@ -39,6 +41,9 @@ export function WidgetFrame({
 	onOpenChange: (open: boolean) => void;
 	/** Optional header adornment, e.g. the showcase "Demo mode" pill. */
 	badge?: ReactNode;
+	/** Messages that arrived while the panel was closed — rendered as a count on
+	 * the launcher. Only meaningful in bubble layout (inline has no launcher). */
+	unreadCount?: number;
 	/** Optional header buttons rendered before the expand/close controls,
 	 * e.g. the "Start a new conversation" action. */
 	actions?: ReactNode;
@@ -85,6 +90,9 @@ export function WidgetFrame({
 
 	const showPanel = inline || mounted;
 	const closing = !inline && mounted && !open;
+	// The badge is a CLOSED-panel affordance: once the panel is open, the thread
+	// itself is the read surface, so the count is moot whatever the caller passes.
+	const unread = open ? 0 : Math.max(0, Math.trunc(unreadCount));
 
 	return (
 		<div
@@ -92,18 +100,36 @@ export function WidgetFrame({
 			style={{ ["--brand" as string]: brandColor }}
 		>
 			{!inline && (
-				<button
-					ref={launcherRef}
-					type="button"
-					className={`llmchat-bubble${open ? " llmchat-bubble--open" : ""}`}
-					onClick={() => onOpenChange(!open)}
-					aria-label={open ? "Close chat" : "Open chat"}
-					aria-expanded={open}
-				>
-					<span className="llmchat-bubble-icon">
-						{open ? <CloseIcon /> : <ChatIcon />}
+				<>
+					{/* The count also reaches a screen reader that isn't focused on the
+					    launcher: an operator replying is an event, and the button's own
+					    label only speaks when it's read. Empty when there's nothing new,
+					    so it never re-announces on open/close. */}
+					<span className="llmchat-sr-only" role="status">
+						{unread > 0
+							? `${unread} new ${unread === 1 ? "message" : "messages"} in the support chat`
+							: ""}
 					</span>
-				</button>
+					<button
+						ref={launcherRef}
+						type="button"
+						className={`llmchat-bubble${open ? " llmchat-bubble--open" : ""}`}
+						onClick={() => onOpenChange(!open)}
+						aria-label={launcherLabel(open, unread)}
+						aria-expanded={open}
+					>
+						<span className="llmchat-bubble-icon">
+							{open ? <CloseIcon /> : <ChatIcon />}
+						</span>
+						{unread > 0 && (
+							// Decorative — the number is already in the button's accessible
+							// name and the live region above.
+							<span className="llmchat-bubble-badge" aria-hidden="true">
+								{badgeLabel(unread)}
+							</span>
+						)}
+					</button>
+				</>
 			)}
 			{showPanel && (
 				<div

--- a/packages/widget/src/styles.ts
+++ b/packages/widget/src/styles.ts
@@ -148,6 +148,64 @@ export const widgetStyles = `
 	}
 }
 
+/* Unread count — messages that landed while the panel was closed (usually the
+   human's reply after an escalation). Inverted brand chrome: the launcher itself
+   is var(--brand), so a brand-filled badge on it would be invisible; a white pill
+   with brand text and a brand ring reads as part of the same object and needs no
+   new hue (deliberately NOT notification-red — this is a support reply, not an
+   alarm). Literal #fff in both themes, like every other on-brand surface. */
+.llmchat-bubble-badge {
+	position: absolute;
+	top: -2px;
+	right: -2px;
+	min-width: 22px;
+	height: 22px;
+	padding: 0 6px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	border-radius: 9999px;
+	background: #fff;
+	color: var(--brand);
+	border: 2px solid var(--brand);
+	/* px, never rem: rem resolves against the HOST page's root font-size even
+	   inside shadow DOM (Shopify's Dawn sets html to 62.5%). */
+	font-size: 11.7px;
+	font-weight: 700;
+	line-height: 1;
+	font-variant-numeric: tabular-nums;
+	/* direction inherits across the shadow boundary: on an RTL host page the
+	   trailing "+" of "9+" is bidi-neutral and would reorder to "+9". */
+	direction: ltr;
+	box-shadow: 0 2px 6px rgba(0, 0, 0, 0.22);
+	animation: llmchat-badge-in 0.22s cubic-bezier(0.16, 1, 0.3, 1);
+}
+@keyframes llmchat-badge-in {
+	from {
+		opacity: 0;
+		transform: scale(0.4);
+	}
+	to {
+		opacity: 1;
+		transform: none;
+	}
+}
+
+/* Announced, never seen: the live region that tells a screen reader a reply
+   arrived while the panel was closed. */
+.llmchat-sr-only {
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	padding: 0;
+	margin: -1px;
+	overflow: hidden;
+	clip: rect(0 0 0 0);
+	clip-path: inset(50%);
+	white-space: nowrap;
+	border: 0;
+}
+
 /* ── Panel ─────────────────────────────────────────────────────────── */
 .llmchat-panel {
 	position: fixed;

--- a/packages/widget/src/unread.test.ts
+++ b/packages/widget/src/unread.test.ts
@@ -1,0 +1,231 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+	BACKGROUND_POLL_INTERVAL_MS,
+	badgeLabel,
+	clearSnapshot,
+	countUnread,
+	latestSequence,
+	launcherLabel,
+	readSnapshot,
+	sameSnapshot,
+	shouldPollInBackground,
+	writeSnapshot,
+} from "./unread";
+import { widgetStyles } from "./styles";
+import { POLL_INTERVAL_MS } from "./useServerMessages";
+
+import type { ConversationSnapshot } from "./unread";
+import type { ServerMessage } from "./messages-sync";
+
+function msg(
+	sequence: number,
+	role: string,
+	content = `msg ${sequence}`,
+): ServerMessage {
+	return { id: `m${sequence}`, role, content, sequence, createdAt: sequence };
+}
+
+function snapshot(
+	over: Partial<ConversationSnapshot> = {},
+): ConversationSnapshot {
+	return {
+		clientId: "c1",
+		conversationId: "conv1",
+		escalated: false,
+		resolved: false,
+		lastSeenSequence: 0,
+		...over,
+	};
+}
+
+beforeEach(() => {
+	sessionStorage.clear();
+});
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("countUnread", () => {
+	it("counts only what the panel will actually render as somebody else's message", () => {
+		const feed = [
+			msg(1, "user"),
+			msg(2, "assistant"),
+			msg(3, "system", "Visitor requested a human operator"),
+			msg(4, "user"), // the visitor's own reply (e.g. arrived by inbound email)
+			msg(5, "admin", "Hi, this is Luca — looking now"),
+		];
+		// Everything past the marker, minus the visitor's own turns.
+		expect(countUnread(feed, 1)).toBe(3); // assistant + system + admin
+		expect(countUnread(feed, 3)).toBe(1); // just the admin reply
+		expect(countUnread(feed, 5)).toBe(0);
+	});
+
+	it("never counts the visitor's own messages — sending doesn't badge yourself", () => {
+		expect(countUnread([msg(1, "user"), msg(2, "user")], 0)).toBe(0);
+	});
+
+	it("ignores empty rows, which MessageList doesn't render either", () => {
+		expect(countUnread([msg(1, "assistant", "")], 0)).toBe(0);
+	});
+
+	it("survives a marker ahead of the feed (rows deleted from the inbox)", () => {
+		expect(countUnread([msg(1, "admin")], 99)).toBe(0);
+	});
+});
+
+describe("latestSequence", () => {
+	it("is 0 for an empty feed and the head otherwise", () => {
+		expect(latestSequence([])).toBe(0);
+		expect(
+			latestSequence([msg(1, "user"), msg(7, "admin"), msg(3, "user")]),
+		).toBe(7);
+	});
+});
+
+describe("badgeLabel", () => {
+	it("shows the count, capped at 9+", () => {
+		expect(badgeLabel(1)).toBe("1");
+		expect(badgeLabel(9)).toBe("9");
+		expect(badgeLabel(10)).toBe("9+");
+		expect(badgeLabel(240)).toBe("9+");
+	});
+});
+
+describe("launcherLabel", () => {
+	it("carries the count into the accessible name, singular and plural", () => {
+		expect(launcherLabel(false, 0)).toBe("Open chat");
+		expect(launcherLabel(false, 1)).toBe("Open chat, 1 new message");
+		expect(launcherLabel(false, 4)).toBe("Open chat, 4 new messages");
+		// Open panel = the thread is the read surface; the count is moot.
+		expect(launcherLabel(true, 4)).toBe("Close chat");
+	});
+});
+
+describe("shouldPollInBackground", () => {
+	it("polls ONLY for an existing, escalated, unresolved conversation", () => {
+		// No conversation in this tab (a fresh pageview) → zero background requests.
+		expect(shouldPollInBackground(null)).toBe(false);
+		// Chatted with the bot but never escalated → nobody owes them a reply.
+		expect(shouldPollInBackground(snapshot({ escalated: false }))).toBe(false);
+		// Escalated → a human is going to reply out of band. Poll.
+		expect(shouldPollInBackground(snapshot({ escalated: true }))).toBe(true);
+		// Resolved → terminal, nothing more is coming.
+		expect(
+			shouldPollInBackground(snapshot({ escalated: true, resolved: true })),
+		).toBe(false);
+	});
+});
+
+describe("snapshot storage", () => {
+	it("round-trips through sessionStorage", () => {
+		const s = snapshot({ escalated: true, lastSeenSequence: 4 });
+		writeSnapshot("pk", s);
+		expect(readSnapshot("pk", "c1")).toEqual(s);
+	});
+
+	it("is invisible to a rotated client id — a new conversation inherits nothing", () => {
+		writeSnapshot("pk", snapshot({ escalated: true, lastSeenSequence: 4 }));
+		// "Start a new conversation" mints a fresh client id.
+		expect(readSnapshot("pk", "c2")).toBeNull();
+		// …and therefore doesn't poll on the old conversation's behalf.
+		expect(shouldPollInBackground(readSnapshot("pk", "c2"))).toBe(false);
+	});
+
+	it("is scoped per project — two widgets on one origin can't adopt each other's read state", () => {
+		// The clientId is shared (one global key), so only the project scoping keeps
+		// project B from inheriting project A's conversation id and escalated flag —
+		// and polling on behalf of a conversation that isn't its own.
+		writeSnapshot(
+			"project-a",
+			snapshot({ conversationId: "convA", escalated: true }),
+		);
+		expect(readSnapshot("project-b", "c1")).toBeNull();
+		expect(readSnapshot("project-a", "c1")?.conversationId).toBe("convA");
+	});
+
+	it("clears — the conversation it described is gone", () => {
+		writeSnapshot("pk", snapshot({ escalated: true }));
+		clearSnapshot("pk");
+		expect(readSnapshot("pk", "c1")).toBeNull();
+		expect(shouldPollInBackground(readSnapshot("pk", "c1"))).toBe(false);
+	});
+
+	it("returns null for missing, malformed, or half-written records", () => {
+		expect(readSnapshot("pk", "c1")).toBeNull();
+		sessionStorage.setItem("llmchat_unread_pk", "{not json");
+		expect(readSnapshot("pk", "c1")).toBeNull();
+		// A record with no conversationId doesn't prove a conversation exists.
+		sessionStorage.setItem(
+			"llmchat_unread_pk",
+			JSON.stringify({ clientId: "c1", escalated: true }),
+		);
+		expect(readSnapshot("pk", "c1")).toBeNull();
+	});
+
+	it("coerces a junk marker to 0 rather than trusting it", () => {
+		sessionStorage.setItem(
+			"llmchat_unread_pk",
+			JSON.stringify({
+				clientId: "c1",
+				conversationId: "conv1",
+				lastSeenSequence: "many",
+			}),
+		);
+		expect(readSnapshot("pk", "c1")?.lastSeenSequence).toBe(0);
+	});
+
+	it("never throws when storage is blocked (partitioned third-party embed)", () => {
+		vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+			throw new Error("SecurityError");
+		});
+		vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+			throw new Error("SecurityError");
+		});
+		vi.spyOn(Storage.prototype, "removeItem").mockImplementation(() => {
+			throw new Error("SecurityError");
+		});
+		expect(readSnapshot("pk", "c1")).toBeNull();
+		expect(() => writeSnapshot("pk", snapshot())).not.toThrow();
+		expect(() => clearSnapshot("pk")).not.toThrow();
+	});
+});
+
+describe("BACKGROUND_POLL_INTERVAL_MS", () => {
+	it("stays inside the spec band — the budget is load-bearing, not just a comment", () => {
+		// 20–30s per the design (see the constant's header): ≤5% of the 4000/h
+		// shared /v1/messages cap per closed tab. The lifecycle tests advance
+		// timers BY this constant, so without this pin a regression to any value
+		// (say 1s = 3600 req/h, most of the cap from one idle tab) stays green.
+		expect(BACKGROUND_POLL_INTERVAL_MS).toBeGreaterThanOrEqual(20_000);
+		expect(BACKGROUND_POLL_INTERVAL_MS).toBeLessThanOrEqual(30_000);
+		// And it must stay an order of magnitude coarser than the open panel.
+		expect(BACKGROUND_POLL_INTERVAL_MS).toBeGreaterThanOrEqual(
+			POLL_INTERVAL_MS * 8,
+		);
+	});
+});
+
+describe("badge chrome", () => {
+	it("the stylesheet styles the exact class WidgetFrame renders", () => {
+		// jsdom never applies the shadow stylesheet, so nothing else binds the
+		// component's className to its CSS — a typo on either side would ship an
+		// unstyled raw count floating next to the launcher icon.
+		expect(widgetStyles).toContain(".llmchat-bubble-badge");
+		// RTL hosts: direction inherits across the shadow boundary; without this
+		// pin the "9+" label bidi-reorders to "+9".
+		expect(widgetStyles).toMatch(
+			/\.llmchat-bubble-badge\s*\{[^}]*direction:\s*ltr/,
+		);
+	});
+});
+
+describe("sameSnapshot", () => {
+	it("is true only when every field matches", () => {
+		expect(sameSnapshot(snapshot(), snapshot())).toBe(true);
+		expect(sameSnapshot(snapshot(), snapshot({ lastSeenSequence: 1 }))).toBe(
+			false,
+		);
+		expect(sameSnapshot(snapshot(), snapshot({ resolved: true }))).toBe(false);
+	});
+});

--- a/packages/widget/src/unread.ts
+++ b/packages/widget/src/unread.ts
@@ -1,0 +1,221 @@
+import type { ServerMessage } from "./messages-sync";
+
+/**
+ * How often the widget polls /v1/messages while the panel is CLOSED, so a visitor
+ * who escalated and then walked away still notices the human's reply.
+ *
+ * 25s, against the 2.5s foreground poll and the 4000-req/hour per-(project, IP)
+ * cap on /v1/messages (widget-messages.ts):
+ *
+ *   open panel        @2.5s → 1440 req/h → 36% of the cap, per tab
+ *   closed, escalated  @25s →  144 req/h → 3.6% of the cap, per tab
+ *
+ * The cap is shared by every visitor behind one IP, so the ceiling that matters is
+ * an office NAT: at 25s, ~27 closed-escalated tabs can sit on one IP before the
+ * project's bucket is even theoretically at risk — and they're 10x cheaper than a
+ * single open panel, which is what actually consumes it. 20s (180/h) trades that
+ * headroom down to ~22 tabs to buy 5s of badge latency nobody perceives; 30s
+ * (120/h) buys little more headroom for a slower badge. The thing being waited on
+ * is a human typing a reply — an event measured in minutes — so latency is the
+ * cheap axis and headroom is the dear one. 25s takes the middle of the band.
+ *
+ * Polls fail open (a 429 or an outage keeps the last good feed), so the worst case
+ * of being wrong here is a late badge, never a broken widget.
+ */
+export const BACKGROUND_POLL_INTERVAL_MS = 25_000;
+
+/** Counts above this render as "9+" — the launcher is 56px wide, not a mailbox. */
+const BADGE_MAX = 9;
+
+/**
+ * Tab-local read state for the current conversation, persisted in sessionStorage
+ * next to the clientId (lib.ts) — same scope, same lifetime: a conversation lives
+ * in one tab, so its read state does too.
+ *
+ * What is stored is the MARKER, never the count. The count is always recomputed
+ * from a fresh feed, so a reload can't resurrect a badge for messages that have
+ * since been read elsewhere, and can't miss ones that arrived while the tab was
+ * gone.
+ */
+export interface ConversationSnapshot {
+	/**
+	 * Owner of this snapshot. "Start a new conversation" rotates the clientId, and a
+	 * snapshot whose id doesn't match the live one is treated as absent — so a fresh
+	 * conversation inherits neither a marker nor a reason to poll.
+	 */
+	clientId: string;
+	/**
+	 * Proof that a conversation EXISTS for this tab. The clientId alone is not: it's
+	 * minted eagerly on mount for every pageview, chat or no chat. This field is what
+	 * keeps a visitor who never opened the widget at zero background requests.
+	 */
+	conversationId: string;
+	/** Escalated to a human — the only state in which anyone owes an out-of-band reply. */
+	escalated: boolean;
+	/** Resolved/archived — the handoff is over, nothing more is coming. */
+	resolved: boolean;
+	/** Sequence of the newest message the visitor has already seen (i.e. that was in
+	 * the feed while the panel was open). */
+	lastSeenSequence: number;
+}
+
+// Keyed per PROJECT, like the stored identity in lib.ts and unlike the clientId's
+// one global key. The clientId can be global because it's an opaque id that two
+// widgets on one origin can share harmlessly (a conversation is keyed by (project,
+// clientId), so they still get one each). Read state can't: a snapshot names a
+// conversation, so a shared record would let a second project's widget adopt the
+// first's marker — and poll on behalf of a conversation that isn't its own.
+const SNAPSHOT_KEY_PREFIX = "llmchat_unread_";
+
+function snapshotKey(projectKey: string): string {
+	return `${SNAPSHOT_KEY_PREFIX}${projectKey}`;
+}
+
+/**
+ * This tab's read state for a project, or null when there is none for `clientId` —
+ * no conversation yet, a rotated id, or unreadable/corrupt storage. Never throws:
+ * storage can be disabled or partitioned inside a third-party embed, and the badge
+ * is a nicety, not a reason to take the widget down.
+ */
+export function readSnapshot(
+	projectKey: string,
+	clientId: string,
+): ConversationSnapshot | null {
+	try {
+		const raw = sessionStorage.getItem(snapshotKey(projectKey));
+		if (!raw) {
+			return null;
+		}
+		const parsed = JSON.parse(raw) as Record<string, unknown>;
+		// Belongs to another (rotated, or stale) conversation → not ours to act on.
+		if (parsed.clientId !== clientId) {
+			return null;
+		}
+		const conversationId = parsed.conversationId;
+		if (typeof conversationId !== "string" || !conversationId) {
+			return null;
+		}
+		const seq = parsed.lastSeenSequence;
+		return {
+			clientId,
+			conversationId,
+			escalated: parsed.escalated === true,
+			resolved: parsed.resolved === true,
+			lastSeenSequence:
+				typeof seq === "number" && Number.isFinite(seq) && seq >= 0 ? seq : 0,
+		};
+	} catch {
+		return null;
+	}
+}
+
+/** Persist the read state. Best-effort — a storage failure just costs the badge. */
+export function writeSnapshot(
+	projectKey: string,
+	snapshot: ConversationSnapshot,
+): void {
+	try {
+		sessionStorage.setItem(snapshotKey(projectKey), JSON.stringify(snapshot));
+	} catch {
+		// ignore
+	}
+}
+
+/**
+ * Forget the read state — the conversation it describes is gone (an operator deleted
+ * it from the inbox, or the visitor started a new one). Leaving it would keep
+ * `shouldPollInBackground` true and poll a dead thread for the life of the tab.
+ */
+export function clearSnapshot(projectKey: string): void {
+	try {
+		sessionStorage.removeItem(snapshotKey(projectKey));
+	} catch {
+		// ignore
+	}
+}
+
+/** True when two snapshots carry the same state (nothing to persist or re-render). */
+export function sameSnapshot(
+	a: ConversationSnapshot,
+	b: ConversationSnapshot,
+): boolean {
+	return (
+		a.clientId === b.clientId &&
+		a.conversationId === b.conversationId &&
+		a.escalated === b.escalated &&
+		a.resolved === b.resolved &&
+		a.lastSeenSequence === b.lastSeenSequence
+	);
+}
+
+/**
+ * Whether to poll /v1/messages while the panel is CLOSED. Deliberately narrow — a
+ * background request is only justified when a HUMAN owes this visitor a reply:
+ *
+ *   - a conversation must exist in this tab (a pageview that never chatted makes
+ *     ZERO background requests — the common case, and the whole point of gating on
+ *     the snapshot rather than on the eagerly-minted clientId),
+ *   - it must be escalated (nothing else produces a reply the visitor is away
+ *     waiting for; the bot answers while they're watching), and
+ *   - it must not be resolved (terminal — polling stops for good).
+ *
+ * The bot's own reply landing while the panel is closed still badges, because the
+ * post-stream refresh in the widget (plus its one delayed retry — the api commits
+ * the assistant row in a waitUntil after the stream closes, so the immediate
+ * refetch can lose that race) already fetches that feed; it just never earns a
+ * new timer.
+ */
+export function shouldPollInBackground(
+	snapshot: ConversationSnapshot | null,
+): boolean {
+	return snapshot !== null && snapshot.escalated && !snapshot.resolved;
+}
+
+/** The highest sequence in the feed (0 when empty) — i.e. the head of the thread. */
+export function latestSequence(messages: ServerMessage[]): number {
+	return messages.reduce((max, m) => (m.sequence > max ? m.sequence : max), 0);
+}
+
+/**
+ * How many messages the visitor hasn't seen: everything past the marker that the
+ * panel will actually RENDER as somebody else's message.
+ *
+ * The predicate deliberately mirrors MessageList's — badging a row the panel then
+ * doesn't show would send the visitor hunting for a message that isn't there.
+ *   - `user` rows are the visitor's own (including their replies that arrive by
+ *     inbound email), so they never count;
+ *   - empty content never renders, so it never counts;
+ *   - `assistant` (the bot), `admin` (the human operator) and `system` (the
+ *     escalation marker) all render as bubbles, so all three count.
+ */
+export function countUnread(
+	messages: ServerMessage[],
+	lastSeenSequence: number,
+): number {
+	return messages.filter(
+		(m) =>
+			m.sequence > lastSeenSequence && m.role !== "user" && Boolean(m.content),
+	).length;
+}
+
+/** Badge text: the exact count, capped at "9+". */
+export function badgeLabel(count: number): string {
+	return count > BADGE_MAX ? `${BADGE_MAX}+` : String(count);
+}
+
+/**
+ * Accessible name for the launcher. The count rides the button's label (and a
+ * polite live region in WidgetFrame) because the badge itself is decorative — a
+ * screen reader must not have to see a pill to learn a human replied.
+ */
+export function launcherLabel(open: boolean, unreadCount: number): string {
+	if (open) {
+		return "Close chat";
+	}
+	if (unreadCount > 0) {
+		return `Open chat, ${unreadCount} new ${
+			unreadCount === 1 ? "message" : "messages"
+		}`;
+	}
+	return "Open chat";
+}

--- a/packages/widget/src/useServerMessages.ts
+++ b/packages/widget/src/useServerMessages.ts
@@ -4,23 +4,39 @@ import { fetchMessages } from "./messages-sync";
 
 import type { ServerMessage } from "./messages-sync";
 
-const POLL_INTERVAL_MS = 2_500;
+/** Poll cadence while the panel is open and the visitor is watching. */
+export const POLL_INTERVAL_MS = 2_500;
 
 /**
- * Poll the persisted conversation feed while the widget is open, so admin
- * replies appear without a refresh. Failed polls keep the last good result.
+ * Poll the persisted conversation feed, so admin replies appear without a refresh.
+ * Failed polls keep the last good result.
+ *
+ * Both the gate and the cadence are the caller's call: the widget polls fast while
+ * the panel is open (the visitor is watching) and slowly in the background while it
+ * is closed on an escalated conversation (nobody is watching, but a human owes them
+ * a reply) — see unread.ts for that lifecycle and its cost.
  */
 export function useServerMessages(
 	apiUrl: string,
 	projectKey: string,
 	clientId: string,
 	enabled: boolean,
+	intervalMs: number = POLL_INTERVAL_MS,
 ): {
 	serverMessages: ServerMessage[];
 	conversationId: string | null;
 	csatRating: number | null;
 	escalatedAt: string | number | null;
 	archivedAt: string | number | null;
+	/**
+	 * Whose feed the fields above describe, or null before the first poll of the
+	 * current id lands. Everything here is cleared in a POST-COMMIT effect, so for
+	 * one render after `clientId` rotates the feed still describes the conversation
+	 * that was just left behind. A caller that persists anything derived from the
+	 * feed must check this against the clientId it is persisting under — comparing
+	 * two values from the same render closure is what makes the staleness visible.
+	 */
+	feedClientId: string | null;
 	refresh: () => void;
 } {
 	const [serverMessages, setServerMessages] = useState<ServerMessage[]>([]);
@@ -28,6 +44,7 @@ export function useServerMessages(
 	const [csatRating, setCsatRating] = useState<number | null>(null);
 	const [escalatedAt, setEscalatedAt] = useState<string | number | null>(null);
 	const [archivedAt, setArchivedAt] = useState<string | number | null>(null);
+	const [feedClientId, setFeedClientId] = useState<string | null>(null);
 	const abortRef = useRef<AbortController | null>(null);
 
 	// A different clientId is a different conversation ("start a new
@@ -39,6 +56,7 @@ export function useServerMessages(
 		setCsatRating(null);
 		setEscalatedAt(null);
 		setArchivedAt(null);
+		setFeedClientId(null);
 	}, [apiUrl, projectKey, clientId]);
 
 	const load = useCallback(async () => {
@@ -57,6 +75,10 @@ export function useServerMessages(
 			setCsatRating(feed.csatRating);
 			setEscalatedAt(feed.escalatedAt);
 			setArchivedAt(feed.archivedAt);
+			// Stamp whose feed this is (see the field's docs). `clientId` here is the
+			// one this load was issued for, not whatever is current by the time it
+			// resolves — a rotation aborts the in-flight request anyway.
+			setFeedClientId(clientId);
 		} catch {
 			// Transient poll failure — keep showing the last good feed.
 		}
@@ -66,13 +88,16 @@ export function useServerMessages(
 		if (!enabled || !clientId) {
 			return;
 		}
+		// A cadence change (panel opened/closed) re-runs this and polls once
+		// immediately — which is exactly right on close: it catches anything that
+		// landed in the last foreground window, so the badge starts out honest.
 		void load();
-		const timer = setInterval(() => void load(), POLL_INTERVAL_MS);
+		const timer = setInterval(() => void load(), intervalMs);
 		return () => {
 			clearInterval(timer);
 			abortRef.current?.abort();
 		};
-	}, [enabled, clientId, load]);
+	}, [enabled, clientId, intervalMs, load]);
 
 	const refresh = useCallback(() => {
 		void load();
@@ -84,6 +109,7 @@ export function useServerMessages(
 		csatRating,
 		escalatedAt,
 		archivedAt,
+		feedClientId,
 		refresh,
 	};
 }

--- a/packages/widget/src/widget.tsx
+++ b/packages/widget/src/widget.tsx
@@ -31,15 +31,36 @@ import { mergeMessages } from "./messages-sync";
 import { rateMessage, useMessageRatings } from "./rating";
 import { ShowcaseChat } from "./ShowcaseChat";
 import { useEffectiveTheme } from "./theme";
-import { useServerMessages } from "./useServerMessages";
+import {
+	BACKGROUND_POLL_INTERVAL_MS,
+	clearSnapshot,
+	countUnread,
+	latestSequence,
+	readSnapshot,
+	sameSnapshot,
+	shouldPollInBackground,
+	writeSnapshot,
+} from "./unread";
+import { POLL_INTERVAL_MS, useServerMessages } from "./useServerMessages";
 import { useWidgetConfig } from "./widget-config";
 
 import type { DisplayMessage } from "./components/MessageList";
 import type { Rating } from "./rating";
 import type { WidgetTheme } from "./theme";
+import type { ConversationSnapshot } from "./unread";
 
 /** How long the "Thanks!" screen shows before the conversation view returns. */
 const CSAT_THANKS_MS = 1200;
+
+/**
+ * How long after a send settles the post-stream refetch is retried once. The
+ * api persists the assistant row in a waitUntil after the stream closes, so the
+ * immediate refetch races that INSERT; one retry a beat later is what makes the
+ * unread badge reliable for a bot reply when the visitor closed the panel
+ * mid-answer on a non-escalated conversation (no poll runs there — these two
+ * requests are the only chance to see the row). Exported for the tests.
+ */
+export const POST_STREAM_REFRESH_RETRY_MS = 2_500;
 
 /**
  * "live" (default) talks to the real API: conversations are created and
@@ -183,6 +204,10 @@ function LiveWidget({
 		null,
 	);
 	const [clientId, setClientId] = useState("");
+	// Tab-local read state for the unread badge (sessionStorage, alongside the
+	// clientId). Null = nothing to badge and nothing to poll for: no conversation in
+	// this tab yet, or a rotated id (a fresh conversation inherits neither).
+	const [snapshot, setSnapshot] = useState<ConversationSnapshot | null>(null);
 	// End-of-conversation CSAT screen: "hidden" during chat, "prompt" when the
 	// visitor ends a conversation (resolve / start-a-new-one — NEVER on merely
 	// closing the panel), "thanks" briefly after a rating.
@@ -207,6 +232,13 @@ function LiveWidget({
 			setIdentified(true);
 		}
 	}, [projectKey]);
+
+	// Load this tab's read state once the client id resolves — and drop it when the
+	// id rotates ("start a new conversation"), since the stored snapshot belongs to
+	// the conversation that was just left behind.
+	useEffect(() => {
+		setSnapshot(clientId ? readSnapshot(projectKey, clientId) : null);
+	}, [projectKey, clientId]);
 
 	// Server decides whether the "Powered by" badge shows (plan-gated, tamper-
 	// proof) and supplies the project's privacy policy URL, admin-defined
@@ -246,6 +278,11 @@ function LiveWidget({
 	const loading = status === "streaming" || status === "submitted";
 	const sendFailed = status === "error" && error != null;
 
+	// Keep polling with the panel CLOSED, but only for an escalated, unresolved
+	// conversation that exists in this tab — the one case where somebody owes the
+	// visitor a reply they'd otherwise never see. Everything else (a fresh pageview
+	// above all) makes zero background requests. See unread.ts for the cost model.
+	const backgroundPoll = !open && shouldPollInBackground(snapshot);
 	// Poll the persisted feed while chatting so admin replies from the
 	// dashboard appear without a refresh.
 	const {
@@ -254,14 +291,99 @@ function LiveWidget({
 		csatRating,
 		escalatedAt: serverEscalatedAt,
 		archivedAt: serverArchivedAt,
+		feedClientId,
 		refresh,
-	} = useServerMessages(apiUrl, projectKey, clientId, open && !needsIdentity);
+	} = useServerMessages(
+		apiUrl,
+		projectKey,
+		clientId,
+		(open && !needsIdentity) || backgroundPoll,
+		open ? POLL_INTERVAL_MS : BACKGROUND_POLL_INTERVAL_MS,
+	);
 	// Escalated this session OR per the server feed (hydrates on reload so the
 	// "Talk to a human" CTA can't reappear and re-fire /v1/escalate).
 	const escalated = deriveEscalated(escalatedLocal, serverEscalatedAt);
 	// Resolved this session OR per the server feed (hydrates on reload like
 	// escalated, so the "Mark resolved" button stays hidden and the notice shows).
 	const resolved = deriveResolved(resolvedLocal, serverArchivedAt);
+
+	// ── Unread badge ──────────────────────────────────────────────────
+	// Whether the feed in hand actually describes the conversation we're holding.
+	// useServerMessages clears its state in its own POST-COMMIT effect, so for one
+	// render after the client id rotates ("start a new conversation") the feed still
+	// describes the conversation just left behind. Persisting a snapshot from it
+	// would staple the NEW id to the OLD conversation — and arm a background poll for
+	// a thread that no longer exists, on every pageview, for the life of the tab.
+	// Both values come from the same render, so they go stale together and the
+	// mismatch is visible.
+	const feedIsCurrent = feedClientId !== null && feedClientId === clientId;
+
+	// Keep the tab-local read state in step with the feed.
+	useEffect(() => {
+		if (!clientId || !feedIsCurrent) {
+			// No feed for THIS conversation yet. Leave the stored record alone — on a
+			// reload it's the only thing that knows to start polling at all.
+			return;
+		}
+		if (!conversationId) {
+			// The server says this visitor has no conversation: they never started one,
+			// or an operator deleted it from the inbox. Nothing to badge, nobody left to
+			// wait for — forget it, rather than polling a dead thread forever.
+			if (snapshot) {
+				clearSnapshot(projectKey);
+				setSnapshot(null);
+			}
+			// The session-local flags described the conversation that's now gone. Left
+			// set, escalatedLocal would be OR-ed into whatever conversation this tab
+			// starts NEXT (deriveEscalated), stamping it escalated and arming the
+			// background poll for a thread no human owes a reply on — for the life of
+			// the tab. resolvedLocal is the mirror image: it would stamp the successor
+			// resolved and silently disarm its badge. (No-ops when already false.)
+			setEscalatedLocal(false);
+			setResolvedLocal(false);
+			return;
+		}
+		const next: ConversationSnapshot = {
+			clientId,
+			conversationId,
+			escalated,
+			resolved,
+			// Open panel = the visitor is reading, so the marker rides the head of the
+			// thread; closed = it freezes, which is what makes the count mean anything.
+			// With no marker at all, nothing has been seen: that state is reached by
+			// sending a first message and closing the panel before the first poll
+			// lands, so the reply that follows arrived while the panel was shut — which
+			// is exactly what there is to badge. (Adopting the head here instead would
+			// silently mark it read.)
+			lastSeenSequence: open
+				? latestSequence(serverMessages)
+				: (snapshot?.lastSeenSequence ?? 0),
+		};
+		if (snapshot && sameSnapshot(snapshot, next)) {
+			return;
+		}
+		writeSnapshot(projectKey, next);
+		setSnapshot(next);
+	}, [
+		clientId,
+		projectKey,
+		feedIsCurrent,
+		conversationId,
+		open,
+		serverMessages,
+		escalated,
+		resolved,
+		snapshot,
+	]);
+
+	// What the launcher badges. Derived from the FEED against the stored marker —
+	// never from a stored count — so a reload with the panel closed recomputes it
+	// from what the server actually has, and no snapshot means nothing to compare
+	// (hence nothing to badge).
+	const unreadCount =
+		open || !snapshot
+			? 0
+			: countUnread(serverMessages, snapshot.lastSeenSequence);
 
 	// Per-message thumbs: optimistic, rolling back if the request fails.
 	const sendRating = useCallback(
@@ -282,13 +404,23 @@ function LiveWidget({
 	const { rate, effective } = useMessageRatings(sendRating);
 
 	// Refetch as soon as a send settles (stream finished or failed) so the
-	// just-persisted exchange replaces the local copy immediately.
+	// just-persisted exchange replaces the local copy immediately. One delayed
+	// retry backs it up: the api persists the assistant row in a waitUntil AFTER
+	// the stream closes, so the immediate refetch can be served before that row
+	// commits. With the panel open the next foreground poll would paper over the
+	// loss — but a visitor who closed the panel mid-answer on a NON-escalated
+	// conversation has no poll left, and the badge for the bot's reply hangs on
+	// whichever of these two requests sees the row.
 	const wasLoading = useRef(false);
 	useEffect(() => {
-		if (wasLoading.current && !loading) {
-			refresh();
-		}
+		const settled = wasLoading.current && !loading;
 		wasLoading.current = loading;
+		if (!settled) {
+			return;
+		}
+		refresh();
+		const retry = setTimeout(refresh, POST_STREAM_REFRESH_RETRY_MS);
+		return () => clearTimeout(retry);
 	}, [loading, refresh]);
 
 	// ── Quote-reply ───────────────────────────────────────────────────
@@ -538,6 +670,7 @@ function LiveWidget({
 			theme={resolvedTheme}
 			open={open}
 			onOpenChange={handleOpenChange}
+			unreadCount={unreadCount}
 			actions={
 				canStartNew ? (
 					<button

--- a/packages/widget/src/widget.unread.test.tsx
+++ b/packages/widget/src/widget.unread.test.tsx
@@ -1,0 +1,590 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Keep the live widget off the model — stub the chat transport/hook and the branding
+// probe. The message FEED is deliberately NOT stubbed: this file is about WHICH
+// requests the widget makes and WHEN, so it drives the real useServerMessages against
+// a fetch mock and counts the calls.
+//
+// The stubbed useChat keeps a REAL status state, so a test can drive the
+// submitted → streaming → ready transition that fires the widget's post-send refresh
+// (the one poll that reaches the server while the panel is already closed).
+const chat = vi.hoisted(() => ({
+	setStatus: null as ((status: string) => void) | null,
+}));
+
+vi.mock("ai", () => ({ DefaultChatTransport: class {} }));
+vi.mock("@ai-sdk/react", async () => {
+	const { useState } = await import("react");
+	return {
+		Chat: class {},
+		useChat: () => {
+			const [status, setStatus] = useState("ready");
+			chat.setStatus = setStatus;
+			return {
+				messages: [],
+				sendMessage: vi.fn(async () => {}),
+				status,
+				error: null,
+			};
+		},
+	};
+});
+vi.mock("./widget-config", () => ({
+	useWidgetConfig: () => ({
+		showBranding: false,
+		privacyPolicyUrl: null,
+		suggestedQuestions: [],
+	}),
+}));
+
+import { BACKGROUND_POLL_INTERVAL_MS } from "./unread";
+import { POLL_INTERVAL_MS } from "./useServerMessages";
+import { POST_STREAM_REFRESH_RETRY_MS, Widget } from "./widget";
+
+interface Row {
+	sequence: number;
+	role: string;
+	content: string;
+}
+
+/** The conversation the tab has been chatting in: visitor turn, bot turn, escalation. */
+const BASE_ROWS: Row[] = [
+	{ sequence: 1, role: "user", content: "my order never arrived" },
+	{ sequence: 2, role: "assistant", content: "let me check that for you" },
+	{
+		sequence: 3,
+		role: "system",
+		content: "Visitor requested a human operator",
+	},
+];
+
+const SNAPSHOT_KEY = "llmchat_unread_pk";
+
+/**
+ * The server's view. Keyed by client id, because that is exactly what the widget can
+ * get wrong: after "start a new conversation" the id rotates, and the server knows
+ * nothing about the new one — so a stale feed must not be mistaken for its feed.
+ */
+let conversations: Record<
+	string,
+	{ rows: Row[]; escalatedAt: string | null; archivedAt: string | null }
+>;
+let fetchMock: ReturnType<typeof vi.fn>;
+
+function pollsFor(clientId?: string): string[] {
+	return fetchMock.mock.calls
+		.map((c) => String(c[0]))
+		.filter(
+			(u) =>
+				u.includes("/v1/messages") &&
+				(clientId === undefined || u.includes(`clientId=${clientId}`)),
+		);
+}
+
+/**
+ * Seed the tab as if the visitor had already chatted here: a client id (as
+ * getOrCreateClientId would have minted) plus the read state the widget records while
+ * the panel is open. Re-mounting on top of this IS the reload case.
+ */
+function seedTab(over: Record<string, unknown> = {}) {
+	sessionStorage.setItem("llmchat_client_id", "c1");
+	sessionStorage.setItem(
+		SNAPSHOT_KEY,
+		JSON.stringify({
+			clientId: "c1",
+			conversationId: "conv1",
+			escalated: true,
+			resolved: false,
+			// The visitor last saw the thread through the escalation marker.
+			lastSeenSequence: 3,
+			...over,
+		}),
+	);
+}
+
+function storedSnapshot(): Record<string, unknown> | null {
+	const raw = sessionStorage.getItem(SNAPSHOT_KEY);
+	return raw ? (JSON.parse(raw) as Record<string, unknown>) : null;
+}
+
+/** Mount the real bubble-layout widget (launcher visible, panel closed). */
+function mount() {
+	return render(
+		<Widget
+			widgetMode="live"
+			projectKey="pk"
+			apiUrl="http://x"
+			brandColor="#4f46e5"
+		/>,
+	);
+}
+
+/**
+ * What the launcher's polite live region currently announces. Queried by class, not
+ * by role: the escalation notice inside the panel is a role="status" too.
+ */
+function announcement(container: HTMLElement): string {
+	return container.querySelector(".llmchat-sr-only")?.textContent ?? "";
+}
+
+/**
+ * The floating launcher itself. By class, not by name: once the panel is open the
+ * header carries its own "Close chat" button, so the accessible name is ambiguous.
+ */
+function toggleLauncher(container: HTMLElement) {
+	fireEvent.click(container.querySelector("button.llmchat-bubble")!);
+}
+
+/** Let effects, the poll, and its state update settle. */
+async function settle(ms = 0) {
+	await act(async () => {
+		await vi.advanceTimersByTimeAsync(ms);
+	});
+}
+
+beforeEach(() => {
+	sessionStorage.clear();
+	localStorage.clear();
+	vi.useFakeTimers();
+	conversations = {
+		c1: {
+			rows: BASE_ROWS,
+			escalatedAt: "2026-07-13T10:00:00.000Z",
+			archivedAt: null,
+		},
+	};
+	fetchMock = vi.fn(async (url: string) => {
+		const clientId = new URL(String(url)).searchParams.get("clientId") ?? "";
+		const conv = conversations[clientId];
+		return new Response(
+			JSON.stringify(
+				conv
+					? {
+							conversationId: `conv-${clientId}`,
+							csatRating: null,
+							escalatedAt: conv.escalatedAt,
+							archivedAt: conv.archivedAt,
+							messages: conv.rows.map((r) => ({
+								id: `m${r.sequence}`,
+								role: r.role,
+								content: r.content,
+								sequence: r.sequence,
+								createdAt: r.sequence,
+								rating: null,
+							})),
+						}
+					: // What the API really answers for a visitor with no conversation:
+						// 200 with a null conversation, not a 404.
+						{
+							conversationId: null,
+							csatRating: null,
+							escalatedAt: null,
+							archivedAt: null,
+							messages: [],
+						},
+			),
+		);
+	});
+	vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+	vi.useRealTimers();
+	vi.unstubAllGlobals();
+	vi.restoreAllMocks();
+});
+
+describe("unread badge — the operator replies while the panel is closed", () => {
+	it("badges the launcher when a human reply lands", async () => {
+		seedTab();
+		const { container } = mount();
+		await settle();
+		// Nothing new yet — the visitor has seen everything through the escalation.
+		expect(
+			screen.getByRole("button", { name: "Open chat" }),
+		).toBeInTheDocument();
+
+		// The operator replies from the dashboard inbox.
+		conversations.c1!.rows = [
+			...BASE_ROWS,
+			{ sequence: 4, role: "admin", content: "Hi — Luca here, looking now" },
+		];
+		await settle(BACKGROUND_POLL_INTERVAL_MS);
+
+		expect(screen.getByText("1")).toBeInTheDocument();
+		// …and it renders as the styled pill, not as loose text: this is the only
+		// place that binds the component's className to the stylesheet's selector
+		// (jsdom never applies the shadow CSS, so getByText alone can't).
+		expect(
+			container.querySelector("button.llmchat-bubble .llmchat-bubble-badge")
+				?.textContent,
+		).toBe("1");
+		// The count reaches a screen reader too, not just the eye.
+		expect(
+			screen.getByRole("button", { name: "Open chat, 1 new message" }),
+		).toBeInTheDocument();
+		expect(announcement(container)).toBe("1 new message in the support chat");
+	});
+
+	it("counts several replies and caps the display at 9+ (the true count stays in the label)", async () => {
+		seedTab();
+		mount();
+		await settle();
+		conversations.c1!.rows = [
+			...BASE_ROWS,
+			...Array.from({ length: 12 }, (_, i) => ({
+				sequence: 4 + i,
+				role: "admin",
+				content: `reply ${i}`,
+			})),
+		];
+		await settle(BACKGROUND_POLL_INTERVAL_MS);
+
+		expect(screen.getByText("9+")).toBeInTheDocument();
+		expect(
+			screen.getByRole("button", { name: "Open chat, 12 new messages" }),
+		).toBeInTheDocument();
+	});
+
+	it("clears the badge on open and remembers the thread as read", async () => {
+		seedTab();
+		const { container } = mount();
+		await settle();
+		conversations.c1!.rows = [
+			...BASE_ROWS,
+			{ sequence: 4, role: "admin", content: "Hi — Luca here, looking now" },
+		];
+		await settle(BACKGROUND_POLL_INTERVAL_MS);
+		expect(screen.getByText("1")).toBeInTheDocument();
+
+		fireEvent.click(screen.getByRole("button", { name: /open chat/i }));
+		await settle();
+
+		expect(screen.queryByText("1")).not.toBeInTheDocument();
+		// Gone from the accessible name and the live region too, not just the pixels.
+		expect(
+			screen.queryByRole("button", { name: /new message/i }),
+		).not.toBeInTheDocument();
+		expect(announcement(container)).toBe("");
+		// The reply is on screen, and the marker has moved to the head of the thread —
+		// so closing the panel again doesn't re-badge what was just read.
+		expect(screen.getByText(/Luca here/)).toBeInTheDocument();
+		expect(storedSnapshot()?.lastSeenSequence).toBe(4);
+	});
+
+	it("stores the read MARKER, never a count — a reload recomputes it from the feed", async () => {
+		seedTab();
+		mount();
+		await settle();
+		conversations.c1!.rows = [
+			...BASE_ROWS,
+			{ sequence: 4, role: "admin", content: "Hi — Luca here" },
+			{ sequence: 5, role: "admin", content: "…and it's on its way" },
+		];
+		await settle(BACKGROUND_POLL_INTERVAL_MS);
+		// Two unread replies, recomputed from a feed the stored record knows nothing
+		// about — the record still holds only where the visitor got to.
+		expect(screen.getByText("2")).toBeInTheDocument();
+		expect(storedSnapshot()).toEqual({
+			clientId: "c1",
+			conversationId: "conv-c1",
+			escalated: true,
+			resolved: false,
+			lastSeenSequence: 3,
+		});
+	});
+
+	it("never badges the visitor's own message (including a reply that arrives by email)", async () => {
+		seedTab();
+		mount();
+		await settle();
+		conversations.c1!.rows = [
+			...BASE_ROWS,
+			{ sequence: 4, role: "user", content: "any update? (sent by email)" },
+		];
+		await settle(BACKGROUND_POLL_INTERVAL_MS);
+
+		expect(
+			screen.getByRole("button", { name: "Open chat" }),
+		).toBeInTheDocument();
+	});
+
+	it("badges the BOT's reply when it lands after the visitor closed the panel mid-answer", async () => {
+		// The race that has no stored marker to lean on: a first-time visitor asks a
+		// question and shuts the panel before the first poll has even told the widget a
+		// conversation exists. The answer is persisted while they're away — and the
+		// post-send refresh is what brings it back. Marking it read here (by adopting
+		// the head of the feed) would lose the only message there was to badge.
+		sessionStorage.setItem("llmchat_client_id", "c1");
+		// No conversation exists yet — /v1/messages answers conversationId: null, so the
+		// widget has nothing to record a marker against.
+		delete conversations.c1;
+		const { container } = mount();
+		await settle();
+
+		toggleLauncher(container);
+		await settle();
+		await act(async () => {
+			chat.setStatus?.("streaming");
+		});
+		// Closed while the answer is still streaming — before any poll saw a conversation.
+		toggleLauncher(container);
+		await settle();
+		expect(storedSnapshot()).toBeNull();
+
+		// The exchange is now persisted; the stream settles and the widget refreshes —
+		// the one poll that reaches the server with the panel already shut.
+		conversations.c1 = {
+			rows: [
+				{ sequence: 1, role: "user", content: "do you ship to France?" },
+				{ sequence: 2, role: "assistant", content: "Yes — 3-5 working days." },
+			],
+			escalatedAt: null,
+			archivedAt: null,
+		};
+		await act(async () => {
+			chat.setStatus?.("ready");
+		});
+		await settle();
+
+		expect(
+			screen.getByRole("button", { name: "Open chat, 1 new message" }),
+		).toBeInTheDocument();
+		expect(storedSnapshot()?.lastSeenSequence).toBe(0);
+	});
+
+	it("still badges the bot's reply when persistence loses the race with the post-send refresh", async () => {
+		// Same close-mid-answer scenario, worst-case ordering: the api commits the
+		// assistant row in a waitUntil AFTER the stream closes, so the immediate
+		// post-send refresh can be served while the visitor's conversation doesn't
+		// exist yet. With the panel closed and nothing escalated there is no poll
+		// left — the one delayed retry is the only request that can still see the
+		// row, and without it the badge is lost for the life of the tab.
+		sessionStorage.setItem("llmchat_client_id", "c1");
+		delete conversations.c1;
+		const { container } = mount();
+		await settle();
+
+		toggleLauncher(container);
+		await settle();
+		await act(async () => {
+			chat.setStatus?.("streaming");
+		});
+		toggleLauncher(container);
+		await settle();
+
+		// The stream settles while the row is still uncommitted: the immediate
+		// refresh answers "no conversation" and no badge appears.
+		await act(async () => {
+			chat.setStatus?.("ready");
+		});
+		await settle();
+		expect(
+			screen.queryByRole("button", { name: /new message/i }),
+		).not.toBeInTheDocument();
+
+		// The waitUntil INSERT lands a beat later — before the delayed retry fires.
+		conversations.c1 = {
+			rows: [
+				{ sequence: 1, role: "user", content: "do you ship to France?" },
+				{ sequence: 2, role: "assistant", content: "Yes — 3-5 working days." },
+			],
+			escalatedAt: null,
+			archivedAt: null,
+		};
+		await settle(POST_STREAM_REFRESH_RETRY_MS);
+
+		expect(
+			screen.getByRole("button", { name: "Open chat, 1 new message" }),
+		).toBeInTheDocument();
+		expect(storedSnapshot()?.lastSeenSequence).toBe(0);
+	});
+});
+
+describe("unread badge — poll lifecycle", () => {
+	it("a fresh pageview that never chatted makes ZERO background requests", async () => {
+		// No seeded tab: the client id gets minted on mount, but no conversation exists.
+		mount();
+		await settle();
+		await settle(BACKGROUND_POLL_INTERVAL_MS * 10);
+
+		expect(pollsFor()).toHaveLength(0);
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it("a conversation that was never escalated is not worth a background request", async () => {
+		// The visitor chatted with the bot and closed the panel. Nobody owes them a
+		// reply out of band, so the widget goes quiet.
+		seedTab({ escalated: false });
+		mount();
+		await settle();
+		await settle(BACKGROUND_POLL_INTERVAL_MS * 10);
+
+		expect(pollsFor()).toHaveLength(0);
+	});
+
+	it("polls on the background cadence — not the foreground one — while closed and escalated", async () => {
+		seedTab();
+		mount();
+		await settle();
+		expect(pollsFor()).toHaveLength(1); // immediately, on mount
+
+		// The 2.5s foreground cadence must NOT be in play: an idle closed launcher
+		// would otherwise burn 1440 requests/hour of the project's shared cap.
+		await settle(BACKGROUND_POLL_INTERVAL_MS - 1);
+		expect(pollsFor()).toHaveLength(1);
+
+		await settle(1);
+		expect(pollsFor()).toHaveLength(2);
+	});
+
+	it("stops polling for good once the conversation is resolved — but keeps the badge", async () => {
+		seedTab();
+		mount();
+		await settle();
+
+		// The operator answers, then closes the conversation in the inbox.
+		conversations.c1!.rows = [
+			...BASE_ROWS,
+			{ sequence: 4, role: "admin", content: "Refund is on its way — Luca" },
+		];
+		await settle(BACKGROUND_POLL_INTERVAL_MS);
+		expect(screen.getByText("1")).toBeInTheDocument();
+
+		conversations.c1!.archivedAt = "2026-07-13T10:30:00.000Z";
+		await settle(BACKGROUND_POLL_INTERVAL_MS);
+		const callsAtResolve = pollsFor().length;
+
+		await settle(BACKGROUND_POLL_INTERVAL_MS * 10);
+		expect(pollsFor()).toHaveLength(callsAtResolve);
+		expect(storedSnapshot()?.resolved).toBe(true);
+		// Stopping the poll must not swallow the reply the visitor still hasn't read.
+		expect(screen.getByText("1")).toBeInTheDocument();
+	});
+
+	it("stops polling when the conversation is deleted from the inbox", async () => {
+		// An operator hard-deletes the conversation. /v1/messages then answers 200 with
+		// conversationId: null — there is nothing left to badge and nobody left to wait
+		// for, so a widget that kept its escalated record would poll a dead thread for
+		// the life of the tab.
+		seedTab();
+		mount();
+		await settle();
+		expect(pollsFor()).toHaveLength(1);
+
+		delete conversations.c1;
+		await settle(BACKGROUND_POLL_INTERVAL_MS);
+		const callsAtDelete = pollsFor().length;
+
+		await settle(BACKGROUND_POLL_INTERVAL_MS * 10);
+		expect(pollsFor()).toHaveLength(callsAtDelete);
+		expect(storedSnapshot()).toBeNull();
+	});
+
+	it("starting a new conversation does not inherit the old one's poll", async () => {
+		// "Start a new conversation" rotates the client id. The feed in hand still
+		// describes the conversation being left behind for one render — adopting it
+		// would staple the NEW id to the OLD conversation and poll forever, on every
+		// pageview, for a thread the server has never heard of.
+		seedTab();
+		const { container } = mount();
+		await settle();
+		toggleLauncher(container);
+		await settle();
+
+		fireEvent.click(
+			screen.getByRole("button", { name: /start a new conversation/i }),
+		);
+		await settle();
+		// Ending a conversation is the CSAT moment; skipping it completes the reset.
+		fireEvent.click(screen.getByRole("button", { name: /^skip$/i }));
+		await settle();
+
+		const rotated = sessionStorage.getItem("llmchat_client_id");
+		expect(rotated).not.toBe("c1");
+		// The record must never name the old conversation under the new id.
+		expect(storedSnapshot()?.clientId).not.toBe(rotated);
+
+		// Close the fresh (empty, unescalated) conversation: nothing to wait for.
+		toggleLauncher(container);
+		await settle();
+		const before = pollsFor(rotated!).length;
+		await settle(BACKGROUND_POLL_INTERVAL_MS * 5);
+		expect(pollsFor(rotated!)).toHaveLength(before);
+		expect(screen.queryByRole("button", { name: /new message/i })).toBeNull();
+	});
+
+	it("clicking escalate does not leak onto the NEXT conversation after the operator deletes this one", async () => {
+		// escalatedLocal is a session flag, not server state. If the operator
+		// deletes the escalated conversation and the visitor keeps chatting under
+		// the same client id, the successor must not inherit "escalated" — that
+		// would arm the background poll for a conversation no human owes a reply
+		// on, at 144 req/h for the life of the tab.
+		sessionStorage.setItem("llmchat_client_id", "c1");
+		conversations.c1 = {
+			rows: [
+				{ sequence: 1, role: "user", content: "can I talk to a human?" },
+				{ sequence: 2, role: "assistant", content: "Let me get someone." },
+			],
+			escalatedAt: null,
+			archivedAt: null,
+		};
+		const { container } = mount();
+		await settle();
+		toggleLauncher(container);
+		await settle();
+
+		// The explicit ask reveals the CTA; clicking it sets the session flag.
+		fireEvent.click(screen.getByRole("button", { name: /talk to a human/i }));
+		await settle();
+		expect(storedSnapshot()?.escalated).toBe(true);
+
+		// Operator hard-deletes the conversation; the next open-panel poll sees it.
+		delete conversations.c1;
+		await settle(POLL_INTERVAL_MS);
+		expect(storedSnapshot()).toBeNull();
+
+		// The visitor starts over in the same tab: a NEW conversation under the
+		// same client id, never escalated.
+		conversations.c1 = {
+			rows: [{ sequence: 1, role: "user", content: "hello again" }],
+			escalatedAt: null,
+			archivedAt: null,
+		};
+		await settle(POLL_INTERVAL_MS);
+		expect(storedSnapshot()?.escalated).toBe(false);
+
+		// Closed and not escalated: the tab goes quiet.
+		toggleLauncher(container);
+		await settle();
+		const before = pollsFor().length;
+		await settle(BACKGROUND_POLL_INTERVAL_MS * 10);
+		expect(pollsFor()).toHaveLength(before);
+	});
+
+	it("a pageview AFTER starting a new conversation still makes ZERO background requests", async () => {
+		// The rotation bug's real cost: a cross-wired record is persisted, so it
+		// re-arms the poll on every subsequent navigation of the customer's site.
+		seedTab();
+		const view = mount();
+		await settle();
+		toggleLauncher(view.container);
+		await settle();
+		fireEvent.click(
+			screen.getByRole("button", { name: /start a new conversation/i }),
+		);
+		await settle();
+		fireEvent.click(screen.getByRole("button", { name: /^skip$/i }));
+		await settle();
+		view.unmount();
+
+		// Fresh pageview, same tab (sessionStorage survives the navigation).
+		fetchMock.mockClear();
+		mount();
+		await settle();
+		await settle(BACKGROUND_POLL_INTERVAL_MS * 5);
+
+		expect(pollsFor()).toHaveLength(0);
+	});
+});


### PR DESCRIPTION
## Problem

After an escalation, a visitor who closed the widget never notices the human's reply — the handoff promise silently fails at the last step.

## Feature

A count badge on the launcher bubble when non-user messages (admin / assistant / system) arrive while the panel is **closed**. Clears on open. Display caps at **9+** (the true count stays in the accessible label). White pill with brand-color text and ring — inverted brand chrome, deliberately not notification-red.

Pure client change: no schema, no API changes — `/v1/messages` already returns everything needed.

## Poll lifecycle

- **Panel open:** unchanged (2.5s foreground poll).
- **Panel closed:** background-poll `/v1/messages` **only if** a conversation exists in this tab **and** it is escalated **and** unresolved. Stops for good on resolve, on client-id rotation ("start a new conversation"), and when the conversation is deleted server-side. A fresh pageview with no chat makes **zero** background requests.
- **Interval: 25s** against the 4000/hr per-(project, IP) cap: 144 req/h = 3.6% of the cap per closed tab vs the open panel's 1440 req/h (36%). The cap is shared per IP (office NAT is the binding constraint): ~27 closed-escalated tabs fit before the bucket is even theoretically at risk. 20s buys 5s of badge latency nobody perceives for real headroom; the event being waited on is a human typing, measured in minutes. Full arithmetic in `unread.ts`.
- **State:** a tab-local read **marker** (never a count) in sessionStorage (`llmchat_unread_<projectKey>`, alongside the existing clientId storage). A reload with the panel closed recomputes the badge from a fresh poll, not stale storage.

No title flashing, no sounds, no browser notifications (v1).

## Hardening from adversarial review (all with mutation-verified regression tests)

- **Rotation cross-wire:** the feed is stamped with the clientId it describes (`feedClientId`), so the one-render-stale feed after "start a new conversation" can never persist a snapshot stapling the new id to the old conversation.
- **First-reply marker:** a missing marker means *nothing seen* (`?? 0`), so the reply that lands after closing mid-first-answer still badges.
- **Deletion:** a deleted conversation clears the snapshot **and** resets the session-local escalated/resolved flags — the tab's next conversation can't inherit them (or their background poll).
- **Post-stream race:** the api commits the assistant row in a `waitUntil` after the stream closes; the post-send refetch retries once (2.5s) so a bot reply still badges when the visitor closed mid-answer on a non-escalated conversation.
- **A11y:** launcher `aria-label` carries the count, a polite sr-only live region announces replies, the pill itself is `aria-hidden`; `direction: ltr` pins "9+" against RTL bidi reordering; existing reduced-motion rule covers the badge animation; px-only sizing (Shopify Dawn rem trap).

## Tests

33 new tests (18 unit in `unread.test.ts`, 15 integration in `widget.unread.test.tsx` driving the real polling hook against a client-id-keyed fetch mock): badge appears on operator reply while closed, clears on open, zero polling on fresh pageview, polling stops after resolve/rotation/deletion, background-vs-foreground cadence, 25s budget pin, badge-class/stylesheet contract.

## Verification

Live e2e on the seeded local stack (real browser, real API, operator replies injected into the dev DB), **11/11 checks, run twice** (before and after the hardening): zero requests on fresh pageview (60s), 2 polls/55s closed+escalated, badge 1 → 3 → 9+, reload recomputes 9+, open clears + stays cleared, resolve stops polling (0 requests/60s), reload-after-resolve silent. Gates: test 7/7 packages, lint 0 errors, build 8/8.

Known accepted limitation: a pale/white-ish `brandColor` renders the badge low-contrast — the same brands already degrade the entire pre-existing launcher chrome; flagged for a separate `brandColor`-validation follow-up rather than special-casing the badge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018pJJgDHCnnNeEqEAApxFcQ