### PR TITLE
fix(marketing): Railway deploy URL for the Laravel template

### DIFF
--- a/apps/marketing/src/app/templates/page.tsx
+++ b/apps/marketing/src/app/templates/page.tsx
@@ -79,7 +79,7 @@ const TEMPLATES: Template[] = [
 			"A Blade landing page rendering the embed with the official Composer package's helper.",
 		tags: ["Laravel 12", "Blade", "Composer package"],
 		deployHref:
-			"https://railway.com/template/clanker-laravel?referralCode=clankersupport",
+			"https://railway.com/deploy/clanker-laravel?referralCode=clankersupport",
 		deployLabel: "Deploy on Railway",
 	},
 	{

--- a/docs/templates-sdks-launch.md
+++ b/docs/templates-sdks-launch.md
@@ -13,7 +13,7 @@ Built 2026-07-17 on `feat/templates-sdks` (+ two new local repos). Everything be
 | Templates monorepo | `~/dev/clankersupport-templates` — `templates/{nextjs-shadcn,tanstack-start,react-router,laravel,fastapi}` | 3 JS templates `pnpm build` green; FastAPI 2/2 pytest + live boot; Laravel static review (3 fixes) |
 | Marketing `/templates` page | `apps/marketing/src/app/templates/` (this branch) | 42/42 tests, prettier, oxlint |
 
-Deploy buttons follow the llmgateway pattern exactly: Vercel `new/clone` with `repository-url=theopenco/clankersupport-templates` + `root-directory=templates/<name>` + env pre-fill (`NEXT_PUBLIC_CLANKER_KEY` / `VITE_CLANKER_KEY` / `CLANKER_PROJECT_KEY`); Laravel uses a Railway template button (`railway.com/template/clanker-laravel`).
+Deploy buttons follow the llmgateway pattern exactly: Vercel `new/clone` with `repository-url=theopenco/clankersupport-templates` + `root-directory=templates/<name>` + env pre-fill (`NEXT_PUBLIC_CLANKER_KEY` / `VITE_CLANKER_KEY` / `CLANKER_PROJECT_KEY`); Laravel uses a Railway template button (`railway.com/deploy/clanker-laravel`).
 
 ## Publish order (dependencies flow downward)
 


### PR DESCRIPTION
Railway's published-template path is `railway.com/deploy/<slug>`, not `/template/<slug>` (verified: /deploy/clanker-laravel → 200, /template/... → 404, no redirect). Updates the /templates page card + the launch runbook. Same fix already pushed to the templates repo READMEs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018pJJgDHCnnNeEqEAApxFcQ