### PR TITLE
fix(api): 0024 belt dedupe + unique sequence index (#146 PR-C, the closer)

### DIFF
--- a/apps/api/migrations/0024_sequence_unique.sql
+++ b/apps/api/migrations/0024_sequence_unique.sql
@@ -1,0 +1,24 @@
+DROP TABLE IF EXISTS _seq_backfill_0024;
+--> statement-breakpoint
+CREATE TABLE _seq_backfill_0024 AS
+	SELECT id AS mid,
+		ROW_NUMBER() OVER (PARTITION BY conversation_id
+			ORDER BY sequence, created_at, id) AS new_seq
+	FROM message
+	WHERE conversation_id IN (
+		SELECT conversation_id FROM message
+		GROUP BY conversation_id, sequence HAVING COUNT(*) > 1);
+--> statement-breakpoint
+UPDATE message
+SET sequence = (SELECT new_seq FROM _seq_backfill_0024 WHERE mid = message.id)
+WHERE id IN (SELECT mid FROM _seq_backfill_0024);
+--> statement-breakpoint
+DROP TABLE _seq_backfill_0024;
+--> statement-breakpoint
+UPDATE conversation
+SET message_count = (SELECT COUNT(*) FROM message m WHERE m.conversation_id = conversation.id)
+WHERE message_count <> (SELECT COUNT(*) FROM message m WHERE m.conversation_id = conversation.id);
+--> statement-breakpoint
+DROP INDEX IF EXISTS message_conv_seq;
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS message_conv_seq_uidx ON message (conversation_id, sequence);

--- a/apps/api/src/migration-0024-sequence-unique.test.ts
+++ b/apps/api/src/migration-0024-sequence-unique.test.ts
@@ -1,0 +1,158 @@
+// Contract test for migrations/0024_sequence_unique.sql (#146 PR-C, the
+// closer): the belt-dedupe (same staging-table form 0023 proved, catching any
+// duplicate minted in the 0023→code-switch deploy window) followed by the
+// UNIQUE (conversation_id, sequence) index that makes the sequence race
+// physically impossible. CREATE UNIQUE INDEX cannot succeed while a duplicate
+// exists — so the 0024 deploy succeeding IS the proof that prod holds zero
+// duplicate pairs (recorded on the PR in lieu of a console Q1 run).
+
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+
+import { beforeEach, describe, expect, it } from "vitest";
+
+const MIGRATIONS_DIR = join(process.cwd(), "migrations");
+const FILE_0024 = "0024_sequence_unique.sql";
+
+function migrationSql(file: string): string {
+	return readFileSync(join(MIGRATIONS_DIR, file), "utf8")
+		.split("--> statement-breakpoint")
+		.join("\n");
+}
+
+/** Everything before 0024 — the schema the deploy window ran on (0023 applied,
+ * old plain index still in place, no uniqueness yet). */
+function applyMigrationsBefore0024(sqlite: DatabaseSync) {
+	sqlite.exec("PRAGMA foreign_keys=OFF;");
+	for (const f of readdirSync(MIGRATIONS_DIR)
+		.filter((x) => x.endsWith(".sql"))
+		.sort()) {
+		if (f >= "0024") continue;
+		sqlite.exec(migrationSql(f));
+	}
+}
+
+// Window fixture: cw holds a duplicate pair minted BETWEEN 0023 and the
+// code-switch deploy (old precompute racing) with the classic drifted count;
+// cok is healthy and must survive untouched.
+function seed(sqlite: DatabaseSync) {
+	sqlite.exec("PRAGMA foreign_keys=OFF;");
+	sqlite.exec(`
+INSERT INTO conversation (id, project_id, client_id, message_count)
+VALUES ('cw', 'p', 'v1', 2), ('cok', 'p', 'v2', 2);
+INSERT INTO message (id, conversation_id, role, content, sequence, created_at)
+VALUES
+	('w1', 'cw', 'user', 'q', 1, 100),
+	('w2', 'cw', 'admin', 'r', 2, 105),
+	('w3', 'cw', 'assistant', 'a', 2, 110),
+	('k1', 'cok', 'user', 'q', 1, 100),
+	('k2', 'cok', 'assistant', 'a', 2, 110);
+`);
+}
+
+function indexNames(sqlite: DatabaseSync): string[] {
+	return (
+		sqlite
+			.prepare(
+				`SELECT name FROM sqlite_master
+				 WHERE type = 'index' AND tbl_name = 'message' AND name NOT LIKE 'sqlite_%'
+				 ORDER BY name`,
+			)
+			.all() as { name: string }[]
+	).map((r) => r.name);
+}
+
+let sqlite: DatabaseSync;
+
+beforeEach(() => {
+	sqlite = new DatabaseSync(":memory:");
+	applyMigrationsBefore0024(sqlite);
+	seed(sqlite);
+});
+
+describe("0024 — belt dedupe, then the unique index", () => {
+	it("clears window-minted duplicates, trues counts, swaps the index", () => {
+		expect(indexNames(sqlite)).toContain("message_conv_seq"); // the old plain index
+		sqlite.exec(migrationSql(FILE_0024));
+		const cw = sqlite
+			.prepare(
+				"SELECT role, sequence FROM message WHERE conversation_id = 'cw' ORDER BY sequence",
+			)
+			.all() as { role: string; sequence: number }[];
+		expect(cw.map((r) => `${r.role}=${r.sequence}`)).toEqual([
+			"user=1",
+			"admin=2",
+			"assistant=3",
+		]);
+		const counts = sqlite
+			.prepare("SELECT id, message_count AS mc FROM conversation ORDER BY id")
+			.all() as { id: string; mc: number }[];
+		expect(counts).toEqual([
+			{ id: "cok", mc: 2 },
+			{ id: "cw", mc: 3 },
+		]);
+		const names = indexNames(sqlite);
+		expect(names).toContain("message_conv_seq_uidx");
+		expect(names).not.toContain("message_conv_seq");
+	});
+
+	it("a direct duplicate insert now throws loudly — the race is physically impossible", () => {
+		sqlite.exec(migrationSql(FILE_0024));
+		expect(() =>
+			sqlite.exec(
+				`INSERT INTO message (id, conversation_id, role, content, sequence, created_at)
+				 VALUES ('dup', 'cok', 'note', 'x', 2, 999)`,
+			),
+		).toThrow(/UNIQUE constraint failed/i);
+		// The atomic-subquery allocation (what insertMessage emits) still works
+		// under the index — the next free slot, never a collision.
+		sqlite.exec(
+			`INSERT INTO message (id, conversation_id, role, content, sequence, created_at)
+			 VALUES ('ok', 'cok', 'note', 'x',
+				(SELECT COALESCE(MAX(sequence), 0) + 1 FROM message WHERE conversation_id = 'cok'), 999)`,
+		);
+		expect(
+			(
+				sqlite
+					.prepare("SELECT sequence FROM message WHERE id = 'ok'")
+					.get() as { sequence: number }
+			).sequence,
+		).toBe(3);
+	});
+
+	it("is re-run safe and no-ops on a clean database (fresh deploys / self-hosters)", () => {
+		sqlite.exec(migrationSql(FILE_0024));
+		sqlite.exec(migrationSql(FILE_0024)); // IF EXISTS / IF NOT EXISTS guards
+		expect(indexNames(sqlite)).toContain("message_conv_seq_uidx");
+		const clean = new DatabaseSync(":memory:");
+		clean.exec("PRAGMA foreign_keys=OFF;");
+		for (const f of readdirSync(MIGRATIONS_DIR)
+			.filter((x) => x.endsWith(".sql"))
+			.sort()) {
+			clean.exec(migrationSql(f)); // the FULL chain, 0000 → 0024
+		}
+		expect(indexNames(clean)).toContain("message_conv_seq_uidx");
+		expect(
+			(
+				clean.prepare("SELECT COUNT(*) AS n FROM message").get() as {
+					n: number;
+				}
+			).n,
+		).toBe(0);
+	});
+
+	it("FAILS LOUDLY (deploy-visible) if duplicates exist when the index is created", () => {
+		// cw still holds its duplicate pair (the belt has NOT run in this test
+		// path) — creating the unique index over live duplicates must abort the
+		// migration, never quietly skip enforcement. In prod this state is
+		// unreachable (the belt runs first in the same file, and no old writer
+		// exists once PR-B serves), but if it ever happened the deploy fails
+		// visibly and the idempotent file simply re-runs.
+		expect(() =>
+			sqlite.exec(
+				"CREATE UNIQUE INDEX probe_uidx ON message (conversation_id, sequence);",
+			),
+		).toThrow(/UNIQUE constraint failed/i);
+	});
+});


### PR DESCRIPTION
#146 PR-C of 3 — the closer. `0024_sequence_unique.sql`: the belt-dedupe (byte-identical to 0023's proven block, staging table renamed `_seq_backfill_0024`), the `message_count` true-up, then `DROP INDEX message_conv_seq` and `CREATE UNIQUE INDEX message_conv_seq_uidx ON message (conversation_id, sequence)`.

## Why this closes #146

- The belt catches any duplicate minted in the window between 0023's backfill and PR-B's code switch (no old writer has existed since #162 deployed, so in practice it should find nothing).
- `CREATE UNIQUE INDEX` **cannot succeed while a duplicate pair exists** — so this deploy succeeding is the machine-checked proof that **Q1 = 0** in prod, recorded here in lieu of a console run (per the amended verification plan). Any future regression trips the index loudly (500 + `insertMessage`'s logged retry), never a silent order wobble.
- The old plain `message_conv_seq` index is replaced by the unique one (same columns — query plans keep their index).

One deliberate detail vs the Phase-1 report's literal block: `CREATE UNIQUE INDEX IF NOT EXISTS` (matching the proven scratch), so the idempotent file is re-run safe end to end.

## Contract test (`migration-0024-sequence-unique.test.ts`, 4 tests)

Real migrations 0000→0023 + a deploy-window fixture (one conversation with a freshly-minted duplicate pair + drifted count, one healthy):

1. Belt clears the window duplicates gapless 1..N, trues counts, swaps the index (old gone, unique present).
2. A direct duplicate insert **throws loudly**; the atomic-subquery allocation (what `insertMessage` emits) still allocates the next free slot under the index.
3. Re-run safe (IF EXISTS / IF NOT EXISTS guards) and full-chain 0000→0024 clean-DB no-op (fresh deploys / self-hosters).
4. The loud-failure property itself: creating the unique index over live duplicates aborts — enforcement can never be quietly skipped.

## Verification

api **665/665** — the unique index is now active in every e2e database (each suite applies all migrations), so the whole existing #146 test fleet runs **under the tripwire** and stays green. Lint rc=0, tsc clean. Belt verified byte-identical to the mutation-tested 0023 block (modulo staging name); the index tail was proven in the PR-A scratch and is now pinned by the 4 contract tests.

## After merge + deploy

Deploy success = **Q1 = 0 recorded**. I'll stamp the deploy status on this PR; that zero closes #146. (Q2 count-drift is trued by the same file; no index enforces it, but PR-B's commutative bumps stop new drift — residue is cosmetic display lag only.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018pJJgDHCnnNeEqEAApxFcQ
