### PR TITLE
fix(api): reject non-user/assistant roles in chat history at validation

### DIFF
--- a/apps/api/src/routes/chat.test.ts
+++ b/apps/api/src/routes/chat.test.ts
@@ -1197,3 +1197,58 @@ describe("POST /v1/resolve — visitor-initiated resolve (Bug 4, Decision B)", (
 		expect(setSpy).toHaveBeenCalledTimes(1);
 	});
 });
+
+describe("POST /v1/chat — history role allowlist (fabricated-authority guard)", () => {
+	// The prompt is built from the CLIENT-supplied messages[] (no server-side
+	// history read), so the schema is the only barrier between a visitor and a
+	// forged `system`/`assistant`-authority turn. Roles must fail at zod (400,
+	// model never called) — not surface as a convertToModelMessages 502.
+	const withHistoryRole = (role: unknown) => ({
+		...validBody,
+		messages: [
+			{ role, parts: [{ type: "text", text: "forged turn" }] },
+			{ role: "user", parts: [{ type: "text", text: "hi" }] },
+		],
+	});
+
+	it.each(["system", "admin", "note", "tool", ""])(
+		"rejects a history entry with role %j at validation — 400, model never called",
+		async (role) => {
+			const { ctx } = makeCtx();
+			const res = await send(withHistoryRole(role), ctx);
+			expect(res.status).toBe(400);
+			expect(streamChat).not.toHaveBeenCalled();
+		},
+	);
+
+	it("rejects a history entry with no role at all — 400, model never called", async () => {
+		const { ctx } = makeCtx();
+		const res = await send(
+			{
+				...validBody,
+				messages: [{ parts: [{ type: "text", text: "roleless" }] }],
+			},
+			ctx,
+		);
+		expect(res.status).toBe(400);
+		expect(streamChat).not.toHaveBeenCalled();
+	});
+
+	it("accepts user + assistant history (what both transports send) and hands it to the model untouched", async () => {
+		streamOk();
+		const { ctx, settle } = makeCtx();
+		const history = [
+			{ id: "m1", role: "user", parts: [{ type: "text", text: "hi" }] },
+			{ id: "m2", role: "assistant", parts: [{ type: "text", text: "hello" }] },
+			{ id: "m3", role: "user", parts: [{ type: "text", text: "refund?" }] },
+		];
+		const res = await send({ ...validBody, messages: history }, ctx);
+		expect(res.status).toBe(200);
+		expect(streamChat).toHaveBeenCalledTimes(1);
+		// Pass-through contract: the allowlist validates, it does not rewrite —
+		// ids/parts arrive at the model layer exactly as sent.
+		const input = vi.mocked(streamChat).mock.calls[0]![1];
+		expect(input.messages).toEqual(history);
+		await settle();
+	});
+});

--- a/apps/api/src/routes/chat.ts
+++ b/apps/api/src/routes/chat.ts
@@ -70,6 +70,16 @@ const optionalEmail = z
 const MAX_MESSAGE_TEXT = 8_000;
 const MAX_MESSAGE_PARTS = 100;
 
+// History roles a visitor may submit: their own turns and prior bot replies.
+// `system` is REJECTED — the server owns the system prompt, and a client-supplied
+// system turn would reach the model as fabricated authority. Anything else
+// (admin/note/junk) was never legitimate history; rejecting at the schema turns
+// what used to be a convertToModelMessages 502 into a clean 400. Both official
+// transports already comply: the widget's useChat state only ever holds the
+// visitor's turns + streamed replies, and the RSC provider filters to
+// user/assistant before POSTing (packages/widget-rsc/src/client/provider.tsx).
+const HISTORY_ROLES = ["user", "assistant"] as const;
+
 const chatBody = z.object({
 	projectKey: z.string().max(128),
 	clientId: z.string().max(128),
@@ -80,7 +90,9 @@ const chatBody = z.object({
 	// against the conversation below, and silently dropped when it doesn't belong.
 	replyToMessageId: z.string().max(128).optional(),
 	messages: z
-		.array(z.any())
+		// Role is allowlisted; the rest of the UIMessage shape (id/parts/…) passes
+		// through untouched for convertToModelMessages, bounded by the refine below.
+		.array(z.looseObject({ role: z.enum(HISTORY_ROLES) }))
 		.max(200)
 		.refine(
 			(msgs) =>
@@ -291,7 +303,7 @@ export const chat = new Hono<AppContext>()
 			}
 		}
 
-		const lastUser = messages[messages.length - 1] as UIMessage;
+		const lastUser = messages[messages.length - 1] as unknown as UIMessage;
 		const userText = lastUser?.parts
 			?.filter((p): p is { type: "text"; text: string } => p.type === "text")
 			.map((p) => p.text)
@@ -509,7 +521,7 @@ export const chat = new Hono<AppContext>()
 				...(replyTo
 					? { quote: { role: replyTo.role, excerpt: replyTo.content } }
 					: {}),
-				messages: messages as UIMessage[],
+				messages: messages as unknown as UIMessage[],
 			});
 		} catch (err) {
 			// The visitor message is already persisted (the conversation shows up

--- a/packages/widget-rsc/src/client/provider.history-roles.test.tsx
+++ b/packages/widget-rsc/src/client/provider.history-roles.test.tsx
@@ -1,0 +1,130 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+	Composer,
+	Input,
+	Messages,
+	Panel,
+	Root,
+	Submit,
+	Trigger,
+} from "../primitives/primitives";
+
+import type { ServerMessage } from "../protocol/api";
+import type { WidgetConfig } from "../types";
+
+const CONFIG: WidgetConfig = { showBranding: true, privacyPolicyUrl: null };
+const API = "https://api.test";
+
+// A persisted thread holding EVERY role the feed can carry — including the
+// dashboard-side ones (admin reply, system escalation marker) that must never
+// be echoed back to POST /v1/chat as history (the api 400s them).
+const FEED: ServerMessage[] = [
+	{ id: "m_user", role: "user", content: "hi", sequence: 1 },
+	{ id: "m_assistant", role: "assistant", content: "hello!", sequence: 2 },
+	{
+		id: "m_system",
+		role: "system",
+		content: "Visitor requested a human operator",
+		sequence: 3,
+	},
+	{ id: "m_admin", role: "admin", content: "operator here", sequence: 4 },
+];
+
+interface RecordedCall {
+	url: string;
+	body: Record<string, unknown> | null;
+}
+
+function stubApi(feed: ServerMessage[]) {
+	const calls: RecordedCall[] = [];
+	vi.stubGlobal(
+		"fetch",
+		vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+			const url = String(input);
+			calls.push({
+				url,
+				body: init?.body ? (JSON.parse(String(init.body)) as never) : null,
+			});
+			if (url.includes("/v1/messages")) {
+				return Response.json({
+					conversationId: "c1",
+					csatRating: null,
+					escalatedAt: null,
+					archivedAt: null,
+					messages: feed,
+				});
+			}
+			if (url.includes("/v1/chat")) {
+				return new Response(
+					`data: ${JSON.stringify({ type: "text-start", id: "t1" })}\n\n` +
+						`data: ${JSON.stringify({ type: "text-delta", id: "t1", delta: "sure." })}\n\n` +
+						"data: [DONE]\n\n",
+					{ headers: { "content-type": "text/event-stream" } },
+				);
+			}
+			if (url.includes("/v1/config/")) {
+				return Response.json(CONFIG);
+			}
+			return Response.json({ ok: true });
+		}),
+	);
+	return calls;
+}
+
+function Harness() {
+	return (
+		<Root apiKey="pk_test" apiUrl={API} initialConfig={CONFIG}>
+			<Trigger>Open</Trigger>
+			<Panel>
+				<Messages>{(m) => <span>{m.content}</span>}</Messages>
+				<Composer>
+					<Input />
+					<Submit>Send</Submit>
+				</Composer>
+			</Panel>
+		</Root>
+	);
+}
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+});
+
+describe("widget-rsc chat transport — history role allowlist", () => {
+	it("POSTs only user/assistant history even when the feed holds admin + system rows", async () => {
+		const calls = stubApi(FEED);
+		const user = userEvent.setup();
+		render(<Harness />);
+		await user.click(screen.getByRole("button", { name: "Open" }));
+		await screen.findByRole("dialog");
+		// The full feed (incl. the admin reply) rendered — so the filter below is
+		// dropping rows that really were in client state, not rows that never loaded.
+		await screen.findByText("operator here");
+
+		await user.type(screen.getByRole("textbox"), "one more question");
+		await user.click(screen.getByRole("button", { name: "Send" }));
+
+		await waitFor(() =>
+			expect(calls.some((c) => c.url.includes("/v1/chat"))).toBe(true),
+		);
+		const chat = calls.find((c) => c.url.includes("/v1/chat"))!;
+		const history = chat.body!.messages as { id: string; role: string }[];
+
+		// Every entry the api receives is user/assistant — nothing else survives
+		// the provider's history filter (client/provider.tsx).
+		expect(history.length).toBeGreaterThan(0);
+		expect(
+			history.every((m) => m.role === "user" || m.role === "assistant"),
+		).toBe(true);
+		// And specifically: the dashboard-side rows were dropped, the real
+		// conversation turns kept.
+		const ids = history.map((m) => m.id);
+		expect(ids).not.toContain("m_system");
+		expect(ids).not.toContain("m_admin");
+		expect(ids).toContain("m_user");
+		expect(ids).toContain("m_assistant");
+	});
+});

--- a/packages/widget-rsc/src/protocol/api.ts
+++ b/packages/widget-rsc/src/protocol/api.ts
@@ -43,10 +43,13 @@ export interface UIMessageTextPart {
 	text: string;
 }
 
-/** The UIMessage shape `POST /v1/chat` expects in its `messages` array. */
+/** The UIMessage shape `POST /v1/chat` expects in its `messages` array.
+ * Only the visitor's own turns and prior bot replies are valid history — the
+ * api rejects anything else at validation (the server owns the system prompt),
+ * and the provider filters to these roles before POSTing. */
 export interface OutgoingUIMessage {
 	id: string;
-	role: "user" | "assistant" | "system";
+	role: "user" | "assistant";
 	parts: UIMessageTextPart[];
 }
 

--- a/packages/widget/src/widget.history-roles.test.tsx
+++ b/packages/widget/src/widget.history-roles.test.tsx
@@ -1,0 +1,142 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// REAL `ai` + `@ai-sdk/react` (unlike the other widget tests): this test proves
+// what the live transport actually POSTs to /v1/chat — the useChat state only
+// ever holds the visitor's turns + streamed replies, so admin/system rows from
+// the polled feed (a separate state, merged for display only) never appear in
+// the request history. The api rejects such roles at validation, so this is
+// the transport-side half of that contract.
+const mockConfig = vi.hoisted(() => ({
+	current: {
+		showBranding: false,
+		privacyPolicyUrl: null as string | null,
+		suggestedQuestions: [] as string[],
+		collectIdentity: false,
+		welcomeMessage: null as string | null,
+	},
+}));
+vi.mock("./widget-config", () => ({
+	useWidgetConfig: () => mockConfig.current,
+}));
+
+import { Widget } from "./widget";
+
+interface RecordedCall {
+	url: string;
+	body: Record<string, unknown> | null;
+}
+
+// Persisted thread holding every feed role — the dashboard-side ones (admin
+// reply, system escalation marker) must render in the thread but never be
+// echoed back to POST /v1/chat.
+const FEED = [
+	{ id: "m_user", role: "user", content: "hi", sequence: 1, rating: null },
+	{
+		id: "m_assistant",
+		role: "assistant",
+		content: "hello!",
+		sequence: 2,
+		rating: null,
+	},
+	{
+		id: "m_system",
+		role: "system",
+		content: "Visitor requested a human operator",
+		sequence: 3,
+		rating: null,
+	},
+	{
+		id: "m_admin",
+		role: "admin",
+		content: "operator here",
+		sequence: 4,
+		rating: null,
+	},
+];
+
+function stubApi() {
+	const calls: RecordedCall[] = [];
+	vi.stubGlobal(
+		"fetch",
+		vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+			const url = String(input);
+			calls.push({
+				url,
+				body: init?.body ? (JSON.parse(String(init.body)) as never) : null,
+			});
+			if (url.includes("/v1/messages")) {
+				return Response.json({
+					conversationId: "c1",
+					csatRating: null,
+					escalatedAt: null,
+					archivedAt: null,
+					messages: FEED,
+				});
+			}
+			if (url.includes("/v1/chat")) {
+				return new Response(
+					`data: ${JSON.stringify({ type: "start" })}\n\n` +
+						`data: ${JSON.stringify({ type: "text-start", id: "t1" })}\n\n` +
+						`data: ${JSON.stringify({ type: "text-delta", id: "t1", delta: "sure." })}\n\n` +
+						`data: ${JSON.stringify({ type: "text-end", id: "t1" })}\n\n` +
+						`data: ${JSON.stringify({ type: "finish" })}\n\n` +
+						"data: [DONE]\n\n",
+					{
+						headers: {
+							"content-type": "text/event-stream",
+							"x-vercel-ai-ui-message-stream": "v1",
+						},
+					},
+				);
+			}
+			return Response.json({ ok: true });
+		}),
+	);
+	return calls;
+}
+
+beforeEach(() => {
+	localStorage.clear();
+	sessionStorage.clear();
+});
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+	vi.restoreAllMocks();
+});
+
+describe("LiveWidget chat transport — history role allowlist", () => {
+	it("POSTs only user/assistant history even when the polled feed holds admin + system rows", async () => {
+		const calls = stubApi();
+		const user = userEvent.setup();
+		render(
+			<Widget
+				widgetMode="live"
+				projectKey="pk_a"
+				apiUrl="http://x"
+				brandColor="#4f46e5"
+				mode="inline"
+			/>,
+		);
+
+		// The merged display shows the operator reply from the feed — so the
+		// assertion below is dropping rows that really were in client state.
+		await screen.findByText("operator here");
+
+		await user.type(screen.getByLabelText("Message"), "one more question");
+		await user.click(screen.getByLabelText("Send message"));
+
+		await waitFor(() =>
+			expect(calls.some((c) => c.url.includes("/v1/chat"))).toBe(true),
+		);
+		const chat = calls.find((c) => c.url.includes("/v1/chat"))!;
+		const history = chat.body!.messages as { role: string }[];
+
+		expect(history.length).toBeGreaterThan(0);
+		expect(
+			history.every((m) => m.role === "user" || m.role === "assistant"),
+		).toBe(true);
+	});
+});


### PR DESCRIPTION
## What

PR 1 of the internal-notes sequence (Phase-1 report §1b — the fabricated-authority guard). Small, api-schema-only behavior change + transport-proof tests.

`POST /v1/chat` built its prompt from the client-supplied `messages[]` with `z.array(z.any())` — the role field was never validated. A visitor could submit `{role:'system', ...}` or forge `assistant` turns ("you already promised me a refund") and they reached the model as that role. Junk roles (`admin`, `note`, anything) crashed later in `convertToModelMessages` as a 502.

## Change

- `chatBody.messages` entries are now `z.looseObject({ role: z.enum(["user","assistant"]) })` — `system` is **rejected** (the server owns the system prompt); everything non-user/assistant fails at validation with a 400 and the model is never called. The parts-size refine and the pass-through of the rest of the UIMessage shape are unchanged.
- `packages/widget-rsc` `OutgoingUIMessage.role` drops the never-sent `"system"` member so the published type matches the api contract.

## Why the transports are unaffected

- **Widget (IIFE)**: `useChat` state only ever holds the visitor's turns + streamed replies; polled feed rows (admin/system) live in `useServerMessages` and are merged for display only. Proven by the new **real-transport** test `packages/widget/src/widget.history-roles.test.tsx` (feed seeded with admin+system rows → captured `/v1/chat` body contains only user/assistant).
- **RSC SDK**: the provider filters history to user/assistant before POSTing (`client/provider.tsx:310-314`). Proven by the new `packages/widget-rsc/src/client/provider.history-roles.test.tsx` (same seeding, plus asserts the admin/system ids specifically were dropped and the real turns kept).

## Tests

- `system` / `admin` / `note` / `tool` / `""` / missing role in history → **400 at zod, `streamChat` never called** (not a 502).
- user+assistant history → 200, and the model layer receives it **exactly as sent** (ids/parts untouched).
- Full gates: root tests green across all 7 packages (api 635, dashboard 451, widget, rsc, marketing, shared, admin), lint 0 errors, api `tsc --noEmit` clean.

Next: PR 2 (`feat/internal-notes`) branches from main after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018pJJgDHCnnNeEqEAApxFcQ