### PR TITLE
feat(mcp): @clankersupport/mcp — MCP connector for Claude Code & Codex

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,7 +108,7 @@ The api ships to workerd. Avoid Node-only deps — they fail to bundle. Already 
 
 ### Auth (`apps/api/src/auth.ts`)
 
-Better Auth with the Drizzle adapter. **Email+password plus Google and GitHub OAuth** (social providers are wired only when the matching `*_CLIENT_ID`/`*_CLIENT_SECRET` env vars are present; `/api/oauth-providers` tells the frontends which are enabled). The passkey plugin remains removed (Node deps). `createAuth(env)` is called **per-request** because env is a Ploy binding, not a module-scope value.
+Better Auth with the Drizzle adapter. **Email+password plus Google and GitHub OAuth** (social providers are wired only when the matching `*_CLIENT_ID`/`*_CLIENT_SECRET` env vars are present; `/api/oauth-providers` tells the frontends which are enabled). The passkey plugin remains removed (Node deps). `createAuth(env)` is called **per-request** because env is a Ploy binding, not a module-scope value. `trustedOrigins` accepts the app origins (dashboard/marketing/showcase/admin, incl. Ploy preview hosts) **plus the API's own origin** — same-origin is CSRF-safe, and non-browser clients whose fetch stamps `Sec-Fetch-*` headers (Node's fetch → the MCP connector) present it to pass Better Auth's origin check (tested in `auth.test.ts`).
 
 ### Request paths (`apps/api/src/index.ts`)
 
@@ -183,6 +183,10 @@ Three entry points via package `exports`:
 - `@llmchat/widget/styles` → `src/styles.ts` (a `widgetStyles` string for injecting into a shadow root `<style>`).
 
 The CSS lives as a TS template literal rather than a `.css` file because Next.js (the in-tree consumers) doesn't grok Vite's `?inline` syntax — a string export works for both bundlers. After `vite build`, `scripts/emit-api-asset.mjs` embeds `dist/widget.js` into `apps/api/src/generated/widget-bundle.ts` (gitignored) so the worker serves `/widget.js` with no filesystem.
+
+### MCP connector (`packages/mcp`)
+
+`@clankersupport/mcp` — a **publishable** stdio MCP server (like `packages/widget-rsc`, it keeps the `@clankersupport/*` npm name) that gives Claude Code / Codex / any MCP client the operator surface as tools: list/read conversations, reply, internal notes, knowledge sources, workspace search. It's a plain Node CLI (`bin: clanker-support-mcp`, run via `npx`) — **NodeNext module resolution + `.js` import extensions**, unlike the bundler-consumed packages; the workerd constraint does not apply. Auth is the dashboard's own email+password flow (`/api/auth/sign-in/email` → replay the session cookie + `x-workspace-id`; one transparent re-auth on 401). Sign-in sends `Origin: <api origin>` because Node's fetch force-stamps `Sec-Fetch-*` headers, which makes Better Auth demand a trusted origin — the API trusts its own origin for exactly this (see Auth above). Config is env-only: `CLANKER_EMAIL` / `CLANKER_PASSWORD` / `CLANKER_API_URL` (self-host) / `CLANKER_WORKSPACE_ID` (optional pin; else the busiest workspace). Docs: `apps/docs/content/integrations/mcp.mdx` and the package README.
 
 ### Marketing site (`apps/marketing`)
 

--- a/apps/api/src/auth.test.ts
+++ b/apps/api/src/auth.test.ts
@@ -174,3 +174,44 @@ describe("buildAuthOptions", () => {
 		spy.mockRestore();
 	});
 });
+
+describe("trustedOrigins", () => {
+	const resolve = (
+		origin: string | null,
+		url = "http://localhost:8787/api/auth/sign-in/email",
+	) => {
+		const headers = new Headers();
+		if (origin !== null) headers.set("origin", origin);
+		return buildAuthOptions(env()).trustedOrigins(
+			new Request(url, { headers }),
+		);
+	};
+
+	it("trusts the API's own origin (same-origin is CSRF-safe; used by the MCP connector)", () => {
+		expect(resolve("http://localhost:8787")).toEqual(["http://localhost:8787"]);
+	});
+
+	it("trusts the configured app origins", () => {
+		expect(resolve("http://localhost:3001")).toEqual(["http://localhost:3001"]);
+	});
+
+	it("falls back to the static allowlist for foreign or absent origins", () => {
+		const fallback = [
+			"http://localhost:3001",
+			"http://localhost:3002",
+			"http://localhost:3003",
+			"http://localhost:3004",
+		];
+		expect(resolve("https://evil.example")).toEqual(fallback);
+		expect(resolve(null)).toEqual(fallback);
+	});
+
+	it("does not trust a same-host origin on a different scheme or port", () => {
+		expect(resolve("https://localhost:8787")).not.toContain(
+			"https://localhost:8787",
+		);
+		expect(resolve("http://localhost:8788")).not.toContain(
+			"http://localhost:8788",
+		);
+	});
+});

--- a/apps/api/src/auth.ts
+++ b/apps/api/src/auth.ts
@@ -146,9 +146,17 @@ export function buildAuthOptions(env: Env) {
 			const mkt = env.vars.MARKETING_URL || "http://localhost:3002";
 			const showcase = env.vars.SHOWCASE_URL || "http://localhost:3003";
 			const admin = adminUrl(env);
+			// The API's own origin is also trusted: same-origin requests are
+			// CSRF-safe by definition (a browser only sends Origin = this API from
+			// pages the API itself serves), and it gives non-browser clients that
+			// can't suppress Sec-Fetch-* headers — Node's fetch, hence the
+			// @clankersupport/mcp connector — a deterministic origin to present
+			// that works on any deployment, hosted or self-hosted.
+			const self = request ? new URL(request.url).origin : undefined;
 			if (
 				origin &&
-				(isAllowedOrigin(origin, dash) ||
+				(origin === self ||
+					isAllowedOrigin(origin, dash) ||
 					isAllowedOrigin(origin, mkt) ||
 					isAllowedOrigin(origin, showcase) ||
 					isAllowedOrigin(origin, admin))

--- a/apps/docs/content/integrations/mcp.mdx
+++ b/apps/docs/content/integrations/mcp.mdx
@@ -1,0 +1,78 @@
+---
+title: MCP connector (Claude Code & Codex)
+description: Work your support inbox from your coding agent — read escalations, send replies, and update the knowledge base over the Model Context Protocol
+icon: Terminal
+---
+
+The official MCP server, [`@clankersupport/mcp`](https://www.npmjs.com/package/@clankersupport/mcp), connects Clanker Support to any [Model Context Protocol](https://modelcontextprotocol.io) client — Claude Code and Codex being the two it's tested against. Your coding agent gets the operator surface as tools: list and read conversations, reply to customers, leave internal notes, search the workspace, and add knowledge sources.
+
+The loop it unlocks: a customer reports a bug and escalates → your agent reads the conversation from the terminal, you fix the bug together → the agent replies to the customer and adds the fix to the knowledge base so the AI answers it next time. No dashboard tab involved.
+
+## Claude Code
+
+```sh
+claude mcp add clanker-support \
+  --env CLANKER_EMAIL=you@company.com \
+  --env CLANKER_PASSWORD=your-password \
+  -- npx -y @clankersupport/mcp
+```
+
+Restart Claude Code (or run `/mcp`) and the `clanker-support` tools are available. For a team-shared, project-scoped setup, commit a `.mcp.json` that references environment variables instead of literal credentials:
+
+```json
+{
+	"mcpServers": {
+		"clanker-support": {
+			"command": "npx",
+			"args": ["-y", "@clankersupport/mcp"],
+			"env": {
+				"CLANKER_EMAIL": "${CLANKER_EMAIL}",
+				"CLANKER_PASSWORD": "${CLANKER_PASSWORD}"
+			}
+		}
+	}
+}
+```
+
+## Codex
+
+Add to `~/.codex/config.toml`:
+
+```toml
+[mcp_servers.clanker-support]
+command = "npx"
+args = ["-y", "@clankersupport/mcp"]
+env = { CLANKER_EMAIL = "you@company.com", CLANKER_PASSWORD = "your-password" }
+```
+
+## Configuration
+
+| Variable               | Required | Default                          | What it does                                                                      |
+| ---------------------- | -------- | -------------------------------- | --------------------------------------------------------------------------------- |
+| `CLANKER_EMAIL`        | yes      | —                                | Operator account email                                                            |
+| `CLANKER_PASSWORD`     | yes      | —                                | Operator account password                                                         |
+| `CLANKER_API_URL`      | no       | `https://api.clankersupport.com` | Your API origin when [self-hosting](/features/self-hosting)                       |
+| `CLANKER_WORKSPACE_ID` | no       | auto                             | Pin a workspace when the account belongs to several (`list_workspaces` lists ids) |
+
+Prefer a dedicated automation account with the least role that covers what you'll do — `agent` is enough for reading, replying, notes, and knowledge sources.
+
+## Tools
+
+| Tool                     | What it does                                                                  |
+| ------------------------ | ----------------------------------------------------------------------------- |
+| `list_workspaces`        | Workspaces this account belongs to, with role and project count               |
+| `list_projects`          | Support projects in the active workspace                                      |
+| `list_conversations`     | Conversations in a project — filter by open / escalated / resolved, or search |
+| `conversation_stats`     | Open / escalated / resolved counts for a project                              |
+| `get_conversation`       | A conversation's full message thread                                          |
+| `reply_to_conversation`  | Send an operator reply to the customer (customer-visible)                     |
+| `add_internal_note`      | Team-only note on a conversation — never shown to the customer                |
+| `list_knowledge_sources` | The project's knowledge base (url / text / qa sources)                        |
+| `add_knowledge_source`   | Add a docs URL, text snippet, or Q&A pair the AI will answer from             |
+| `search`                 | Workspace-wide search — the same one the dashboard's ⌘K palette uses          |
+
+`reply_to_conversation` is customer-visible, and its tool description instructs agents to confirm the draft with you before sending.
+
+## Self-hosting
+
+Set `CLANKER_API_URL` to your deployment's API origin — everything else is identical. The API must be a build that trusts its own origin for sign-in (July 2026 or later).

--- a/apps/docs/content/integrations/meta.json
+++ b/apps/docs/content/integrations/meta.json
@@ -2,5 +2,5 @@
 	"title": "Integrations",
 	"description": "Every way to put Clanker Support on your site",
 	"icon": "Blocks",
-	"pages": ["index", "widget", "react-sdk", "shopify", "wordpress"]
+	"pages": ["index", "widget", "react-sdk", "shopify", "wordpress", "mcp"]
 }

--- a/packages/mcp/LICENSE
+++ b/packages/mcp/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026-present LLMGateway, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1,0 +1,84 @@
+# @clankersupport/mcp
+
+The official [Clanker Support](https://clankersupport.com) MCP server — work your support inbox from Claude Code, Codex, or any [Model Context Protocol](https://modelcontextprotocol.io) client.
+
+Your coding agent can read escalated conversations, draft and send replies, leave internal notes for your team, search across every conversation, and keep the AI's knowledge base up to date — without you leaving the terminal. Fix a bug a customer reported, then answer them and add the fix to the knowledge base, all in one session.
+
+## Setup
+
+You need a Clanker Support operator account (the one you use for the dashboard, or a dedicated automation account — recommended, with the least role that covers what you'll do).
+
+### Claude Code
+
+```sh
+claude mcp add clanker-support \
+  --env CLANKER_EMAIL=you@company.com \
+  --env CLANKER_PASSWORD=your-password \
+  -- npx -y @clankersupport/mcp
+```
+
+Or, to share the connector with your team via a project-scoped `.mcp.json` (keep credentials out of it — reference environment variables instead):
+
+```json
+{
+	"mcpServers": {
+		"clanker-support": {
+			"command": "npx",
+			"args": ["-y", "@clankersupport/mcp"],
+			"env": {
+				"CLANKER_EMAIL": "${CLANKER_EMAIL}",
+				"CLANKER_PASSWORD": "${CLANKER_PASSWORD}"
+			}
+		}
+	}
+}
+```
+
+### Codex
+
+Add to `~/.codex/config.toml`:
+
+```toml
+[mcp_servers.clanker-support]
+command = "npx"
+args = ["-y", "@clankersupport/mcp"]
+env = { CLANKER_EMAIL = "you@company.com", CLANKER_PASSWORD = "your-password" }
+```
+
+### Any other MCP client
+
+Run `npx -y @clankersupport/mcp` over stdio with the environment variables below.
+
+## Configuration
+
+| Variable               | Required | Default                          | What it does                                                                                                          |
+| ---------------------- | -------- | -------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `CLANKER_EMAIL`        | yes      | —                                | Operator account email                                                                                                |
+| `CLANKER_PASSWORD`     | yes      | —                                | Operator account password (stays in your local MCP client config; sent only to the API)                               |
+| `CLANKER_API_URL`      | no       | `https://api.clankersupport.com` | Point at your own deployment when self-hosting (e.g. `http://localhost:8787`)                                         |
+| `CLANKER_WORKSPACE_ID` | no       | auto                             | Pin a workspace. Defaults to your only workspace, or the one with the most projects — `list_workspaces` shows the ids |
+
+## Tools
+
+| Tool                     | What it does                                                                  |
+| ------------------------ | ----------------------------------------------------------------------------- |
+| `list_workspaces`        | Workspaces this account belongs to, with role and project count               |
+| `list_projects`          | Support projects in the active workspace                                      |
+| `list_conversations`     | Conversations in a project — filter by open / escalated / resolved, or search |
+| `conversation_stats`     | Open / escalated / resolved counts for a project                              |
+| `get_conversation`       | A conversation's full message thread                                          |
+| `reply_to_conversation`  | Send an operator reply to the customer (customer-visible)                     |
+| `add_internal_note`      | Team-only note on a conversation — never shown to the customer                |
+| `list_knowledge_sources` | The project's knowledge base (url / text / qa sources)                        |
+| `add_knowledge_source`   | Add a docs URL, text snippet, or Q&A pair the AI will answer from             |
+| `search`                 | Workspace-wide search — the same one the dashboard's ⌘K palette uses          |
+
+Replies are customer-visible: a well-behaved agent will show you the draft before calling `reply_to_conversation`, and the tool description tells it to.
+
+## Self-hosting
+
+Everything works against your own deployment — set `CLANKER_API_URL` to your API origin. Requires an API build that trusts its own origin for sign-in (any build from July 2026 on).
+
+## License
+
+MIT

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,0 +1,59 @@
+{
+	"name": "@clankersupport/mcp",
+	"version": "0.1.0",
+	"description": "MCP server for Clanker Support — read your support inbox, reply to customers, and manage your knowledge base from Claude Code, Codex, or any MCP client.",
+	"keywords": [
+		"mcp",
+		"model-context-protocol",
+		"ai",
+		"customer-support",
+		"claude-code",
+		"codex",
+		"connector"
+	],
+	"homepage": "https://clankersupport.com",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/theopenco/llmchat.git",
+		"directory": "packages/mcp"
+	},
+	"license": "MIT",
+	"type": "module",
+	"main": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"default": "./dist/index.js"
+		}
+	},
+	"bin": {
+		"clanker-support-mcp": "./dist/cli.js"
+	},
+	"files": [
+		"dist",
+		"README.md",
+		"LICENSE"
+	],
+	"publishConfig": {
+		"access": "public"
+	},
+	"scripts": {
+		"build": "tsc -p tsconfig.build.json",
+		"format": "prettier --write .",
+		"lint": "prettier --check .",
+		"test": "vitest run"
+	},
+	"dependencies": {
+		"@modelcontextprotocol/sdk": "^1.29.0",
+		"zod": "^4.0.0"
+	},
+	"devDependencies": {
+		"@types/node": "^22.0.0",
+		"typescript": "5.9.2",
+		"vitest": "^3.0.0"
+	},
+	"engines": {
+		"node": ">=20"
+	}
+}

--- a/packages/mcp/src/cli.ts
+++ b/packages/mcp/src/cli.ts
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+
+import { ClankerClient } from "./client.js";
+import { loadConfig } from "./config.js";
+import { createServer } from "./server.js";
+
+// stdout is the MCP protocol channel — all human output goes to stderr.
+try {
+	const cfg = loadConfig();
+	const server = createServer(new ClankerClient(cfg));
+	await server.connect(new StdioServerTransport());
+	console.error(`clanker-support MCP server ready (${cfg.apiUrl})`);
+} catch (err) {
+	console.error(err instanceof Error ? err.message : String(err));
+	process.exit(1);
+}

--- a/packages/mcp/src/client.test.ts
+++ b/packages/mcp/src/client.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { ClankerApiError, ClankerClient } from "./client.js";
+
+import type { ClankerConfig } from "./config.js";
+
+const CFG: ClankerConfig = {
+	apiUrl: "http://api.test",
+	email: "op@example.com",
+	password: "hunter22",
+};
+
+function jsonResponse(body: unknown, init: ResponseInit = {}) {
+	return new Response(JSON.stringify(body), {
+		status: 200,
+		headers: { "content-type": "application/json" },
+		...init,
+	});
+}
+
+function signInResponse() {
+	const res = jsonResponse({ user: { id: "u1" } });
+	res.headers.append(
+		"set-cookie",
+		"better-auth.session_token=tok123; Path=/; HttpOnly",
+	);
+	return res;
+}
+
+describe("ClankerClient", () => {
+	it("signs in lazily, replays the session cookie, and scopes to the workspace", async () => {
+		const fetchMock = vi
+			.fn<typeof fetch>()
+			.mockResolvedValueOnce(signInResponse())
+			.mockResolvedValueOnce(jsonResponse({ projects: [] }));
+		const client = new ClankerClient({ ...CFG, workspaceId: "ws1" }, fetchMock);
+
+		await client.listProjects();
+
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+		const [signInUrl, signInInit] = fetchMock.mock.calls[0];
+		expect(String(signInUrl)).toBe("http://api.test/api/auth/sign-in/email");
+		expect(JSON.parse(signInInit!.body as string)).toEqual({
+			email: CFG.email,
+			password: CFG.password,
+		});
+		const [url, init] = fetchMock.mock.calls[1];
+		expect(String(url)).toBe("http://api.test/api/projects");
+		const headers = init!.headers as Record<string, string>;
+		expect(headers.cookie).toBe("better-auth.session_token=tok123");
+		expect(headers["x-workspace-id"]).toBe("ws1");
+	});
+
+	it("resolves the workspace with the most projects when none is configured", async () => {
+		const fetchMock = vi
+			.fn<typeof fetch>()
+			.mockResolvedValueOnce(signInResponse())
+			.mockResolvedValueOnce(
+				jsonResponse({
+					workspaces: [
+						{ workspace: { id: "ws-empty" }, projectCount: 0 },
+						{ workspace: { id: "ws-busy" }, projectCount: 3 },
+					],
+				}),
+			)
+			.mockResolvedValueOnce(jsonResponse({ projects: [] }));
+		const client = new ClankerClient(CFG, fetchMock);
+
+		await client.listProjects();
+
+		const headers = fetchMock.mock.calls[2][1]!.headers as Record<
+			string,
+			string
+		>;
+		expect(headers["x-workspace-id"]).toBe("ws-busy");
+	});
+
+	it("re-authenticates once on a 401 and retries the request", async () => {
+		const fetchMock = vi
+			.fn<typeof fetch>()
+			.mockResolvedValueOnce(signInResponse())
+			.mockResolvedValueOnce(new Response("expired", { status: 401 }))
+			.mockResolvedValueOnce(signInResponse())
+			.mockResolvedValueOnce(jsonResponse({ projects: [{ id: "p1" }] }));
+		const client = new ClankerClient({ ...CFG, workspaceId: "ws1" }, fetchMock);
+
+		const data = (await client.listProjects()) as { projects: unknown[] };
+
+		expect(data.projects).toHaveLength(1);
+		expect(fetchMock).toHaveBeenCalledTimes(4);
+	});
+
+	it("surfaces API errors with status and body", async () => {
+		const fetchMock = vi
+			.fn<typeof fetch>()
+			.mockResolvedValueOnce(signInResponse())
+			.mockResolvedValueOnce(
+				new Response(JSON.stringify({ error: "payment required" }), {
+					status: 402,
+				}),
+			);
+		const client = new ClankerClient({ ...CFG, workspaceId: "ws1" }, fetchMock);
+
+		await expect(client.listProjects()).rejects.toMatchObject({
+			name: "ClankerApiError",
+			status: 402,
+		});
+	});
+
+	it("fails clearly when sign-in is rejected", async () => {
+		const fetchMock = vi
+			.fn<typeof fetch>()
+			.mockResolvedValue(new Response("nope", { status: 401 }));
+		const client = new ClankerClient(CFG, fetchMock);
+
+		await expect(client.listProjects()).rejects.toThrow(
+			/sign-in failed — check CLANKER_EMAIL/,
+		);
+		expect(
+			(await client.listProjects().catch((e: unknown) => e)) as ClankerApiError,
+		).toBeInstanceOf(ClankerApiError);
+	});
+
+	it("serializes query params and drops undefined ones", async () => {
+		const fetchMock = vi
+			.fn<typeof fetch>()
+			.mockResolvedValueOnce(signInResponse())
+			.mockResolvedValueOnce(jsonResponse({ conversations: [] }));
+		const client = new ClankerClient({ ...CFG, workspaceId: "ws1" }, fetchMock);
+
+		await client.listConversations("p1", {
+			status: "escalated",
+			limit: 5,
+			search: undefined,
+		});
+
+		const url = new URL(String(fetchMock.mock.calls[1][0]));
+		expect(url.pathname).toBe("/api/projects/p1/conversations");
+		expect(url.searchParams.get("status")).toBe("escalated");
+		expect(url.searchParams.get("limit")).toBe("5");
+		expect(url.searchParams.has("search")).toBe(false);
+	});
+});

--- a/packages/mcp/src/client.ts
+++ b/packages/mcp/src/client.ts
@@ -1,0 +1,203 @@
+import type { ClankerConfig } from "./config.js";
+
+/** An API error with the HTTP status and the server's error payload, surfaced
+ * verbatim to the MCP client so the model can react (e.g. 402 = plan limit). */
+export class ClankerApiError extends Error {
+	constructor(
+		readonly status: number,
+		readonly body: string,
+	) {
+		super(`Clanker Support API error ${status}: ${body}`);
+		this.name = "ClankerApiError";
+	}
+}
+
+type Query = Record<string, string | number | undefined>;
+
+/**
+ * Minimal authenticated client for the Clanker Support dashboard API.
+ *
+ * Auth is the same email+password flow the dashboard uses (Better Auth):
+ * sign in once, capture the session cookie, replay it on every call, and
+ * re-authenticate transparently when the session expires (one retry per
+ * request). Workspace scoping is the dashboard's `x-workspace-id` header.
+ */
+export class ClankerClient {
+	private cookie: string | null = null;
+	private workspaceId: string | null;
+
+	constructor(
+		private readonly cfg: ClankerConfig,
+		private readonly fetchImpl: typeof fetch = fetch,
+	) {
+		this.workspaceId = cfg.workspaceId ?? null;
+	}
+
+	private async signIn(): Promise<void> {
+		const res = await this.fetchImpl(
+			`${this.cfg.apiUrl}/api/auth/sign-in/email`,
+			{
+				method: "POST",
+				headers: {
+					"content-type": "application/json",
+					// Node's fetch always sends Sec-Fetch-* headers, which makes
+					// Better Auth demand a trusted Origin. The API trusts its own
+					// origin (same-origin is CSRF-safe), so present exactly that.
+					origin: new URL(this.cfg.apiUrl).origin,
+				},
+				body: JSON.stringify({
+					email: this.cfg.email,
+					password: this.cfg.password,
+				}),
+			},
+		);
+		if (!res.ok) {
+			throw new ClankerApiError(
+				res.status,
+				"sign-in failed — check CLANKER_EMAIL / CLANKER_PASSWORD" +
+					(this.cfg.apiUrl.includes("clankersupport.com")
+						? ""
+						: ` against ${this.cfg.apiUrl}`),
+			);
+		}
+		// Keep only the cookie pairs (drop attributes) so they replay verbatim.
+		const pairs = res.headers
+			.getSetCookie()
+			.map((c) => c.split(";")[0])
+			.filter(Boolean);
+		if (pairs.length === 0) {
+			throw new ClankerApiError(res.status, "sign-in returned no session");
+		}
+		this.cookie = pairs.join("; ");
+	}
+
+	/** The active workspace id — configured, or resolved once from the account's
+	 * memberships (single workspace, else the one with the most projects). */
+	async resolveWorkspaceId(): Promise<string> {
+		if (this.workspaceId) return this.workspaceId;
+		const data = (await this.request("/api/workspaces", {
+			workspace: false,
+		})) as {
+			workspaces: { workspace: { id: string }; projectCount: number }[];
+		};
+		const rows = data.workspaces;
+		if (rows.length === 0) {
+			throw new Error(
+				"This account belongs to no workspace. Sign in to the dashboard once to provision one.",
+			);
+		}
+		const best = [...rows].sort((a, b) => b.projectCount - a.projectCount)[0];
+		this.workspaceId = best.workspace.id;
+		return this.workspaceId;
+	}
+
+	async request(
+		path: string,
+		opts: {
+			method?: string;
+			query?: Query;
+			body?: unknown;
+			/** Attach the x-workspace-id header (default true). */
+			workspace?: boolean;
+			retried?: boolean;
+		} = {},
+	): Promise<unknown> {
+		if (!this.cookie) await this.signIn();
+
+		const url = new URL(`${this.cfg.apiUrl}${path}`);
+		for (const [k, v] of Object.entries(opts.query ?? {})) {
+			if (v !== undefined) url.searchParams.set(k, String(v));
+		}
+		const headers: Record<string, string> = { cookie: this.cookie! };
+		if (opts.workspace !== false) {
+			headers["x-workspace-id"] = await this.resolveWorkspaceId();
+		}
+		if (opts.body !== undefined) {
+			headers["content-type"] = "application/json";
+		}
+
+		const res = await this.fetchImpl(url, {
+			method: opts.method ?? (opts.body !== undefined ? "POST" : "GET"),
+			headers,
+			body: opts.body !== undefined ? JSON.stringify(opts.body) : undefined,
+		});
+
+		if (res.status === 401 && !opts.retried) {
+			// Session expired — sign in again and retry once.
+			this.cookie = null;
+			return this.request(path, { ...opts, retried: true });
+		}
+		if (!res.ok) {
+			throw new ClankerApiError(res.status, await res.text());
+		}
+		return res.json();
+	}
+
+	// ── Domain methods (paths mirror apps/api/src/routes/*) ─────────────
+
+	listWorkspaces() {
+		return this.request("/api/workspaces", { workspace: false });
+	}
+
+	listProjects() {
+		return this.request("/api/projects");
+	}
+
+	listConversations(
+		projectId: string,
+		q: { status?: string; search?: string; limit?: number },
+	) {
+		return this.request(`/api/projects/${projectId}/conversations`, {
+			query: { ...q },
+		});
+	}
+
+	conversationStats(projectId: string) {
+		return this.request(`/api/projects/${projectId}/conversations/stats`);
+	}
+
+	getConversation(
+		projectId: string,
+		conversationId: string,
+		q: { limit?: number; before?: number },
+	) {
+		return this.request(
+			`/api/projects/${projectId}/conversations/${conversationId}`,
+			{ query: { ...q } },
+		);
+	}
+
+	reply(projectId: string, conversationId: string, content: string) {
+		return this.request(
+			`/api/projects/${projectId}/conversations/${conversationId}/reply`,
+			{ body: { content } },
+		);
+	}
+
+	addNote(projectId: string, conversationId: string, content: string) {
+		return this.request(
+			`/api/projects/${projectId}/conversations/${conversationId}/notes`,
+			{ body: { content } },
+		);
+	}
+
+	listSources(projectId: string) {
+		return this.request(`/api/projects/${projectId}/sources`);
+	}
+
+	addUrlSource(projectId: string, body: { url: string; title?: string }) {
+		return this.request(`/api/projects/${projectId}/sources`, { body });
+	}
+
+	addTextSource(projectId: string, body: { content: string; title?: string }) {
+		return this.request(`/api/projects/${projectId}/sources/text`, { body });
+	}
+
+	addQaSource(projectId: string, body: { question: string; answer: string }) {
+		return this.request(`/api/projects/${projectId}/sources/qa`, { body });
+	}
+
+	search(q: string) {
+		return this.request("/api/search", { query: { q } });
+	}
+}

--- a/packages/mcp/src/config.ts
+++ b/packages/mcp/src/config.ts
@@ -1,0 +1,38 @@
+/** Connector configuration, read from the environment — the only config
+ * channel every MCP client (Claude Code, Codex, generic) supports. */
+export type ClankerConfig = {
+	/** API origin. Defaults to the hosted API; point at your own deployment
+	 * (e.g. http://localhost:8787) when self-hosting. */
+	apiUrl: string;
+	email: string;
+	password: string;
+	/** Optional. When absent and the account belongs to exactly one workspace,
+	 * that workspace is used; with several, the one with the most projects. */
+	workspaceId?: string;
+};
+
+const DEFAULT_API_URL = "https://api.clankersupport.com";
+
+export function loadConfig(
+	env: Record<string, string | undefined> = process.env,
+): ClankerConfig {
+	const email = env.CLANKER_EMAIL;
+	const password = env.CLANKER_PASSWORD;
+	const missing = [
+		...(email ? [] : ["CLANKER_EMAIL"]),
+		...(password ? [] : ["CLANKER_PASSWORD"]),
+	];
+	if (missing.length > 0) {
+		throw new Error(
+			`Missing required environment variable(s): ${missing.join(", ")}. ` +
+				"Set them to the email and password of a Clanker Support operator account " +
+				"(create a dedicated account for automation if you prefer).",
+		);
+	}
+	return {
+		apiUrl: (env.CLANKER_API_URL ?? DEFAULT_API_URL).replace(/\/+$/, ""),
+		email: email!,
+		password: password!,
+		workspaceId: env.CLANKER_WORKSPACE_ID || undefined,
+	};
+}

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1,0 +1,3 @@
+export { ClankerClient, ClankerApiError } from "./client.js";
+export { loadConfig, type ClankerConfig } from "./config.js";
+export { createServer } from "./server.js";

--- a/packages/mcp/src/server.test.ts
+++ b/packages/mcp/src/server.test.ts
@@ -1,0 +1,121 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { describe, expect, it, vi } from "vitest";
+
+import { ClankerClient } from "./client.js";
+import { createServer } from "./server.js";
+
+function jsonResponse(body: unknown) {
+	return new Response(JSON.stringify(body), { status: 200 });
+}
+
+function signInResponse() {
+	const res = jsonResponse({ user: { id: "u1" } });
+	res.headers.append("set-cookie", "better-auth.session_token=tok; Path=/");
+	return res;
+}
+
+/** Boot the real server over an in-memory transport with a mocked HTTP layer —
+ * exercises the full MCP round trip (list tools, call tool, error shaping). */
+async function connect(fetchMock: typeof fetch) {
+	const clanker = new ClankerClient(
+		{
+			apiUrl: "http://api.test",
+			email: "op@example.com",
+			password: "pw",
+			workspaceId: "ws1",
+		},
+		fetchMock,
+	);
+	const server = createServer(clanker);
+	const client = new Client({ name: "test", version: "0.0.0" });
+	const [a, b] = InMemoryTransport.createLinkedPair();
+	await Promise.all([server.connect(a), client.connect(b)]);
+	return client;
+}
+
+describe("clanker-support MCP server", () => {
+	it("exposes the operator tool surface", async () => {
+		const client = await connect(vi.fn<typeof fetch>());
+		const { tools } = await client.listTools();
+		expect(tools.map((t) => t.name).sort()).toEqual([
+			"add_internal_note",
+			"add_knowledge_source",
+			"conversation_stats",
+			"get_conversation",
+			"list_conversations",
+			"list_knowledge_sources",
+			"list_projects",
+			"list_workspaces",
+			"reply_to_conversation",
+			"search",
+		]);
+	});
+
+	it("calls a tool end-to-end and returns the API payload", async () => {
+		const fetchMock = vi
+			.fn<typeof fetch>()
+			.mockResolvedValueOnce(signInResponse())
+			.mockResolvedValueOnce(
+				jsonResponse({ conversations: [{ id: "c1" }], nextCursor: null }),
+			);
+		const client = await connect(fetchMock);
+
+		const result = await client.callTool({
+			name: "list_conversations",
+			arguments: { projectId: "p1", status: "escalated" },
+		});
+
+		const content = result.content as { type: string; text: string }[];
+		expect(result.isError).toBeFalsy();
+		expect(JSON.parse(content[0].text).conversations[0].id).toBe("c1");
+		const calledUrl = new URL(String(fetchMock.mock.calls[1][0]));
+		expect(calledUrl.searchParams.get("status")).toBe("escalated");
+	});
+
+	it("routes add_knowledge_source by kind and validates required fields", async () => {
+		const fetchMock = vi
+			.fn<typeof fetch>()
+			.mockResolvedValueOnce(signInResponse())
+			.mockResolvedValueOnce(jsonResponse({ source: { id: "s1" } }));
+		const client = await connect(fetchMock);
+
+		const ok = await client.callTool({
+			name: "add_knowledge_source",
+			arguments: { projectId: "p1", kind: "qa", question: "Q?", answer: "A." },
+		});
+		expect(ok.isError).toBeFalsy();
+		expect(String(fetchMock.mock.calls[1][0])).toBe(
+			"http://api.test/api/projects/p1/sources/qa",
+		);
+
+		const bad = await client.callTool({
+			name: "add_knowledge_source",
+			arguments: { projectId: "p1", kind: "url" },
+		});
+		expect(bad.isError).toBe(true);
+		expect((bad.content as { text: string }[])[0].text).toMatch(
+			/requires `url`/,
+		);
+	});
+
+	it("shapes API failures as isError results, not protocol errors", async () => {
+		const fetchMock = vi
+			.fn<typeof fetch>()
+			.mockResolvedValueOnce(signInResponse())
+			.mockResolvedValueOnce(
+				new Response(JSON.stringify({ error: "payment required" }), {
+					status: 402,
+				}),
+			);
+		const client = await connect(fetchMock);
+
+		const result = await client.callTool({
+			name: "list_projects",
+			arguments: {},
+		});
+
+		expect(result.isError).toBe(true);
+		expect((result.content as { text: string }[])[0].text).toMatch(/402/);
+	});
+});

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -1,0 +1,207 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+
+import type { ClankerClient } from "./client.js";
+
+const VERSION = "0.1.0";
+
+/** Wrap a handler: JSON results as text content, errors as isError results so
+ * the model sees the API's message (401/402/404 …) instead of a dead call. */
+function handle<A extends unknown[]>(
+	fn: (...args: A) => Promise<unknown>,
+): (...args: A) => Promise<{
+	content: { type: "text"; text: string }[];
+	isError?: boolean;
+}> {
+	return async (...args: A) => {
+		try {
+			const data = await fn(...args);
+			return {
+				content: [{ type: "text", text: JSON.stringify(data, null, 2) }],
+			};
+		} catch (err) {
+			return {
+				content: [{ type: "text", text: String(err) }],
+				isError: true,
+			};
+		}
+	};
+}
+
+/** Build the MCP server over an authenticated client. Tool names and argument
+ * shapes mirror the dashboard API (apps/api) — the server adds no state of its
+ * own. */
+export function createServer(client: ClankerClient): McpServer {
+	const server = new McpServer({ name: "clanker-support", version: VERSION });
+
+	server.registerTool(
+		"list_workspaces",
+		{
+			description:
+				"List the workspaces this account belongs to, with role and project count. " +
+				"Useful to find a workspace id for CLANKER_WORKSPACE_ID when the account has several.",
+			inputSchema: {},
+		},
+		handle(() => client.listWorkspaces()),
+	);
+
+	server.registerTool(
+		"list_projects",
+		{
+			description:
+				"List the support projects (embedded widgets) in the active workspace — id, name, public key, model, and settings. Most other tools need a projectId from here.",
+			inputSchema: {},
+		},
+		handle(() => client.listProjects()),
+	);
+
+	server.registerTool(
+		"list_conversations",
+		{
+			description:
+				"List support conversations in a project, newest first. Filter by status " +
+				"(open = active, escalated = customer asked for a human, resolved = archived, all) " +
+				"or full-text search. Returns per-conversation metadata, tags, and a snippet of the first message.",
+			inputSchema: {
+				projectId: z.string().describe("Project id from list_projects"),
+				status: z
+					.enum(["open", "resolved", "escalated", "all"])
+					.optional()
+					.describe("Status view (default open)"),
+				search: z
+					.string()
+					.optional()
+					.describe("Full-text search over messages, names, and emails"),
+				limit: z.number().int().min(1).max(100).optional(),
+			},
+		},
+		handle(({ projectId, ...q }) => client.listConversations(projectId, q)),
+	);
+
+	server.registerTool(
+		"conversation_stats",
+		{
+			description:
+				"Conversation counts for a project (open / escalated / resolved) — a quick inbox health check.",
+			inputSchema: {
+				projectId: z.string().describe("Project id from list_projects"),
+			},
+		},
+		handle(({ projectId }) => client.conversationStats(projectId)),
+	);
+
+	server.registerTool(
+		"get_conversation",
+		{
+			description:
+				"Read a conversation's message thread (visitor, AI, and operator messages, newest page by default). " +
+				"Pass `before` (a message sequence number) to page back through older messages.",
+			inputSchema: {
+				projectId: z.string(),
+				conversationId: z.string(),
+				limit: z.number().int().min(1).max(100).optional(),
+				before: z
+					.number()
+					.int()
+					.optional()
+					.describe("Load messages with sequence < this (paging upward)"),
+			},
+		},
+		handle(({ projectId, conversationId, ...q }) =>
+			client.getConversation(projectId, conversationId, q),
+		),
+	);
+
+	server.registerTool(
+		"reply_to_conversation",
+		{
+			description:
+				"Send an operator reply to the CUSTOMER in a conversation. This is customer-visible " +
+				"(it appears in their widget, and threads over email on escalated conversations) — " +
+				"confirm the text with the user before sending. For team-only context use add_internal_note.",
+			inputSchema: {
+				projectId: z.string(),
+				conversationId: z.string(),
+				content: z.string().min(1).max(10_000).describe("Reply text"),
+			},
+		},
+		handle(({ projectId, conversationId, content }) =>
+			client.reply(projectId, conversationId, content),
+		),
+	);
+
+	server.registerTool(
+		"add_internal_note",
+		{
+			description:
+				"Attach a team-only internal note to a conversation. Never shown to the customer — " +
+				"use for context, debugging findings, or handoff notes.",
+			inputSchema: {
+				projectId: z.string(),
+				conversationId: z.string(),
+				content: z.string().min(1).max(10_000).describe("Note text"),
+			},
+		},
+		handle(({ projectId, conversationId, content }) =>
+			client.addNote(projectId, conversationId, content),
+		),
+	);
+
+	server.registerTool(
+		"list_knowledge_sources",
+		{
+			description:
+				"List a project's knowledge base sources (url / text / qa) — what the AI answers from.",
+			inputSchema: { projectId: z.string() },
+		},
+		handle(({ projectId }) => client.listSources(projectId)),
+	);
+
+	server.registerTool(
+		"add_knowledge_source",
+		{
+			description:
+				"Add a knowledge base source the AI will answer from. kind 'url' needs `url`; " +
+				"kind 'text' needs `content` (docs snippet, changelog, policy); " +
+				"kind 'qa' needs `question` + `answer` (a canned Q&A). " +
+				"New sources are active immediately for future AI answers.",
+			inputSchema: {
+				projectId: z.string(),
+				kind: z.enum(["url", "text", "qa"]),
+				url: z.string().optional().describe("For kind 'url'"),
+				title: z.string().max(200).optional(),
+				content: z.string().max(50_000).optional().describe("For kind 'text'"),
+				question: z.string().max(2_000).optional().describe("For kind 'qa'"),
+				answer: z.string().max(8_000).optional().describe("For kind 'qa'"),
+			},
+		},
+		handle(({ projectId, kind, url, title, content, question, answer }) => {
+			if (kind === "url") {
+				if (!url) throw new Error("kind 'url' requires `url`");
+				return client.addUrlSource(projectId, { url, title });
+			}
+			if (kind === "text") {
+				if (!content) throw new Error("kind 'text' requires `content`");
+				return client.addTextSource(projectId, { content, title });
+			}
+			if (!question || !answer) {
+				throw new Error("kind 'qa' requires `question` and `answer`");
+			}
+			return client.addQaSource(projectId, { question, answer });
+		}),
+	);
+
+	server.registerTool(
+		"search",
+		{
+			description:
+				"Workspace-wide search across conversations (message bodies, visitor names, emails) and project names — the same search the dashboard's ⌘K palette uses.",
+			inputSchema: {
+				query: z.string().min(2).describe("Search term (min 2 chars)"),
+			},
+		},
+		handle(({ query }) => client.search(query)),
+	);
+
+	return server;
+}

--- a/packages/mcp/tsconfig.build.json
+++ b/packages/mcp/tsconfig.build.json
@@ -1,0 +1,5 @@
+{
+	"extends": "./tsconfig.json",
+	"include": ["src"],
+	"exclude": ["src/**/*.test.ts"]
+}

--- a/packages/mcp/tsconfig.json
+++ b/packages/mcp/tsconfig.json
@@ -1,0 +1,15 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		// This package ships a Node-executable CLI (run via `npx`), so the emitted
+		// JS must resolve under Node's own ESM rules — NodeNext, with explicit .js
+		// extensions on relative imports — unlike the bundler-consumed packages.
+		"module": "NodeNext",
+		"moduleResolution": "NodeNext",
+		"lib": ["ES2023"],
+		"outDir": "./dist",
+		"rootDir": "./src",
+		"types": ["node"]
+	},
+	"include": ["src"]
+}

--- a/packages/mcp/vitest.config.ts
+++ b/packages/mcp/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	test: {
+		environment: "node",
+	},
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -484,6 +484,25 @@ importers:
         specifier: 5.9.2
         version: 5.9.2
 
+  packages/mcp:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(zod@4.4.3)
+      zod:
+        specifier: ^4.0.0
+        version: 4.4.3
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.17
+      typescript:
+        specifier: 5.9.2
+        version: 5.9.2
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.6(@types/debug@4.1.13)(@types/node@22.19.17)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
+
   packages/shared:
     dependencies:
       zod:
@@ -2214,6 +2233,16 @@ packages:
 
   '@mermaid-js/parser@1.1.1':
     resolution: {integrity: sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw==}
+
+  '@modelcontextprotocol/sdk@1.29.0':
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@next/env@15.1.0':
     resolution: {integrity: sha512-UcCO481cROsqJuszPPXJnb7GGuLq617ve4xuAyyNG4VSSocJNtMU5Fsx+Lp6mlN8c7W58aZLc5y6D/2xNmaK+w==}
@@ -4037,6 +4066,10 @@ packages:
   '@vitest/utils@3.2.6':
     resolution: {integrity: sha512-lI23nIs4bnT3T8NIoh+vFaz5s2/DdP0Jgt2jxwgWljvwn82cLJtyi/If+fjFyoLMGIOz0U/fKvWE0d4jsNQEfg==}
 
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -4070,6 +4103,17 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
+
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
   ansi-escapes@7.3.0:
     resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
@@ -4254,6 +4298,10 @@ packages:
   blake3-wasm@2.1.5:
     resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
 
+  body-parser@2.3.0:
+    resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
+    engines: {node: '>=18'}
+
   bottleneck@2.19.5:
     resolution: {integrity: sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==}
 
@@ -4278,6 +4326,10 @@ packages:
   busboy@1.6.0:
     resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
     engines: {node: '>=10.16.0'}
+
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
 
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
@@ -4454,6 +4506,14 @@ packages:
   config-chain@1.1.13:
     resolution: {integrity: sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==}
 
+  content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
   content-type@2.0.0:
     resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
     engines: {node: '>=18'}
@@ -4483,6 +4543,14 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
+
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
@@ -4492,6 +4560,10 @@ packages:
 
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
 
   cose-base@1.0.3:
     resolution: {integrity: sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==}
@@ -4739,6 +4811,10 @@ packages:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
 
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
@@ -4879,6 +4955,9 @@ packages:
   duplexer2@0.1.4:
     resolution: {integrity: sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==}
 
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
   electron-to-chromium@1.5.349:
     resolution: {integrity: sha512-QsWVGyRuY07Aqb234QytTfwd5d9AJlfNIQ5wIOl1L+PZDzI9d9+Fn0FRale/QYlFxt/bUnB0/nLd1jFPGxGK1A==}
 
@@ -4887,6 +4966,10 @@ packages:
 
   emojilib@2.4.0:
     resolution: {integrity: sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw==}
+
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
 
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
@@ -4979,6 +5062,9 @@ packages:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
 
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+
   escape-string-regexp@1.0.5:
     resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
     engines: {node: '>=0.8.0'}
@@ -5016,8 +5102,16 @@ packages:
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
   eventsource-parser@3.0.8:
     resolution: {integrity: sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
     engines: {node: '>=18.0.0'}
 
   execa@5.1.1:
@@ -5040,12 +5134,25 @@ packages:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
 
+  express-rate-limit@8.6.0:
+    resolution: {integrity: sha512-XKJXDsASUOo0LLtFwW5hCcQGH0N4WQc/Rn8/Pvoia+TJFOkkFPvrtW9lZOeeNcxQJspvOIERMwiRLsVFlhHEkA==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
+
   extend-shallow@2.0.1:
     resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==}
     engines: {node: '>=0.10.0'}
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
@@ -5056,6 +5163,9 @@ packages:
 
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
+
+  fast-uri@3.1.4:
+    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -5091,6 +5201,10 @@ packages:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
 
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+
   find-up-simple@1.0.1:
     resolution: {integrity: sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ==}
     engines: {node: '>=18'}
@@ -5111,6 +5225,10 @@ packages:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
 
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
   fraction.js@5.3.4:
     resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
 
@@ -5127,6 +5245,10 @@ packages:
         optional: true
       react-dom:
         optional: true
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
 
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
@@ -5437,6 +5559,10 @@ packages:
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
+
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
     engines: {node: '>= 14'}
@@ -5459,6 +5585,10 @@ packages:
 
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+
+  iconv-lite@0.7.3:
+    resolution: {integrity: sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==}
     engines: {node: '>=0.10.0'}
 
   ieee754@1.2.1:
@@ -5510,6 +5640,14 @@ packages:
   internmap@2.0.3:
     resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
     engines: {node: '>=12'}
+
+  ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
+    engines: {node: '>= 12'}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
 
   is-alphabetical@2.0.1:
     resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
@@ -5575,6 +5713,9 @@ packages:
 
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
   is-stream@2.0.1:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
@@ -5659,6 +5800,12 @@ packages:
 
   json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json-schema@0.4.0:
     resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
@@ -5931,8 +6078,16 @@ packages:
   mdast-util-to-string@4.0.0:
     resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
 
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
   meow@13.2.0:
     resolution: {integrity: sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==}
+    engines: {node: '>=18'}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
     engines: {node: '>=18'}
 
   merge-stream@2.0.0:
@@ -6058,9 +6213,17 @@ packages:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
 
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
   mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
 
   mime@4.1.0:
     resolution: {integrity: sha512-X5ju04+cAzsojXKes0B/S4tcYtFAJ6tTMuSPBEn9CPGlrWr8Fiw7qYeLT0XyH80HSoAoqWCaz+MWKh22P7G1cw==}
@@ -6134,6 +6297,10 @@ packages:
 
   napi-build-utils@2.0.0:
     resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
+
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
 
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
@@ -6396,6 +6563,10 @@ packages:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
 
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
+
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
@@ -6534,6 +6705,10 @@ packages:
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
   path-data-parser@0.1.0:
     resolution: {integrity: sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==}
 
@@ -6558,6 +6733,9 @@ packages:
 
   path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
+
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -6592,6 +6770,10 @@ packages:
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
 
   pkg-conf@2.1.0:
     resolution: {integrity: sha512-C+VUP+8jis7EsQZIhDYmS5qlNtjv2yP4SNtjXK9AP1ZcTRlnSfuumaTnRfYZnYgUUYVIKqL0fRvmUGDV2fmp6g==}
@@ -6722,6 +6904,10 @@ packages:
   proto-list@1.2.4:
     resolution: {integrity: sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==}
 
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
@@ -6733,6 +6919,10 @@ packages:
     resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
     engines: {node: '>=0.6'}
 
+  qs@6.15.3:
+    resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
+    engines: {node: '>=0.6'}
+
   query-selector-shadow-dom@1.0.1:
     resolution: {integrity: sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==}
 
@@ -6741,6 +6931,14 @@ packages:
 
   ramda@0.27.2:
     resolution: {integrity: sha512-SbiLPU40JuJniHexQSAgad32hfwd+DRUdwF2PlVuI5RZD0/vahUco7R8vD86J/tcEKKF9vZrUVwgtmGCqlCKyA==}
+
+  range-parser@1.3.0:
+    resolution: {integrity: sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
 
   rc@1.2.8:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
@@ -6901,6 +7099,10 @@ packages:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
 
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -6939,6 +7141,10 @@ packages:
 
   roughjs@4.6.6:
     resolution: {integrity: sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==}
+
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
 
   rrweb-cssom@0.7.1:
     resolution: {integrity: sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==}
@@ -7012,12 +7218,23 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
   serialize-javascript@7.0.5:
     resolution: {integrity: sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==}
     engines: {node: '>=20.0.0'}
 
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
+
   set-cookie-parser@3.1.0:
     resolution: {integrity: sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
   sharp@0.33.5:
     resolution: {integrity: sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==}
@@ -7053,6 +7270,10 @@ packages:
 
   side-channel@1.1.0:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.1:
+    resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
     engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
@@ -7133,6 +7354,10 @@ packages:
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
 
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
@@ -7380,6 +7605,10 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
   tough-cookie@5.1.2:
     resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
     engines: {node: '>=16'}
@@ -7447,6 +7676,10 @@ packages:
   type-fest@5.7.0:
     resolution: {integrity: sha512-1URUxUqfHFM1c+zfSPsa3gnkO7Aq21qyH75SIduNYz4SzY964rn1X2vCMQaHSHhktiw+0kPa2iyb6PUpXqB6Vg==}
     engines: {node: '>=20'}
+
+  type-is@2.1.0:
+    resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
+    engines: {node: '>= 18'}
 
   typescript@5.9.2:
     resolution: {integrity: sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==}
@@ -7527,6 +7760,10 @@ packages:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
 
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
     hasBin: true
@@ -7571,6 +7808,10 @@ packages:
 
   validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
 
   vfile-location@5.0.3:
     resolution: {integrity: sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==}
@@ -7792,6 +8033,11 @@ packages:
 
   youch@4.1.0-beta.10:
     resolution: {integrity: sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==}
+
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
 
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
@@ -8945,6 +9191,28 @@ snapshots:
   '@mermaid-js/parser@1.1.1':
     dependencies:
       '@chevrotain/types': 11.1.2
+
+  '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.16)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.8
+      express: 5.2.1
+      express-rate-limit: 8.6.0(express@5.2.1)
+      hono: 4.12.16
+      jose: 6.2.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
+    transitivePeerDependencies:
+      - supports-color
 
   '@next/env@15.1.0': {}
 
@@ -10666,6 +10934,11 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 2.0.0
 
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+
   acorn-jsx@5.3.2(acorn@8.17.0):
     dependencies:
       acorn: 8.17.0
@@ -10699,6 +10972,17 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.4(zod@4.4.3)
       '@opentelemetry/api': 1.9.0
       zod: 4.4.3
+
+  ajv-formats@3.0.1(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
+
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.4
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
 
   ansi-escapes@7.3.0:
     dependencies:
@@ -10926,6 +11210,20 @@ snapshots:
 
   blake3-wasm@2.1.5: {}
 
+  body-parser@2.3.0:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 2.0.0
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.3
+      on-finished: 2.4.1
+      qs: 6.15.3
+      raw-body: 3.0.2
+      type-is: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   bottleneck@2.19.5: {}
 
   brace-expansion@1.1.15:
@@ -10955,6 +11253,8 @@ snapshots:
   busboy@1.6.0:
     dependencies:
       streamsearch: 1.1.0
+
+  bytes@3.1.2: {}
 
   cac@6.7.14: {}
 
@@ -11138,6 +11438,10 @@ snapshots:
       ini: 1.3.8
       proto-list: 1.2.4
 
+  content-disposition@1.1.0: {}
+
+  content-type@1.0.5: {}
+
   content-type@2.0.0: {}
 
   conventional-changelog-angular@8.3.1:
@@ -11163,11 +11467,20 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
+  cookie-signature@1.2.2: {}
+
+  cookie@0.7.2: {}
+
   cookie@1.1.1: {}
 
   core-js@3.49.0: {}
 
   core-util-is@1.0.3: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
 
   cose-base@1.0.3:
     dependencies:
@@ -11437,6 +11750,8 @@ snapshots:
 
   delayed-stream@1.0.0: {}
 
+  depd@2.0.0: {}
+
   dequal@2.0.3: {}
 
   detect-libc@2.1.2: {}
@@ -11491,11 +11806,15 @@ snapshots:
     dependencies:
       readable-stream: 2.3.8
 
+  ee-first@1.1.1: {}
+
   electron-to-chromium@1.5.349: {}
 
   emoji-regex@8.0.0: {}
 
   emojilib@2.4.0: {}
+
+  encodeurl@2.0.0: {}
 
   end-of-stream@1.4.5:
     dependencies:
@@ -11727,6 +12046,8 @@ snapshots:
 
   escalade@3.2.0: {}
 
+  escape-html@1.0.3: {}
+
   escape-string-regexp@1.0.5: {}
 
   escape-string-regexp@5.0.0: {}
@@ -11770,7 +12091,13 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.8
 
+  etag@1.8.1: {}
+
   eventsource-parser@3.0.8: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.0.8
 
   execa@5.1.1:
     dependencies:
@@ -11815,11 +12142,54 @@ snapshots:
 
   expect-type@1.3.0: {}
 
+  express-rate-limit@8.6.0(express@5.2.1):
+    dependencies:
+      debug: 4.4.3
+      express: 5.2.1
+      ip-address: 10.2.0
+    transitivePeerDependencies:
+      - supports-color
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.3.0
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.1
+      range-parser: 1.3.0
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.1.0
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+
   extend-shallow@2.0.1:
     dependencies:
       is-extendable: 0.1.1
 
   extend@3.0.2: {}
+
+  fast-deep-equal@3.1.3: {}
 
   fast-glob@3.3.3:
     dependencies:
@@ -11834,6 +12204,8 @@ snapshots:
   fast-string-width@3.0.2:
     dependencies:
       fast-string-truncated-width: 3.0.3
+
+  fast-uri@3.1.4: {}
 
   fastq@1.20.1:
     dependencies:
@@ -11861,6 +12233,17 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   find-up-simple@1.0.1: {}
 
   find-up@2.1.0:
@@ -11884,6 +12267,8 @@ snapshots:
       hasown: 2.0.3
       mime-types: 2.1.35
 
+  forwarded@0.2.0: {}
+
   fraction.js@5.3.4: {}
 
   framer-motion@12.42.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
@@ -11894,6 +12279,8 @@ snapshots:
     optionalDependencies:
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
+
+  fresh@2.0.0: {}
 
   fs-constants@1.0.0: {}
 
@@ -12275,6 +12662,14 @@ snapshots:
 
   html-void-elements@3.0.0: {}
 
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
+
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.4
@@ -12296,6 +12691,10 @@ snapshots:
   human-signals@8.0.1: {}
 
   iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  iconv-lite@0.7.3:
     dependencies:
       safer-buffer: 2.1.2
 
@@ -12337,6 +12736,10 @@ snapshots:
   internmap@1.0.1: {}
 
   internmap@2.0.3: {}
+
+  ip-address@10.2.0: {}
+
+  ipaddr.js@1.9.1: {}
 
   is-alphabetical@2.0.1: {}
 
@@ -12383,6 +12786,8 @@ snapshots:
   is-plain-obj@4.1.0: {}
 
   is-potential-custom-element-name@1.0.1: {}
+
+  is-promise@4.0.0: {}
 
   is-stream@2.0.1: {}
 
@@ -12485,6 +12890,10 @@ snapshots:
   json-parse-better-errors@1.0.2: {}
 
   json-parse-even-better-errors@2.3.1: {}
+
+  json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   json-schema@0.4.0: {}
 
@@ -12820,7 +13229,11 @@ snapshots:
     dependencies:
       '@types/mdast': 4.0.4
 
+  media-typer@1.1.0: {}
+
   meow@13.2.0: {}
+
+  merge-descriptors@2.0.0: {}
 
   merge-stream@2.0.0: {}
 
@@ -13121,9 +13534,15 @@ snapshots:
 
   mime-db@1.52.0: {}
 
+  mime-db@1.54.0: {}
+
   mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
 
   mime@4.1.0: {}
 
@@ -13182,6 +13601,8 @@ snapshots:
   nanostores@1.3.0: {}
 
   napi-build-utils@2.0.0: {}
+
+  negotiator@1.0.0: {}
 
   neo-async@2.6.2: {}
 
@@ -13305,6 +13726,10 @@ snapshots:
   object-hash@3.0.0: {}
 
   object-inspect@1.13.4: {}
+
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
 
   once@1.4.0:
     dependencies:
@@ -13452,6 +13877,8 @@ snapshots:
     dependencies:
       entities: 6.0.1
 
+  parseurl@1.3.3: {}
+
   path-data-parser@0.1.0: {}
 
   path-exists@3.0.0: {}
@@ -13465,6 +13892,8 @@ snapshots:
   path-parse@1.0.7: {}
 
   path-to-regexp@6.3.0: {}
+
+  path-to-regexp@8.4.2: {}
 
   path-type@4.0.0: {}
 
@@ -13483,6 +13912,8 @@ snapshots:
   pify@3.0.0: {}
 
   pirates@4.0.7: {}
+
+  pkce-challenge@5.0.1: {}
 
   pkg-conf@2.1.0:
     dependencies:
@@ -13614,6 +14045,11 @@ snapshots:
 
   proto-list@1.2.4: {}
 
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
   pump@3.0.4:
     dependencies:
       end-of-stream: 1.4.5
@@ -13625,11 +14061,25 @@ snapshots:
     dependencies:
       side-channel: 1.1.0
 
+  qs@6.15.3:
+    dependencies:
+      es-define-property: 1.0.1
+      side-channel: 1.1.1
+
   query-selector-shadow-dom@1.0.1: {}
 
   queue-microtask@1.2.3: {}
 
   ramda@0.27.2: {}
+
+  range-parser@1.3.0: {}
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.3
+      unpipe: 1.0.0
 
   rc@1.2.8:
     dependencies:
@@ -13864,6 +14314,8 @@ snapshots:
 
   require-directory@2.1.1: {}
 
+  require-from-string@2.0.2: {}
+
   resolve-from@4.0.0: {}
 
   resolve-from@5.0.0: {}
@@ -13924,6 +14376,16 @@ snapshots:
       path-data-parser: 0.1.0
       points-on-curve: 0.2.0
       points-on-path: 0.2.1
+
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
 
   rrweb-cssom@0.7.1: {}
 
@@ -14026,9 +14488,36 @@ snapshots:
 
   semver@7.7.4: {}
 
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.3.0
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   serialize-javascript@7.0.5: {}
 
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+
   set-cookie-parser@3.1.0: {}
+
+  setprototypeof@1.2.0: {}
 
   sharp@0.33.5:
     dependencies:
@@ -14133,6 +14622,14 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  side-channel@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
+
   siginfo@2.0.0: {}
 
   signal-exit@3.0.7: {}
@@ -14205,6 +14702,8 @@ snapshots:
   sprintf-js@1.0.3: {}
 
   stackback@0.0.2: {}
+
+  statuses@2.0.2: {}
 
   std-env@3.10.0: {}
 
@@ -14499,6 +14998,8 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
+  toidentifier@1.0.1: {}
+
   tough-cookie@5.1.2:
     dependencies:
       tldts: 6.1.86
@@ -14554,6 +15055,12 @@ snapshots:
   type-fest@5.7.0:
     dependencies:
       tagged-tag: 1.0.0
+
+  type-is@2.1.0:
+    dependencies:
+      content-type: 2.0.0
+      media-typer: 1.1.0
+      mime-types: 3.0.2
 
   typescript@5.9.2: {}
 
@@ -14632,6 +15139,8 @@ snapshots:
 
   universalify@2.0.1: {}
 
+  unpipe@1.0.0: {}
+
   update-browserslist-db@1.2.3(browserslist@4.28.2):
     dependencies:
       browserslist: 4.28.2
@@ -14667,6 +15176,8 @@ snapshots:
     dependencies:
       spdx-correct: 3.2.0
       spdx-expression-parse: 3.0.1
+
+  vary@1.1.2: {}
 
   vfile-location@5.0.3:
     dependencies:
@@ -15011,6 +15522,10 @@ snapshots:
       '@speed-highlight/core': 1.2.15
       cookie: 1.1.1
       youch-core: 0.3.3
+
+  zod-to-json-schema@3.25.2(zod@4.4.3):
+    dependencies:
+      zod: 4.4.3
 
   zod@4.4.3: {}
 


### PR DESCRIPTION
## What

A new publishable package, **`packages/mcp` → `@clankersupport/mcp`**: a stdio MCP server that gives Claude Code, Codex, and any Model Context Protocol client the operator surface as tools — so developers can work their support inbox from their dev environment.

### Tools (10)

`list_workspaces` · `list_projects` · `list_conversations` (status/search) · `conversation_stats` · `get_conversation` · `reply_to_conversation` (customer-visible; description instructs agents to confirm drafts) · `add_internal_note` · `list_knowledge_sources` · `add_knowledge_source` (url/text/qa) · `search` (⌘K palette search)

### How it authenticates

The dashboard's own Better Auth email+password flow: sign in once, replay the session cookie + `x-workspace-id`, transparent re-auth on 401. Env-only config: `CLANKER_EMAIL` / `CLANKER_PASSWORD` / `CLANKER_API_URL` (self-host) / `CLANKER_WORKSPACE_ID` (optional pin; defaults to the busiest workspace).

### One API change

`trustedOrigins` in `apps/api/src/auth.ts` now also trusts the **API's own origin**. Node's `fetch` force-stamps `Sec-Fetch-*` headers, which makes Better Auth's CSRF middleware demand a trusted `Origin` on sign-in; same-origin is CSRF-safe by definition (a browser only sends `Origin: <api>` from pages the API itself serves). Covered by 4 new tests in `auth.test.ts`, including scheme/port mismatch rejection.

### Setup UX

- Claude Code: `claude mcp add clanker-support --env … -- npx -y @clankersupport/mcp` (or team-shared `.mcp.json`)
- Codex: `[mcp_servers.clanker-support]` in `~/.codex/config.toml`
- Docs: new `integrations/mcp` page in apps/docs + package README

## Testing

- 10 unit tests: client (cookie capture, 401 re-auth, workspace resolution, error surfacing, query serialization) + server over the SDK's in-memory transport (tool listing, end-to-end call, kind routing/validation, API-error shaping)
- Full api suite: 669 passed (includes the 4 new trustedOrigins tests)
- Verified end-to-end against the local seeded stack: spawned the built CLI over stdio exactly as Claude Code/Codex would — listed the Acme Tools inbox, added a QA knowledge source, searched the workspace
- `pnpm --filter @llmchat/docs build` passes with the new MDX page

## After merge

1. Deploy the api (the self-origin trust must reach prod before the connector works against `api.clankersupport.com`)
2. `pnpm publish --access public` from `packages/mcp` so `npx -y @clankersupport/mcp` resolves
3. Optional next phase: MCP Registry `server.json`, then a remote Streamable-HTTP + OAuth endpoint for the Claude.ai connectors directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)