### PR TITLE
feat(marketing): point signup CTAs at /sign-up and lead with the free trial

### DIFF
--- a/apps/marketing/src/app/blog/[slug]/page.tsx
+++ b/apps/marketing/src/app/blog/[slug]/page.tsx
@@ -8,7 +8,7 @@ import { TrackView } from "@/components/TrackView";
 import { formatDate } from "@/lib/format";
 import { breadcrumbLd, pageMeta } from "@/lib/seo";
 import { JsonLd } from "@/components/JsonLd";
-import { CANONICAL_SITE_URL } from "@/lib/site-urls";
+import { CANONICAL_SITE_URL, SIGNUP_URL } from "@/lib/site-urls";
 
 export function generateStaticParams() {
 	return allPosts.map((p) => ({ slug: p.slug }));
@@ -174,12 +174,10 @@ export default async function PostPage({
 							One script tag. Your choice of model. Live in minutes.
 						</h2>
 						<Link
-							href={
-								process.env.NEXT_PUBLIC_DASHBOARD_URL ?? "http://localhost:3001"
-							}
+							href={SIGNUP_URL}
 							className="mt-6 inline-block rounded-full bg-ink px-6 py-3 font-mono text-[0.72rem] uppercase tracking-[0.14em] text-paper transition-colors hover:bg-accent"
 						>
-							Get your support agent now
+							Start your free trial
 						</Link>
 					</div>
 				</div>

--- a/apps/marketing/src/app/compare/page.tsx
+++ b/apps/marketing/src/app/compare/page.tsx
@@ -9,10 +9,7 @@ import { TrackedLink } from "@/components/TrackedLink";
 import { FaqSection } from "@/components/FaqSection";
 import { JsonLd } from "@/components/JsonLd";
 import { breadcrumbLd, faqPageLd, pageMeta, type Faq } from "@/lib/seo";
-import { CANONICAL_SITE_URL } from "@/lib/site-urls";
-
-const dashboardUrl =
-	process.env.NEXT_PUBLIC_DASHBOARD_URL ?? "http://localhost:3001";
+import { CANONICAL_SITE_URL, SIGNUP_URL } from "@/lib/site-urls";
 
 export const metadata = pageMeta({
 	title: "AI support, compared — Clanker Support vs. the alternatives",
@@ -258,12 +255,12 @@ export default function ComparePage() {
 					</h2>
 					<div className="mt-8 flex flex-wrap justify-center gap-3">
 						<TrackedLink
-							href={dashboardUrl}
+							href={SIGNUP_URL}
 							event={ANALYTICS_EVENTS.signupStarted}
 							eventProps={{ source: "compare_cta" }}
 							className="rounded-full bg-paper px-6 py-3 font-mono text-[0.72rem] uppercase tracking-[0.14em] text-ink transition-colors hover:bg-accent hover:text-paper"
 						>
-							Get your support agent now
+							Start your free trial
 						</TrackedLink>
 						<Link
 							href="/blog"

--- a/apps/marketing/src/app/docs/migrate/[slug]/page.tsx
+++ b/apps/marketing/src/app/docs/migrate/[slug]/page.tsx
@@ -8,10 +8,7 @@ import { CodeBlock } from "@/components/CodeBlock";
 import { TrackView } from "@/components/TrackView";
 import { JsonLd } from "@/components/JsonLd";
 import { breadcrumbLd, howToLd, pageMeta } from "@/lib/seo";
-import { CANONICAL_SITE_URL, DOCS_URL } from "@/lib/site-urls";
-
-const dashboardUrl =
-	process.env.NEXT_PUBLIC_DASHBOARD_URL ?? "http://localhost:3001";
+import { CANONICAL_SITE_URL, DOCS_URL, SIGNUP_URL } from "@/lib/site-urls";
 
 export function generateStaticParams() {
 	return allMigrations.map((m) => ({ slug: m.slug }));
@@ -241,7 +238,7 @@ export default async function MigratePage({
 				{/* CTA */}
 				<section className="mt-12">
 					<Link
-						href={dashboardUrl}
+						href={SIGNUP_URL}
 						className="inline-block rounded-full bg-ink px-6 py-3 font-mono text-[0.72rem] uppercase tracking-[0.14em] text-paper transition-colors hover:bg-accent"
 					>
 						Start your migration free →

--- a/apps/marketing/src/app/features/[slug]/page.tsx
+++ b/apps/marketing/src/app/features/[slug]/page.tsx
@@ -8,10 +8,11 @@ import { JsonLd } from "@/components/JsonLd";
 import { FaqSection } from "@/components/FaqSection";
 import { FEATURES, getFeature } from "@/lib/features";
 import { breadcrumbLd, faqPageLd, pageMeta } from "@/lib/seo";
-import { CANONICAL_SHOWCASE_URL, CANONICAL_SITE_URL } from "@/lib/site-urls";
-
-const dashboardUrl =
-	process.env.NEXT_PUBLIC_DASHBOARD_URL ?? "http://localhost:3001";
+import {
+	CANONICAL_SHOWCASE_URL,
+	CANONICAL_SITE_URL,
+	SIGNUP_URL,
+} from "@/lib/site-urls";
 
 export function generateStaticParams() {
 	return FEATURES.map((f) => ({ slug: f.slug }));
@@ -99,12 +100,12 @@ export default async function FeaturePage({
 
 						<div className="animate-rise-in mt-8 flex flex-wrap gap-3 [animation-delay:200ms]">
 							<TrackedLink
-								href={dashboardUrl}
+								href={SIGNUP_URL}
 								event={ANALYTICS_EVENTS.signupStarted}
 								eventProps={{ source: "feature_page", feature: feature.slug }}
 								className="inline-flex items-center gap-2 rounded-full bg-accent px-7 py-3.5 text-sm font-semibold text-white shadow-[0_10px_30px_-8px_rgba(46,107,255,0.7)] transition-colors hover:bg-accent-deep"
 							>
-								Get your support agent now
+								Start your free trial
 								<span aria-hidden>→</span>
 							</TrackedLink>
 							<a
@@ -217,7 +218,7 @@ export default async function FeaturePage({
 							</h2>
 							<div className="mt-9 flex flex-wrap justify-center gap-3">
 								<TrackedLink
-									href={dashboardUrl}
+									href={SIGNUP_URL}
 									event={ANALYTICS_EVENTS.signupStarted}
 									eventProps={{
 										source: "feature_closing",
@@ -225,7 +226,7 @@ export default async function FeaturePage({
 									}}
 									className="inline-flex items-center gap-2 rounded-full bg-accent px-7 py-3.5 text-sm font-semibold text-white shadow-[0_10px_30px_-8px_rgba(46,107,255,0.7)] transition-colors hover:bg-accent-deep"
 								>
-									Get your support agent now
+									Start your free trial
 									<span aria-hidden>→</span>
 								</TrackedLink>
 								<Link

--- a/apps/marketing/src/app/features/page.tsx
+++ b/apps/marketing/src/app/features/page.tsx
@@ -6,10 +6,7 @@ import { TrackedLink } from "@/components/TrackedLink";
 import { JsonLd } from "@/components/JsonLd";
 import { FEATURES } from "@/lib/features";
 import { breadcrumbLd, pageMeta } from "@/lib/seo";
-import { CANONICAL_SITE_URL } from "@/lib/site-urls";
-
-const dashboardUrl =
-	process.env.NEXT_PUBLIC_DASHBOARD_URL ?? "http://localhost:3001";
+import { CANONICAL_SITE_URL, SIGNUP_URL } from "@/lib/site-urls";
 
 export const metadata = pageMeta({
 	title: "Features — what Clanker Support does",
@@ -98,12 +95,12 @@ export default function FeaturesPage() {
 							</h2>
 							<div className="mt-9 flex flex-wrap justify-center gap-3">
 								<TrackedLink
-									href={dashboardUrl}
+									href={SIGNUP_URL}
 									event={ANALYTICS_EVENTS.signupStarted}
 									eventProps={{ source: "features_hub" }}
 									className="inline-flex items-center gap-2 rounded-full bg-accent px-7 py-3.5 text-sm font-semibold text-white shadow-[0_10px_30px_-8px_rgba(46,107,255,0.7)] transition-colors hover:bg-accent-deep"
 								>
-									Get your support agent now
+									Start your free trial
 									<span aria-hidden>→</span>
 								</TrackedLink>
 								<Link

--- a/apps/marketing/src/app/page.tsx
+++ b/apps/marketing/src/app/page.tsx
@@ -216,7 +216,7 @@ export default function Home() {
 							left talking to a wall, and nothing lands in a black hole.
 						</p>
 
-						<div className="animate-rise-in mt-10 flex flex-wrap items-center justify-center gap-3 [animation-delay:200ms]">
+						<div className="animate-rise-in mt-10 [animation-delay:200ms]">
 							<ShimmerCta
 								href={SIGNUP_URL}
 								event={ANALYTICS_EVENTS.signupStarted}
@@ -225,14 +225,6 @@ export default function Home() {
 								Start your free trial
 								<span aria-hidden>→</span>
 							</ShimmerCta>
-							<TrackedLink
-								href={CANONICAL_SHOWCASE_URL}
-								event={ANALYTICS_EVENTS.ctaClicked}
-								eventProps={{ label: "live_demo", location: "home_hero" }}
-								className="inline-flex items-center gap-2 rounded-full border border-rule px-7 py-4 text-base font-medium text-ink-soft transition-colors hover:border-accent/40 hover:text-ink"
-							>
-								Chat with the live demo
-							</TrackedLink>
 						</div>
 
 						<p className="animate-rise-in mt-5 text-[0.8rem] text-faint [animation-delay:260ms]">

--- a/apps/marketing/src/app/page.tsx
+++ b/apps/marketing/src/app/page.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import { allPosts } from "content-collections";
-import { ANALYTICS_EVENTS } from "@llmchat/shared";
+import { ANALYTICS_EVENTS, TRIAL_PERIOD_DAYS } from "@llmchat/shared";
 import { SiteHeader } from "@/components/SiteHeader";
 import { SiteFooter } from "@/components/SiteFooter";
 import { TrackedLink } from "@/components/TrackedLink";
@@ -31,17 +31,16 @@ import { USE_CASES } from "@/lib/use-cases";
 import { formatDateShort } from "@/lib/format";
 import { faqPageLd, type Faq } from "@/lib/seo";
 import {
+	CANONICAL_SHOWCASE_URL,
 	CANONICAL_SITE_URL,
 	DISCORD_URL,
 	DOCS_URL,
 	GITHUB_URL,
 	RSC_PACKAGE,
+	SIGNUP_URL,
 	WORDPRESS_PLUGIN_URL,
 	X_URL,
 } from "@/lib/site-urls";
-
-const dashboardUrl =
-	process.env.NEXT_PUBLIC_DASHBOARD_URL ?? "http://localhost:3001";
 
 // Latest three posts, surfaced on the home page so fresh content is one click
 // from the root — crawlers weight link depth heavily when scheduling crawls,
@@ -187,7 +186,7 @@ export default function Home() {
 			<SiteHeader active="features" />
 
 			<main>
-				{/* ── Hero — copy locked; no client JS added ───────────── */}
+				{/* ── Hero — the offer up front: trial, risk reversal, live demo ── */}
 				<section className="relative overflow-hidden">
 					<GridPattern
 						width={44}
@@ -199,7 +198,7 @@ export default function Home() {
 						<span className="animate-rise-in inline-flex items-center gap-2 rounded-full border border-rule bg-paper-card/60 px-3 py-1 font-mono text-[0.68rem] uppercase tracking-[0.14em] text-muted">
 							<span className="size-1.5 rounded-full bg-accent shadow-[0_0_10px_2px_rgba(46,107,255,0.7)]" />
 							<AnimatedGradientText className="[--color-from:#1D4FD7] [--color-to:#2E6BFF] dark:[--color-from:#7CA2FF] dark:[--color-to:#2E6BFF]">
-								Simple monthly plans · Live in 30 seconds
+								Free for {TRIAL_PERIOD_DAYS} days · Live in minutes
 							</AnimatedGradientText>
 						</span>
 
@@ -217,16 +216,29 @@ export default function Home() {
 							left talking to a wall, and nothing lands in a black hole.
 						</p>
 
-						<div className="animate-rise-in mt-10 [animation-delay:200ms]">
+						<div className="animate-rise-in mt-10 flex flex-wrap items-center justify-center gap-3 [animation-delay:200ms]">
 							<ShimmerCta
-								href={dashboardUrl}
+								href={SIGNUP_URL}
 								event={ANALYTICS_EVENTS.signupStarted}
 								eventProps={{ source: "home_hero" }}
 							>
-								Get your support agent now
+								Start your free trial
 								<span aria-hidden>→</span>
 							</ShimmerCta>
+							<TrackedLink
+								href={CANONICAL_SHOWCASE_URL}
+								event={ANALYTICS_EVENTS.ctaClicked}
+								eventProps={{ label: "live_demo", location: "home_hero" }}
+								className="inline-flex items-center gap-2 rounded-full border border-rule px-7 py-4 text-base font-medium text-ink-soft transition-colors hover:border-accent/40 hover:text-ink"
+							>
+								Chat with the live demo
+							</TrackedLink>
 						</div>
+
+						<p className="animate-rise-in mt-5 text-[0.8rem] text-faint [animation-delay:260ms]">
+							{TRIAL_PERIOD_DAYS} days free on every plan · Cancel anytime ·
+							Open source — self-host free
+						</p>
 					</div>
 				</section>
 
@@ -485,21 +497,27 @@ export default function Home() {
 							</h2>
 							<div className="mt-10 flex flex-wrap justify-center gap-3">
 								<TrackedLink
-									href={dashboardUrl}
+									href={SIGNUP_URL}
 									event={ANALYTICS_EVENTS.signupStarted}
 									eventProps={{ source: "home_closing" }}
 									className="inline-flex items-center gap-2 rounded-full bg-accent px-7 py-3.5 text-sm font-semibold text-white shadow-[0_10px_30px_-8px_rgba(46,107,255,0.7)] transition-colors hover:bg-accent-deep"
 								>
-									Get your support agent now
+									Start your free trial
 									<span aria-hidden>→</span>
 								</TrackedLink>
-								<Link
-									href="/compare"
+								<TrackedLink
+									href={CANONICAL_SHOWCASE_URL}
+									event={ANALYTICS_EVENTS.ctaClicked}
+									eventProps={{ label: "live_demo", location: "home_closing" }}
 									className="rounded-full border border-rule px-7 py-3.5 text-sm font-medium text-ink-soft transition-colors hover:border-ink/40 hover:text-ink"
 								>
-									Compare alternatives
-								</Link>
+									Chat with the live demo
+								</TrackedLink>
 							</div>
+							<p className="mt-5 text-[0.8rem] text-faint">
+								{TRIAL_PERIOD_DAYS} days free on every plan · No charge until
+								your trial ends · Cancel anytime
+							</p>
 						</div>
 					</div>
 				</section>

--- a/apps/marketing/src/app/pricing/PricingPlans.tsx
+++ b/apps/marketing/src/app/pricing/PricingPlans.tsx
@@ -37,12 +37,12 @@ function perMonth(t: PlanCard, interval: BillingInterval): number {
 export function PricingPlans({
 	tiers,
 	enterprise,
-	dashboardUrl,
+	signupUrl,
 	salesEmail,
 }: {
 	tiers: PlanCard[];
 	enterprise: EnterpriseCard;
-	dashboardUrl: string;
+	signupUrl: string;
 	salesEmail: string;
 }) {
 	const [interval, setInterval] = useState<BillingInterval>("month");
@@ -151,7 +151,7 @@ export function PricingPlans({
 							</ul>
 
 							<TrackedLink
-								href={dashboardUrl}
+								href={signupUrl}
 								event={ANALYTICS_EVENTS.signupStarted}
 								eventProps={{
 									source: "pricing_tier",

--- a/apps/marketing/src/app/pricing/page.tsx
+++ b/apps/marketing/src/app/pricing/page.tsx
@@ -14,11 +14,13 @@ import { TrackedLink } from "@/components/TrackedLink";
 import { FaqSection } from "@/components/FaqSection";
 import { JsonLd } from "@/components/JsonLd";
 import { breadcrumbLd, faqPageLd, pageMeta, type Faq } from "@/lib/seo";
-import { CANONICAL_SITE_URL, DOCS_URL, SALES_EMAIL } from "@/lib/site-urls";
+import {
+	CANONICAL_SITE_URL,
+	DOCS_URL,
+	SALES_EMAIL,
+	SIGNUP_URL,
+} from "@/lib/site-urls";
 import { PricingPlans, type PlanCard } from "./PricingPlans";
-
-const dashboardUrl =
-	process.env.NEXT_PUBLIC_DASHBOARD_URL ?? "http://localhost:3001";
 
 const fmt = (n: number) => n.toLocaleString("en-US");
 const starterPrice = BILLING_TIERS.starter.priceUsdMonthly;
@@ -205,7 +207,7 @@ export default function PricingPage() {
 				<PricingPlans
 					tiers={hostedTiers}
 					enterprise={ENTERPRISE_TIER}
-					dashboardUrl={dashboardUrl}
+					signupUrl={SIGNUP_URL}
 					salesEmail={SALES_EMAIL}
 				/>
 
@@ -258,12 +260,12 @@ export default function PricingPage() {
 					</h2>
 					<div className="mt-8 flex flex-wrap justify-center gap-3">
 						<TrackedLink
-							href={dashboardUrl}
+							href={SIGNUP_URL}
 							event={ANALYTICS_EVENTS.signupStarted}
 							eventProps={{ source: "pricing_cta" }}
 							className="rounded-full bg-paper px-6 py-3 font-mono text-[0.72rem] uppercase tracking-[0.14em] text-ink transition-colors hover:bg-accent hover:text-paper"
 						>
-							Get your support agent now
+							Start your free trial
 						</TrackedLink>
 						<Link
 							href="/compare"

--- a/apps/marketing/src/app/templates/page.tsx
+++ b/apps/marketing/src/app/templates/page.tsx
@@ -10,11 +10,9 @@ import {
 	DOCS_URL,
 	RSC_NPM_URL,
 	RSC_PACKAGE,
+	SIGNUP_URL,
 	WORDPRESS_PLUGIN_URL,
 } from "@/lib/site-urls";
-
-const dashboardUrl =
-	process.env.NEXT_PUBLIC_DASHBOARD_URL ?? "http://localhost:3001";
 
 export const metadata = pageMeta({
 	title: "Templates — deploy the support agent in one click",
@@ -426,7 +424,7 @@ export default function TemplatesPage() {
 					</div>
 					<div className="flex shrink-0 flex-wrap gap-3">
 						<TrackedLink
-							href={dashboardUrl}
+							href={SIGNUP_URL}
 							event={ANALYTICS_EVENTS.signupStarted}
 							eventProps={{ source: "templates_cta" }}
 							className="rounded-full bg-ink px-6 py-3 font-mono text-[0.72rem] uppercase tracking-[0.14em] text-paper transition-colors hover:bg-accent"

--- a/apps/marketing/src/app/use-cases/[slug]/page.tsx
+++ b/apps/marketing/src/app/use-cases/[slug]/page.tsx
@@ -9,10 +9,11 @@ import { JsonLd } from "@/components/JsonLd";
 import { FaqSection } from "@/components/FaqSection";
 import { USE_CASES, getUseCase } from "@/lib/use-cases";
 import { breadcrumbLd, faqPageLd, pageMeta } from "@/lib/seo";
-import { CANONICAL_SHOWCASE_URL, CANONICAL_SITE_URL } from "@/lib/site-urls";
-
-const dashboardUrl =
-	process.env.NEXT_PUBLIC_DASHBOARD_URL ?? "http://localhost:3001";
+import {
+	CANONICAL_SHOWCASE_URL,
+	CANONICAL_SITE_URL,
+	SIGNUP_URL,
+} from "@/lib/site-urls";
 
 export function generateStaticParams() {
 	return USE_CASES.map((u) => ({ slug: u.slug }));
@@ -104,12 +105,12 @@ export default async function UseCasePage({
 
 						<div className="animate-rise-in mt-8 flex flex-wrap gap-3 [animation-delay:200ms]">
 							<TrackedLink
-								href={dashboardUrl}
+								href={SIGNUP_URL}
 								event={ANALYTICS_EVENTS.signupStarted}
 								eventProps={{ source: "use_case_page", useCase: useCase.slug }}
 								className="inline-flex items-center gap-2 rounded-full bg-accent px-7 py-3.5 text-sm font-semibold text-white shadow-[0_10px_30px_-8px_rgba(46,107,255,0.7)] transition-colors hover:bg-accent-deep"
 							>
-								Get your support agent now
+								Start your free trial
 								<span aria-hidden>→</span>
 							</TrackedLink>
 							<a
@@ -222,7 +223,7 @@ export default async function UseCasePage({
 							</h2>
 							<div className="mt-9 flex flex-wrap justify-center gap-3">
 								<TrackedLink
-									href={dashboardUrl}
+									href={SIGNUP_URL}
 									event={ANALYTICS_EVENTS.signupStarted}
 									eventProps={{
 										source: "use_case_closing",
@@ -230,7 +231,7 @@ export default async function UseCasePage({
 									}}
 									className="inline-flex items-center gap-2 rounded-full bg-accent px-7 py-3.5 text-sm font-semibold text-white shadow-[0_10px_30px_-8px_rgba(46,107,255,0.7)] transition-colors hover:bg-accent-deep"
 								>
-									Get your support agent now
+									Start your free trial
 									<span aria-hidden>→</span>
 								</TrackedLink>
 								<Link

--- a/apps/marketing/src/app/use-cases/page.tsx
+++ b/apps/marketing/src/app/use-cases/page.tsx
@@ -6,10 +6,7 @@ import { TrackedLink } from "@/components/TrackedLink";
 import { JsonLd } from "@/components/JsonLd";
 import { USE_CASES } from "@/lib/use-cases";
 import { breadcrumbLd, pageMeta } from "@/lib/seo";
-import { CANONICAL_SITE_URL } from "@/lib/site-urls";
-
-const dashboardUrl =
-	process.env.NEXT_PUBLIC_DASHBOARD_URL ?? "http://localhost:3001";
+import { CANONICAL_SITE_URL, SIGNUP_URL } from "@/lib/site-urls";
 
 export const metadata = pageMeta({
 	title: "Use cases — who Clanker Support is for",
@@ -108,12 +105,12 @@ export default function UseCasesPage() {
 							</p>
 							<div className="mt-9 flex flex-wrap justify-center gap-3">
 								<TrackedLink
-									href={dashboardUrl}
+									href={SIGNUP_URL}
 									event={ANALYTICS_EVENTS.signupStarted}
 									eventProps={{ source: "use_cases_hub" }}
 									className="inline-flex items-center gap-2 rounded-full bg-accent px-7 py-3.5 text-sm font-semibold text-white shadow-[0_10px_30px_-8px_rgba(46,107,255,0.7)] transition-colors hover:bg-accent-deep"
 								>
-									Get your support agent now
+									Start your free trial
 									<span aria-hidden>→</span>
 								</TrackedLink>
 								<Link

--- a/apps/marketing/src/app/vs/[slug]/page.tsx
+++ b/apps/marketing/src/app/vs/[slug]/page.tsx
@@ -10,10 +10,7 @@ import { TrackView } from "@/components/TrackView";
 import { FaqSection } from "@/components/FaqSection";
 import { JsonLd } from "@/components/JsonLd";
 import { breadcrumbLd, faqPageLd, pageMeta } from "@/lib/seo";
-import { CANONICAL_SITE_URL } from "@/lib/site-urls";
-
-const dashboardUrl =
-	process.env.NEXT_PUBLIC_DASHBOARD_URL ?? "http://localhost:3001";
+import { CANONICAL_SITE_URL, SIGNUP_URL } from "@/lib/site-urls";
 
 export function generateStaticParams() {
 	return allCompetitors.map((c) => ({ slug: c.id }));
@@ -112,12 +109,12 @@ export default async function VsPage({
 
 					<div className="mt-8 flex flex-wrap gap-3">
 						<TrackedLink
-							href={dashboardUrl}
+							href={SIGNUP_URL}
 							event={ANALYTICS_EVENTS.signupStarted}
 							eventProps={{ source: "vs_page", competitor: competitor.id }}
 							className="rounded-full bg-ink px-6 py-3 font-mono text-[0.72rem] uppercase tracking-[0.14em] text-paper transition-colors hover:bg-accent"
 						>
-							Get your support agent now →
+							Start your free trial →
 						</TrackedLink>
 						<Link
 							href="/compare"

--- a/apps/marketing/src/components/AuthButton.tsx
+++ b/apps/marketing/src/components/AuthButton.tsx
@@ -4,49 +4,69 @@ import Link from "next/link";
 
 import { useSession } from "@/lib/auth-client";
 import { track, ANALYTICS_EVENTS } from "@/lib/analytics";
-import { CANONICAL_DASHBOARD_URL } from "@/lib/site-urls";
+import { CANONICAL_DASHBOARD_URL, SIGNUP_URL } from "@/lib/site-urls";
+
+const primary =
+	"inline-flex items-center gap-1.5 rounded-full bg-accent px-4 py-2 text-sm font-medium text-white shadow-[0_8px_24px_-8px_rgba(46,107,255,0.6)] transition-colors hover:bg-accent-deep";
+const ghost =
+	"inline-flex items-center gap-1.5 text-sm font-medium text-ink-soft transition-colors hover:text-ink";
 
 /**
- * Flips between "Sign in" and "Dashboard" based on the cross-app session.
- * `variant="primary"` is the filled indigo button (header / hero); `"ghost"`
- * is a quieter inline link.
+ * Signed out: a quiet "Sign in" link plus the filled "Start free trial"
+ * button pointing at the dashboard's /sign-up page — the header's primary
+ * action is account creation, not login. Signed in: a single "Dashboard"
+ * button. "Sign in" hides on the narrowest screens so the trial CTA and the
+ * mobile nav never fight for space.
  */
-export function AuthButton({
-	variant = "primary",
-	className = "",
-}: {
-	variant?: "primary" | "ghost";
-	className?: string;
-}) {
+export function AuthButton({ className = "" }: { className?: string }) {
 	const { data, isPending } = useSession();
 	const signedIn = !!data?.user;
 
-	const href = CANONICAL_DASHBOARD_URL;
-	const label = signedIn ? "Dashboard" : "Sign in";
-	const event = signedIn
-		? ANALYTICS_EVENTS.ctaClicked
-		: ANALYTICS_EVENTS.ctaClicked;
-
-	const base =
-		variant === "primary"
-			? "inline-flex items-center gap-1.5 rounded-full bg-accent px-4 py-2 text-sm font-medium text-white shadow-[0_8px_24px_-8px_rgba(46,107,255,0.6)] transition-colors hover:bg-accent-deep"
-			: "inline-flex items-center gap-1.5 text-sm font-medium text-ink-soft transition-colors hover:text-ink";
+	if (signedIn) {
+		return (
+			<Link
+				href={CANONICAL_DASHBOARD_URL}
+				onClick={() =>
+					track(ANALYTICS_EVENTS.ctaClicked, {
+						label: "open_dashboard",
+						location: "header",
+					})
+				}
+				className={`${primary} ${className}`}
+			>
+				Dashboard
+				<span aria-hidden>↗</span>
+			</Link>
+		);
+	}
 
 	return (
-		<Link
-			href={href}
-			onClick={() =>
-				track(event, {
-					label: signedIn ? "open_dashboard" : "sign_in",
-					location: "header",
-				})
-			}
-			// Avoid a flash of the wrong label before the session resolves.
+		<span
+			className={`inline-flex items-center gap-3.5 ${className}`}
+			// Avoid a flash of the wrong actions before the session resolves.
 			data-loading={isPending ? "" : undefined}
-			className={`${base} ${className}`}
 		>
-			{label}
-			{signedIn && <span aria-hidden>↗</span>}
-		</Link>
+			<Link
+				href={CANONICAL_DASHBOARD_URL}
+				onClick={() =>
+					track(ANALYTICS_EVENTS.ctaClicked, {
+						label: "sign_in",
+						location: "header",
+					})
+				}
+				className={`${ghost} hidden min-[420px]:inline-flex`}
+			>
+				Sign in
+			</Link>
+			<Link
+				href={SIGNUP_URL}
+				onClick={() =>
+					track(ANALYTICS_EVENTS.signupStarted, { source: "header" })
+				}
+				className={primary}
+			>
+				Start free trial
+			</Link>
+		</span>
 	);
 }

--- a/apps/marketing/src/components/SiteFooter.tsx
+++ b/apps/marketing/src/components/SiteFooter.tsx
@@ -8,12 +8,10 @@ import { TOOLS } from "@/lib/tools";
 import {
 	DISCORD_URL,
 	DOCS_URL,
+	SIGNUP_URL,
 	WORDPRESS_PLUGIN_URL,
 	X_URL,
 } from "@/lib/site-urls";
-
-const dashboardUrl =
-	process.env.NEXT_PUBLIC_DASHBOARD_URL ?? "http://localhost:3001";
 
 const colHead =
 	"font-mono text-[0.68rem] uppercase tracking-[0.16em] text-faint";
@@ -41,12 +39,12 @@ export function SiteFooter() {
 							one script tag, your choice of model.
 						</p>
 						<TrackedLink
-							href={dashboardUrl}
+							href={SIGNUP_URL}
 							event={ANALYTICS_EVENTS.signupStarted}
 							eventProps={{ source: "footer" }}
 							className="mt-6 inline-block rounded-full bg-ink px-5 py-2.5 font-mono text-[0.72rem] uppercase tracking-[0.14em] text-paper transition-colors hover:bg-accent"
 						>
-							Get your support agent now
+							Start your free trial
 						</TrackedLink>
 					</div>
 

--- a/apps/marketing/src/components/home/PricingTeaser.tsx
+++ b/apps/marketing/src/components/home/PricingTeaser.tsx
@@ -1,6 +1,12 @@
 import Link from "next/link";
-import { BILLING_TIERS, TRIAL_PERIOD_DAYS } from "@llmchat/shared";
+import {
+	ANALYTICS_EVENTS,
+	BILLING_TIERS,
+	TRIAL_PERIOD_DAYS,
+} from "@llmchat/shared";
 import { ShineBorder } from "@/components/magicui/shine-border";
+import { TrackedLink } from "@/components/TrackedLink";
+import { SIGNUP_URL } from "@/lib/site-urls";
 
 /**
  * Real prices from the single source of truth (@llmchat/shared BILLING_TIERS —
@@ -60,10 +66,23 @@ export function PricingTeaser() {
 									<span className="text-sm text-muted">/month</span>
 								</div>
 								<p className="mt-2 text-sm text-muted">{t.blurb}</p>
-								<p className="mt-4 text-sm text-ink-soft">
+								<p className="mt-4 flex-1 text-sm text-ink-soft">
 									{tier.maxResponsesPerMonth.toLocaleString("en-US")} AI
 									responses / month included
 								</p>
+								<TrackedLink
+									href={SIGNUP_URL}
+									event={ANALYTICS_EVENTS.signupStarted}
+									eventProps={{ source: "home_pricing_teaser", plan: t.plan }}
+									className={`mt-6 inline-flex items-center justify-center gap-2 rounded-full px-5 py-2.5 text-sm font-semibold transition-colors ${
+										t.featured
+											? "bg-accent text-white shadow-[0_10px_30px_-8px_rgba(46,107,255,0.7)] hover:bg-accent-deep"
+											: "border border-rule text-ink-soft hover:border-accent/40 hover:text-ink"
+									}`}
+								>
+									Start free trial
+									<span aria-hidden>→</span>
+								</TrackedLink>
 							</div>
 						);
 					})}

--- a/apps/marketing/src/components/tools/ToolPage.tsx
+++ b/apps/marketing/src/components/tools/ToolPage.tsx
@@ -10,10 +10,7 @@ import { JsonLd } from "@/components/JsonLd";
 import { FaqSection } from "@/components/FaqSection";
 import { TOOLS, type Tool } from "@/lib/tools";
 import { breadcrumbLd, faqPageLd, webApplicationLd } from "@/lib/seo";
-import { CANONICAL_SITE_URL } from "@/lib/site-urls";
-
-const dashboardUrl =
-	process.env.NEXT_PUBLIC_DASHBOARD_URL ?? "http://localhost:3001";
+import { CANONICAL_SITE_URL, SIGNUP_URL } from "@/lib/site-urls";
 
 /**
  * Shared shell for every /tools page: JSON-LD (WebApplication + FAQPage +
@@ -154,12 +151,12 @@ export function ToolPage({
 							</p>
 							<div className="mt-9 flex flex-wrap justify-center gap-3">
 								<TrackedLink
-									href={dashboardUrl}
+									href={SIGNUP_URL}
 									event={ANALYTICS_EVENTS.signupStarted}
 									eventProps={{ source: "tool_page", tool: tool.slug }}
 									className="inline-flex items-center gap-2 rounded-full bg-accent px-7 py-3.5 text-sm font-semibold text-white shadow-[0_10px_30px_-8px_rgba(46,107,255,0.7)] transition-colors hover:bg-accent-deep"
 								>
-									Get your support agent now
+									Start your free trial
 									<span aria-hidden>→</span>
 								</TrackedLink>
 								<Link

--- a/apps/marketing/src/lib/site-urls.ts
+++ b/apps/marketing/src/lib/site-urls.ts
@@ -9,6 +9,11 @@ export const CANONICAL_DASHBOARD_URL =
 export const CANONICAL_SHOWCASE_URL =
 	process.env.NEXT_PUBLIC_SHOWCASE_URL ?? "http://localhost:3003";
 
+/** Where every signup CTA lands. Deep-links to the dashboard's /sign-up page —
+ * the dashboard root redirects signed-out visitors to the sign-in form, which
+ * is a funnel dead-end for someone who just clicked "start free trial". */
+export const SIGNUP_URL = `${CANONICAL_DASHBOARD_URL}/sign-up`;
+
 /** The marketing site's own canonical origin — the base for metadataBase,
  * canonical tags, the sitemap, and robots. Falls back to the production host
  * (this site *is* clankersupport.com) so SEO URLs are absolute even when


### PR DESCRIPTION
## What

Fixes the signup funnel: visitors were reaching the marketing site but not signing up. The biggest leak — every signup CTA pointed at the dashboard **root**, which redirects signed-out visitors to the **sign-in** form (a dead end for someone without an account). On top of that, the 7-day free trial was buried below the fold and the header's only button was "Sign in".

## Changes

- **`SIGNUP_URL`** in `site-urls.ts` — all 19 signup CTAs across 14 files (home, pricing, compare, features, use-cases, vs pages, blog, templates, migration guides, tools, footer) now deep-link to the dashboard's `/sign-up` page
- **Hero leads with the offer**: badge "Free for 7 days · Live in minutes" (`TRIAL_PERIOD_DAYS` from `@llmchat/shared` — can't drift from Stripe), single "Start your free trial" CTA, risk-reversal microcopy underneath ("7 days free on every plan · Cancel anytime · Open source — self-host free")
- **Header**: signed-out visitors get a filled "Start free trial" button; "Sign in" demoted to a ghost link. Signed-in users keep the "Dashboard" button
- **Home pricing teaser**: per-tier "Start free trial" buttons — the first mid-page conversion point
- **Closing band**: same offer treatment, secondary link swapped to the live showcase demo
- All claims honest: the card *is* collected at checkout, so no "no credit card required" anywhere

## Analytics

Contract preserved — every CTA keeps its `signup_started` event and source props, with new sources (`header`, `home_pricing_teaser`) and `cta_clicked` on the demo link, so existing PostHog funnels keep working and the new touchpoints are measurable.

## Testing

- Marketing suite 42/42, prettier + oxlint clean, `tsc --noEmit` (only pre-existing `seo.test.ts` errors that exist on main)
- Booted the full dev stack, smoke-tested every touched route (all 200), and drove the real flow in a browser: hero CTA → lands on **Create your account**
- Demo recording of the converting path was shared in-session

🤖 Generated with [Claude Code](https://claude.com/claude-code)