### PR TITLE
fix: internal-notes audit punch-list — scroll follow, pinned guarantees, allowlist consolidation

### DIFF
--- a/apps/api/src/lib/llm.quote.test.ts
+++ b/apps/api/src/lib/llm.quote.test.ts
@@ -1,6 +1,7 @@
+import { isQuotableRole } from "@llmchat/shared";
 import { describe, expect, it } from "vitest";
 
-import { isQuotableRole, renderQuoteAnnotation, withQuote } from "./llm";
+import { renderQuoteAnnotation, withQuote } from "./llm";
 
 import type { UIMessage } from "ai";
 

--- a/apps/api/src/lib/llm.ts
+++ b/apps/api/src/lib/llm.ts
@@ -8,6 +8,8 @@ import {
 	type UIMessage,
 } from "ai";
 
+import type { QuotableRole } from "@llmchat/shared";
+
 import type { Env } from "@/env";
 
 export interface LlmCallInput {
@@ -39,20 +41,6 @@ export interface LlmCallInput {
 	 */
 	quote?: { role: QuotableRole; excerpt: string };
 	messages: UIMessage[];
-}
-
-/**
- * The message roles a visitor may quote — an ALLOWLIST, not a denylist. `system`
- * is excluded on purpose: those rows are internal markers ("Visitor requested a
- * human operator") that the widget never displays, so re-surfacing one into the
- * prompt would be a net-new injection/leak channel rather than a reply to
- * something the visitor actually saw.
- */
-export const QUOTABLE_ROLES = ["user", "assistant", "admin"] as const;
-export type QuotableRole = (typeof QUOTABLE_ROLES)[number];
-
-export function isQuotableRole(role: string): role is QuotableRole {
-	return (QUOTABLE_ROLES as readonly string[]).includes(role);
 }
 
 // Cap aggregate source content to keep system prompts bounded. ~80k chars

--- a/apps/api/src/routes/chat.quote-reply.test.ts
+++ b/apps/api/src/routes/chat.quote-reply.test.ts
@@ -15,8 +15,9 @@ vi.mock("@/lib/kv", () => ({
 	shouldSendHolding: vi.fn(async () => true),
 }));
 vi.mock("@/lib/llm", async (orig) => ({
-	// isQuotableRole is the real allowlist — mocking it would let a `system` row
-	// through and quietly void the test that proves it can't.
+	// isQuotableRole (the real allowlist) lives in @llmchat/shared, which this
+	// file never mocks — so a `system` row can't slip through a stubbed guard
+	// and quietly void the test that proves it can't.
 	...(await orig<typeof import("@/lib/llm")>()),
 	streamChat: vi.fn(),
 	summarizeForVisitor: vi.fn(async () => null),

--- a/apps/api/src/routes/chat.ts
+++ b/apps/api/src/routes/chat.ts
@@ -20,12 +20,7 @@ import {
 	reserveOnce,
 	shouldSendHolding,
 } from "@/lib/kv";
-import {
-	isQuotableRole,
-	streamChat,
-	summarizeForVisitor,
-	type QuotableRole,
-} from "@/lib/llm";
+import { streamChat, summarizeForVisitor } from "@/lib/llm";
 import {
 	confirmReturnVerification,
 	isReturnVerified,
@@ -50,11 +45,14 @@ import {
 	ANALYTICS_EVENTS,
 	DEFAULT_MODEL,
 	effectiveModel,
+	HISTORY_ROLES,
 	isModelAllowed,
 	isPaidPlan,
+	isQuotableRole,
 	isRecapRole,
 	isVisitorVisibleRole,
 	planEntitlements,
+	type QuotableRole,
 } from "@llmchat/shared";
 
 import type { AppContext } from "@/env";
@@ -72,16 +70,6 @@ const optionalEmail = z
 const MAX_MESSAGE_TEXT = 8_000;
 const MAX_MESSAGE_PARTS = 100;
 
-// History roles a visitor may submit: their own turns and prior bot replies.
-// `system` is REJECTED — the server owns the system prompt, and a client-supplied
-// system turn would reach the model as fabricated authority. Anything else
-// (admin/note/junk) was never legitimate history; rejecting at the schema turns
-// what used to be a convertToModelMessages 502 into a clean 400. Both official
-// transports already comply: the widget's useChat state only ever holds the
-// visitor's turns + streamed replies, and the RSC provider filters to
-// user/assistant before POSTing (packages/widget-rsc/src/client/provider.tsx).
-const HISTORY_ROLES = ["user", "assistant"] as const;
-
 const chatBody = z.object({
 	projectKey: z.string().max(128),
 	clientId: z.string().max(128),
@@ -92,7 +80,8 @@ const chatBody = z.object({
 	// against the conversation below, and silently dropped when it doesn't belong.
 	replyToMessageId: z.string().max(128).optional(),
 	messages: z
-		// Role is allowlisted; the rest of the UIMessage shape (id/parts/…) passes
+		// Role is allowlisted (HISTORY_ROLES, @llmchat/shared — system/admin/note
+		// rejected as a 400); the rest of the UIMessage shape (id/parts/…) passes
 		// through untouched for convertToModelMessages, bounded by the refine below.
 		.array(z.looseObject({ role: z.enum(HISTORY_ROLES) }))
 		.max(200)

--- a/apps/api/src/routes/conversations.ts
+++ b/apps/api/src/routes/conversations.ts
@@ -579,6 +579,8 @@ export const conversations = new Hono<AppContext>()
 	// write notes — triage annotation is the agent role's job.
 	.post(
 		"/projects/:projectId/conversations/:id/notes",
+		// Intentionally redundant with requireWorkspace today (agent = lowest
+		// rank) — defense in depth if workspace admission ever widens.
 		requireRole("agent"),
 		zValidator(
 			"json",

--- a/apps/api/src/routes/internal-notes.e2e.test.ts
+++ b/apps/api/src/routes/internal-notes.e2e.test.ts
@@ -75,6 +75,7 @@ import { planEntitlements } from "@llmchat/shared";
 import { maybeSummarize } from "@/lib/conversation-summary";
 import { db } from "@/lib/db";
 import { sendEmail } from "@/lib/email";
+import { captureEvent, captureInBackground } from "@/lib/posthog";
 import { sendEscalationSlack } from "@/lib/slack";
 import {
 	streamChat,
@@ -207,7 +208,11 @@ async function seed(sqlite: DatabaseSync) {
 			projectId: pA,
 			clientId: "visitor-1",
 			name: "Vic Visitor",
-			messageCount: 6,
+			// Deliberately AHEAD of MAX(sequence) (6, below) — the shape a thread
+			// takes after a future row deletion (#146). The gap makes the sequence
+			// assertions discriminate the messageCount+1 protocol from a
+			// MAX(sequence)+1 reimplementation, which this fixture would catch.
+			messageCount: 8,
 		},
 	]);
 	await sdb.insert(message).values([
@@ -321,19 +326,33 @@ describe("notes endpoint — POST /api/projects/:pid/conversations/:id/notes", (
 			ENV,
 		);
 
-	it("agent-role member can write; 201; sequence + messageCount bump; NO email", async () => {
+	it("agent-role member can write; 201; sequence + messageCount bump; NO email, analytics, or emailMessageId", async () => {
 		const res = await post({ "x-test-user": u2, "x-workspace-id": wsA });
 		expect(res.status).toBe(201);
 		const body = (await res.json()) as {
-			message: { role: string; sequence: number; authorUserId: string };
+			message: {
+				id: string;
+				role: string;
+				sequence: number;
+				authorUserId: string;
+			};
 		};
 		expect(body.message.role).toBe("note");
-		expect(body.message.sequence).toBe(7);
+		// messageCount(8)+1 — NOT MAX(sequence)(6)+1, which the fixture's gap
+		// would expose as 7.
+		expect(body.message.sequence).toBe(9);
 		expect(body.message.authorUserId).toBe(u2);
 		const conv = sqlite
 			.prepare("SELECT message_count FROM conversation WHERE id = ?")
 			.get(c1) as { message_count: number };
-		expect(conv.message_count).toBe(7);
+		expect(conv.message_count).toBe(9);
+		// The created row carries NO email_message_id: a stamped RFC-5322 id
+		// would let inbound-email threading (In-Reply-To matching) resolve a
+		// reply against a note — the exact hazard the handler comment warns about.
+		const row = sqlite
+			.prepare("SELECT email_message_id AS emid FROM message WHERE id = ?")
+			.get(body.message.id) as { emid: string | null };
+		expect(row.emid).toBeNull();
 		// The exclusion from email is structural: with a visitor email on file, a
 		// note write must still never touch the email lib.
 		sqlite
@@ -343,6 +362,10 @@ describe("notes endpoint — POST /api/projects/:pid/conversations/:id/notes", (
 		expect(res2.status).toBe(201);
 		expect(sendEmail).not.toHaveBeenCalled();
 		expect(sendEscalationSlack).not.toHaveBeenCalled();
+		// No server-side analytics on the notes path either — the only note_added
+		// event is the dashboard's client-side one (which carries no payload).
+		expect(captureEvent).not.toHaveBeenCalled();
+		expect(captureInBackground).not.toHaveBeenCalled();
 	});
 
 	it("unauthenticated → 401; foreign tenant → 404; non-member → 403", async () => {
@@ -473,7 +496,7 @@ describe("rating a note fails closed", () => {
 
 describe("M3 — inbox triage summary never ingests a note", () => {
 	it("the transcript handed to the summarizer lacks the note, keeps the conversation", async () => {
-		await maybeSummarize(ENV as never, { id: c1, messageCount: 6 });
+		await maybeSummarize(ENV as never, { id: c1, messageCount: 8 });
 		expect(summarizeConversation).toHaveBeenCalledTimes(1);
 		const transcript = vi.mocked(summarizeConversation).mock.calls[0]![1];
 		expect(transcript).not.toContain(NOTE_TOKEN);

--- a/apps/dashboard/src/app/inbox/_components/MessageThread.test.tsx
+++ b/apps/dashboard/src/app/inbox/_components/MessageThread.test.tsx
@@ -2,7 +2,10 @@ import { act, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { MessageThread } from "./MessageThread";
-import { appendOptimisticReply } from "./optimistic-updaters";
+import {
+	appendOptimisticNote,
+	appendOptimisticReply,
+} from "./optimistic-updaters";
 
 import type { Conversation, Message } from "./types";
 
@@ -306,6 +309,32 @@ describe("MessageThread auto-scroll (useStickToBottom)", () => {
 
 		rerender(<MessageThread messages={next.messages} />);
 		// Role "admin" => stick-to-bottom treats it as the agent's own send.
+		expect(s.top).toBe(1000);
+	});
+
+	it("follows the agent's own note (built by appendOptimisticNote) even when scrolled up", () => {
+		const base = [
+			msg({ content: "hi", sequence: 1 }),
+			msg({ role: "assistant", content: "hello", sequence: 2 }),
+		];
+		const { el, rerender } = renderThread(base);
+		const s = mockScroll(el, { scrollHeight: 1000, clientHeight: 400 });
+		s.setTop(0); // scrolled up reading history
+
+		// The exact array the inbox's optimistic note writes into the thread cache.
+		const next = appendOptimisticNote(
+			{ conversation: { id: "c1" } as Conversation, messages: base },
+			{
+				tempId: "temp-n1",
+				content: "VIP customer — comp the order",
+				createdAt: "2026-07-23T05:00:00.000Z",
+				authorName: "Omar Owner",
+			},
+		) as { messages: Message[] };
+
+		rerender(<MessageThread messages={next.messages} />);
+		// Role "note" => own-send too: adding a note follows to the bottom
+		// exactly like sending a reply.
 		expect(s.top).toBe(1000);
 	});
 

--- a/apps/dashboard/src/app/inbox/_components/MessageThread.tsx
+++ b/apps/dashboard/src/app/inbox/_components/MessageThread.tsx
@@ -266,9 +266,13 @@ export function MessageThread({
 			// leaves it unchanged, so paging in history never reads as new content
 			// and never yanks to the bottom.
 			contentKey: messages.at(-1)?.id ?? messages.length,
-			// The agent's own sends are role "admin"; following those is expected.
-			// Inbound visitor/bot messages instead obey the near-bottom rule.
-			sendKey: messages.reduce((id, m) => (m.role === "admin" ? m.id : id), ""),
+			// The agent's own sends — replies (role "admin") and internal notes
+			// (role "note") — are followed to the bottom; inbound visitor/bot
+			// messages instead obey the near-bottom rule.
+			sendKey: messages.reduce(
+				(id, m) => (m.role === "admin" || m.role === "note" ? m.id : id),
+				"",
+			),
 		});
 
 	// Scroll anchoring for prepended history: when the FIRST message changes (an

--- a/apps/dashboard/src/app/inbox/_components/optimistic-updaters.ts
+++ b/apps/dashboard/src/app/inbox/_components/optimistic-updaters.ts
@@ -37,8 +37,9 @@ export function appendOptimisticReply(
 /**
  * Same contract as appendOptimisticReply, for an internal note: the amber card
  * appears the instant the operator hits "Add note", stamped with their own name
- * (the reconciled server row carries the joined authorName). Role "note" also
- * gets the agent's-own-send stick-to-bottom treatment.
+ * (the reconciled server row carries the joined authorName). Like "admin",
+ * role "note" is one of the own-send roles in MessageThread's sendKey, so the
+ * thread follows your note to the bottom even when you'd scrolled up.
  */
 export function appendOptimisticNote(
 	prev: unknown,

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -391,9 +391,10 @@ export const message = sqliteTable(
 			.references(() => conversation.id, { onDelete: "cascade" }),
 		// "note" = operator-internal annotation: rendered only in the dashboard
 		// thread, excluded from every visitor/model/email surface via the role
-		// ALLOWLISTS in @llmchat/shared (VISITOR_VISIBLE_ROLES / RECAP_ROLES) and
-		// lib/llm.ts (QUOTABLE_ROLES). TS-only enum — the column is plain text in
-		// SQL (no CHECK), so widening it needs no migration.
+		// ALLOWLISTS in @llmchat/shared (VISITOR_VISIBLE_ROLES / RECAP_ROLES /
+		// HISTORY_ROLES / QUOTABLE_ROLES — all four side by side there). TS-only
+		// enum — the column is plain text in SQL (no CHECK), so widening it needs
+		// no migration.
 		role: text({
 			enum: ["user", "assistant", "admin", "system", "note"],
 		}).notNull(),

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -40,6 +40,15 @@ export {
 	type TierEntitlements,
 } from "./billing-tiers";
 
+// ─── Message-role allowlists ────────────────────────────────────────────────
+// ALL FOUR role allowlists live side by side, on purpose: a new message role
+// gets judged against every boundary in one place, and stays invisible on all
+// of them until it is deliberately added. Each guards a different edge:
+//   VISITOR_VISIBLE_ROLES — what may LEAVE the operator dashboard
+//   RECAP_ROLES           — what the visitor-facing escalation recap summarizes
+//   HISTORY_ROLES         — what a visitor may SUBMIT as /v1/chat history
+//   QUOTABLE_ROLES        — what a visitor may quote-reply
+
 /** Roles allowed to leave the operator dashboard, incl. email. Everything not
  * listed (e.g. the operator-internal "note") must never reach a visitor
  * surface: the widget feed (/v1/messages), the escalation notification email's
@@ -64,6 +73,28 @@ export const RECAP_ROLES = ["user", "assistant", "admin"] as const;
 export type RecapRole = (typeof RECAP_ROLES)[number];
 export function isRecapRole(role: string): role is RecapRole {
 	return (RECAP_ROLES as readonly string[]).includes(role);
+}
+
+/** History roles a visitor may SUBMIT to /v1/chat: their own turns and prior
+ * bot replies — the inbound counterpart of the outbound lists above. `system`
+ * is REJECTED — the server owns the system prompt, and a client-supplied
+ * system turn would reach the model as fabricated authority. Anything else
+ * (admin/note/junk) was never legitimate history; rejecting at the schema
+ * turns what used to be a convertToModelMessages 502 into a clean 400. Both
+ * official transports already comply: the widget's useChat state only ever
+ * holds the visitor's turns + streamed replies, and the RSC provider filters
+ * to user/assistant before POSTing (packages/widget-rsc/src/client/provider.tsx). */
+export const HISTORY_ROLES = ["user", "assistant"] as const;
+
+/** The message roles a visitor may quote-reply — an ALLOWLIST, not a denylist.
+ * `system` is excluded on purpose: those rows are internal markers ("Visitor
+ * requested a human operator") that the widget never displays, so re-surfacing
+ * one into the prompt would be a net-new injection/leak channel rather than a
+ * reply to something the visitor actually saw. */
+export const QUOTABLE_ROLES = ["user", "assistant", "admin"] as const;
+export type QuotableRole = (typeof QUOTABLE_ROLES)[number];
+export function isQuotableRole(role: string): role is QuotableRole {
+	return (QUOTABLE_ROLES as readonly string[]).includes(role);
 }
 
 // `system` rows (the escalation marker) are part of the served feed, so the


### PR DESCRIPTION
Post-merge-audit punch-list for the internal-notes feature (#157/#159). Four atomic commits, one per item; item 1 (D10) required no change.

## 1. D10 — note_added payload
**Verdict: already clean.** `track(ANALYTICS_EVENTS.noteAdded)` at `page.tsx:536` passes **no properties at all** (`track` forwards `props` = undefined to `posthog.capture`). No content, no preview, no ids — nothing to reduce, so per the conditional, no change and no new test.

## 2. Stick-to-bottom for your own note
`MessageThread.tsx` sendKey now treats role `"note"` as an own-send alongside `"admin"` — adding a note follows to the bottom even when scrolled up reading history. The `appendOptimisticNote` comment that falsely claimed this already worked now describes the real mechanism. New scroll test mirrors the optimistic-reply case.

## 3. Pinned guarantees (internal-notes.e2e.test.ts)
- PostHog mock asserted **not called** server-side on POST /notes (the only note_added event is the dashboard's client-side, payload-free one).
- Created note row asserted `email_message_id IS NULL` — the inbound-threading hazard the handler comment warns about.
- Fixture reshaped: `messageCount` (8) deliberately disagrees with `MAX(sequence)` (6), so the sequence assertions discriminate `messageCount+1` from a `MAX+1` reimplementation (#146 groundwork).

## 4. Allowlist consolidation
`HISTORY_ROLES` (was `routes/chat.ts`) and `QUOTABLE_ROLES` + `isQuotableRole` (was `lib/llm.ts`) moved into `@llmchat/shared` beside `VISITOR_VISIBLE_ROLES`/`RECAP_ROLES` — four constants, one file, with a family header cross-referencing the four boundaries. Pure relocation, zero behavior change; greps confirm single definitions remain and no consumer still imports the old locations. Stale location comments in `schema.ts` and `chat.quote-reply.test.ts` refreshed.

## 5. requireRole("agent")
Kept, with the comment: intentionally redundant with requireWorkspace today (agent = lowest rank) — defense in depth if workspace admission ever widens.

## Verification
Gates: api 648/648, dashboard 458/458 (+1 new scroll test), shared 38/38, lint rc=0, `tsc --noEmit` clean.

Mutation-tested every new assertion (mutant applied → test run → revert):

| Mutant | Result |
|---|---|
| sendKey reverted to admin-only | scroll test FAILS ✓ |
| nextSeq → `MAX(sequence)+1` | `expected 7 to be 9` ✓ |
| `emailMessageId` stamped on note insert | `expected 'mutant-note@example.com' to be null` ✓ |
| server-side `captureEvent` added | `expected "spy" to not be called… called 2 times` ✓ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018pJJgDHCnnNeEqEAApxFcQ
