### PR TITLE
fix(marketing): /templates polish — fill dead grid cells + docs CLI wording

### DIFF
--- a/apps/docs/content/sdks/templates.mdx
+++ b/apps/docs/content/sdks/templates.mdx
@@ -50,7 +50,7 @@ Prefer to start locally? Scaffold any of the templates with the CLI:
 npm create clanker-support@latest
 ```
 
-It prompts for a template and stack, copies it into a new directory, and leaves you a `.env` to drop your project key into. From there it's a normal app — install dependencies and run the dev server as you would for that stack.
+It prompts for a template, a project directory, and (optionally) your project key — supply the key and it writes a ready-to-run `.env`; skip it and set the template's env var yourself. From there it's a normal app — install dependencies and run the dev server as you would for that stack.
 
 ## After you deploy
 

--- a/apps/marketing/src/app/templates/page.tsx
+++ b/apps/marketing/src/app/templates/page.tsx
@@ -154,9 +154,16 @@ const SDKS: SdkEntry[] = [
 	{
 		name: "Plain <script> embed",
 		registry: "Docs",
-		href: DOCS_URL,
+		href: `${DOCS_URL}/integrations/widget`,
 		blurb:
 			"One script tag before </body> — works on any site, no build step, no framework.",
+	},
+	{
+		name: "All SDK docs",
+		registry: "Docs",
+		href: `${DOCS_URL}/sdks`,
+		blurb:
+			"Install guides for every package and template — pick your stack and go.",
 	},
 ];
 
@@ -321,6 +328,50 @@ export default function TemplatesPage() {
 								</div>
 							</article>
 						))}
+
+						{/* With five templates in a two-column grid, the sixth cell
+						    would render as a dead hole on desktop — make it the
+						    request-a-template slot instead. */}
+						<article className="group relative flex flex-col justify-center overflow-hidden bg-paper p-8 transition-colors hover:bg-paper-card sm:p-10">
+							<span
+								aria-hidden
+								className="pointer-events-none absolute -right-3 -top-6 select-none font-display text-[7rem] font-bold leading-none text-rule/60 transition-colors group-hover:text-accent/10"
+							>
+								06
+							</span>
+							<div className="relative">
+								<span className="font-mono text-xs font-medium text-faint transition-colors group-hover:text-accent-soft">
+									06
+								</span>
+								<h2 className="font-display mt-4 text-2xl font-semibold tracking-tight-display text-ink">
+									Your stack next
+								</h2>
+								<p className="mt-2 max-w-md text-sm leading-relaxed text-muted">
+									Astro, SvelteKit, Django, Rails — new starters land by
+									request. Tell us what you deploy and we&apos;ll wire the
+									support agent in the official way for that stack.
+								</p>
+								<div className="mt-8 flex flex-wrap items-center gap-x-5 gap-y-3">
+									<a
+										href="https://github.com/theopenco/clankersupport-templates/issues/new?title=Template%20request%3A%20"
+										target="_blank"
+										rel="noopener noreferrer"
+										className="rounded-full border border-rule px-5 py-2.5 font-mono text-[0.68rem] uppercase tracking-[0.14em] text-ink-soft transition-colors hover:border-accent/40 hover:text-ink"
+									>
+										Request a template
+									</a>
+									<a
+										href={REPO_TREE}
+										target="_blank"
+										rel="noopener noreferrer"
+										className="inline-flex items-center gap-2 font-mono text-[0.68rem] uppercase tracking-[0.14em] text-muted transition-colors hover:text-ink"
+									>
+										Browse the repo
+										<span aria-hidden>↗</span>
+									</a>
+								</div>
+							</div>
+						</article>
 					</div>
 				</section>
 


### PR DESCRIPTION
## Why

A full audit of the /templates page (3-agent panel: every live link + asset status-checked, every card claim fact-checked against the templates repo, the docs twin cross-checked) found the page **factually clean** — all 5 Vercel clone URLs, the Railway link, GitHub tree links, preview PNGs, registry pages, scaffold command, tags, and env vars verified correct against the live site and `theopenco/clankersupport-templates`.

What it did surface were two desktop-only visual defects and one docs inaccuracy:

1. **Dead grid cells**: 5 template cards in a 2-column grid left the 6th cell as a large empty hole next to FastAPI; the SDKs grid (7 entries) had the same at cell 8.
2. **Docs mischaracterized the CLI**: `sdks/templates.mdx` said the scaffolder "leaves you a `.env` to drop your project key into" — it actually prompts for an optional key and writes an already-filled `.env` only when one is supplied.

## What

- New **"06 · Your stack next"** tile fills the templates grid: request-a-template (prefilled GitHub issue) + browse-the-repo links, matching the ghost-numeral card language.
- New **"All SDK docs"** entry fills the SDKs grid, linking the docs `/sdks` overview (previously unlinked from this page); the plain-script entry now points at `/integrations/widget` instead of the docs home (both live-checked 200).
- Reworded the docs CLI paragraph to match the published `create-clanker-support@1.0.0` behavior.

Verified: local build screenshots confirm both grids are now full (mobile unaffected — single column). `pnpm --filter @llmchat/marketing build` (66/66 pages prerendered), `pnpm --filter @llmchat/docs build`, marketing tests 42/42, lint, format all green.

Audit false-alarm worth recording: `packages/widget-rsc/package.json` says 1.0.0 while npm has 1.1.0 — intentional; `publish.yml` runs semantic-release on merge and stamps the version at publish time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018pJJgDHCnnNeEqEAApxFcQ