### PR TITLE
feat(api): 0025 — usage_event.kind discriminator (#98 PR-A)

### DIFF
--- a/apps/api/migrations/0025_usage_event_kind.sql
+++ b/apps/api/migrations/0025_usage_event_kind.sql
@@ -1,0 +1,21 @@
+-- Suggest-with-AI (#98, R4): discriminate usage_event row classes so operator-side
+-- AI drafts can be RECORDED without being COUNTED as visitor responses.
+-- monthlyResponseCount (lib/plan.ts) counts every row for the workspace this
+-- month; without this column a suggestion row would consume the customer's
+-- included visitor quota (402 message_limit_reached silences their LIVE widget
+-- earlier on fixed tiers) and show phantom overage in the billing UI. 'chat' is
+-- the correct backfill for every historical row: the table has had exactly ONE
+-- production writer since introduction — the /v1/chat post-stream metering
+-- (routes/chat.ts) — so pre-0025 rows are all genuinely visitor-chat responses.
+--
+-- PHASE 1 of 2 (deliberate migrate-before-serve split, mirroring 0014/0015 and
+-- 0022). This PR ships ONLY the column — schema.ts is intentionally NOT changed.
+-- Unlike 0022 the hazard here is WRITE-side, not read-side: every usage_event
+-- reader is a projected select (none would name `kind`), but a schema field
+-- would appear in INSERTs. The follow-up PR therefore declares the field with a
+-- SQL-level .default("chat") (never $defaultFn), so the existing chat writer
+-- keeps omitting the column and only the new suggest endpoint's own insert names
+-- it — after this column is live in prod. The suggest endpoint, the
+-- kind='chat' quota filters (lib/plan.ts, routes/projects.ts), and the dashboard
+-- UI all land in that follow-up.
+ALTER TABLE usage_event ADD COLUMN kind text NOT NULL DEFAULT 'chat';

--- a/apps/api/src/migration-0025-usage-event-kind.test.ts
+++ b/apps/api/src/migration-0025-usage-event-kind.test.ts
@@ -1,0 +1,139 @@
+// Contract test for migrations/0025_usage_event_kind.sql (#98 PR-A, the
+// migrate-before-serve half): the `kind` discriminator that lets operator-side
+// AI-suggestion usage be RECORDED without being COUNTED as a visitor response.
+// Pins the three properties the follow-up PR's code will rely on: (1) every
+// pre-0025 row backfills to 'chat' (they are all /v1/chat responses — the
+// table's only historical writer), (2) an insert that omits `kind` still gets
+// 'chat' (the live chat writer never names the column, so it stays compatible
+// across the deploy window), and (3) the quota query shape the follow-up adds
+// (`WHERE kind = 'chat'`) excludes suggestion rows.
+
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+
+import { beforeEach, describe, expect, it } from "vitest";
+
+const MIGRATIONS_DIR = join(process.cwd(), "migrations");
+const FILE_0025 = "0025_usage_event_kind.sql";
+
+function migrationSql(file: string): string {
+	return readFileSync(join(MIGRATIONS_DIR, file), "utf8")
+		.split("--> statement-breakpoint")
+		.join("\n");
+}
+
+function applyMigrationsBefore0025(sqlite: DatabaseSync) {
+	sqlite.exec("PRAGMA foreign_keys=OFF;");
+	for (const f of readdirSync(MIGRATIONS_DIR)
+		.filter((x) => x.endsWith(".sql"))
+		.sort()) {
+		if (f >= "0025") continue;
+		sqlite.exec(migrationSql(f));
+	}
+}
+
+// A pre-0025 usage row: the shape the sole production writer (chat.ts) emits —
+// messageId always "", costUsd always 0.
+function seedPreColumnRow(sqlite: DatabaseSync) {
+	sqlite.exec("PRAGMA foreign_keys=OFF;");
+	sqlite.exec(`
+INSERT INTO usage_event (id, workspace_id, project_id, conversation_id, message_id, model, prompt_tokens, completion_tokens, cost_usd, created_at)
+VALUES ('u1', 'ws', 'p', 'c', '', 'gpt-5.4-mini', 100, 50, 0, 1750000000);
+`);
+}
+
+let sqlite: DatabaseSync;
+
+beforeEach(() => {
+	sqlite = new DatabaseSync(":memory:");
+	applyMigrationsBefore0025(sqlite);
+	seedPreColumnRow(sqlite);
+});
+
+describe("0025 — usage_event.kind discriminator", () => {
+	it("adds kind NOT NULL DEFAULT 'chat' and backfills every existing row to 'chat'", () => {
+		sqlite.exec(migrationSql(FILE_0025));
+		const col = (
+			sqlite.prepare("PRAGMA table_info(usage_event)").all() as {
+				name: string;
+				notnull: number;
+				dflt_value: string | null;
+			}[]
+		).find((c) => c.name === "kind");
+		expect(col).toBeDefined();
+		expect(col!.notnull).toBe(1);
+		expect(col!.dflt_value).toBe("'chat'");
+		const row = sqlite
+			.prepare("SELECT kind FROM usage_event WHERE id = 'u1'")
+			.get() as { kind: string };
+		expect(row.kind).toBe("chat");
+	});
+
+	it("a kind-omitting insert (the live chat writer) still lands as 'chat'; explicit 'suggestion' works", () => {
+		sqlite.exec(migrationSql(FILE_0025));
+		sqlite.exec(`
+INSERT INTO usage_event (id, workspace_id, project_id, conversation_id, message_id, model, prompt_tokens, completion_tokens, cost_usd, created_at)
+VALUES ('u2', 'ws', 'p', 'c', '', 'gpt-5.4-mini', 10, 5, 0, 1750000100);
+INSERT INTO usage_event (id, workspace_id, project_id, conversation_id, message_id, model, prompt_tokens, completion_tokens, cost_usd, created_at, kind)
+VALUES ('u3', 'ws', 'p', 'c', '', 'gpt-5.4-mini', 10, 5, 0, 1750000200, 'suggestion');
+`);
+		const kinds = (
+			sqlite.prepare("SELECT id, kind FROM usage_event ORDER BY id").all() as {
+				id: string;
+				kind: string;
+			}[]
+		).map((r) => `${r.id}=${r.kind}`);
+		expect(kinds).toEqual(["u1=chat", "u2=chat", "u3=suggestion"]);
+	});
+
+	it("the follow-up's quota query shape (WHERE kind='chat') excludes suggestion rows", () => {
+		sqlite.exec(migrationSql(FILE_0025));
+		sqlite.exec(`
+INSERT INTO usage_event (id, workspace_id, project_id, conversation_id, message_id, model, prompt_tokens, completion_tokens, cost_usd, created_at, kind)
+VALUES ('s1', 'ws', 'p', 'c', '', 'gpt-5.4-mini', 10, 5, 0, 1750000300, 'suggestion'),
+       ('s2', 'ws', 'p', 'c', '', 'gpt-5.4-mini', 10, 5, 0, 1750000400, 'suggestion');
+`);
+		const { all, chatOnly } = {
+			all: (
+				sqlite
+					.prepare(
+						"SELECT COUNT(*) AS n FROM usage_event WHERE workspace_id = 'ws'",
+					)
+					.get() as { n: number }
+			).n,
+			chatOnly: (
+				sqlite
+					.prepare(
+						"SELECT COUNT(*) AS n FROM usage_event WHERE workspace_id = 'ws' AND kind = 'chat'",
+					)
+					.get() as { n: number }
+			).n,
+		};
+		expect(all).toBe(3);
+		expect(chatOnly).toBe(1); // only the pre-column backfilled row
+	});
+
+	it("full-chain 0000→0025 applies clean on a fresh database (new deploys / self-hosters)", () => {
+		const clean = new DatabaseSync(":memory:");
+		clean.exec("PRAGMA foreign_keys=OFF;");
+		for (const f of readdirSync(MIGRATIONS_DIR)
+			.filter((x) => x.endsWith(".sql"))
+			.sort()) {
+			clean.exec(migrationSql(f));
+		}
+		const cols = (
+			clean.prepare("PRAGMA table_info(usage_event)").all() as {
+				name: string;
+			}[]
+		).map((c) => c.name);
+		expect(cols).toContain("kind");
+		expect(
+			(
+				clean.prepare("SELECT COUNT(*) AS n FROM usage_event").get() as {
+					n: number;
+				}
+			).n,
+		).toBe(0);
+	});
+});


### PR DESCRIPTION
## Suggest-with-AI #98 — PR-A: `usage_event.kind` discriminator (migration only)

Phase 1 of the migrate-before-serve split (0014/0015 + 0022 precedent), per the approved Phase-1 report (`docs/goals/98-suggest-with-ai-phase1.md`, rides with PR-B).

### The one statement

```sql
ALTER TABLE usage_event ADD COLUMN kind text NOT NULL DEFAULT 'chat';
```

**Why it's required (R4):** `monthlyResponseCount` (lib/plan.ts:143-151) counts every `usage_event` row for the workspace this month — no discriminator exists. The upcoming operator-side suggest endpoint must **record** its token usage without **counting** it as a visitor response; without this column a suggestion row would consume the customer's included quota (`isResponseBlocked` → 402 `message_limit_reached` silences their live widget earlier on fixed tiers) and show phantom overage in `PlanUsageCard`.

**Why `DEFAULT 'chat'` is the correct backfill:** the table has exactly one production writer since introduction — the `/v1/chat` post-stream metering (git-verified in Phase 1) — so every historical row is genuinely a visitor-chat response.

**Why schema.ts is untouched here:** the hazard is *write-side* (every reader is a projected select — Phase-1 census verified zero `db.query.usageEvent.*`). PR-B declares the field with a SQL-level `.default("chat")` (never `$defaultFn`) so the existing chat writer keeps omitting the column; only the new suggest endpoint's own insert names it — after this column is live in prod.

### Contract test (4 tests, green)

1. Column added `NOT NULL DEFAULT 'chat'`; existing rows backfill to `'chat'`.
2. A kind-omitting insert (the live chat writer's shape) still lands `'chat'`; explicit `'suggestion'` works.
3. The follow-up's quota query shape (`WHERE kind='chat'`) excludes suggestion rows.
4. Full-chain 0000→0025 applies clean on a fresh DB (new deploys / self-hosters).

### Gates

- `pnpm test` — 8/8 packages green (incl. the new contract test)
- `pnpm lint` — green
- Migration SQL byte-exact to the pre-approved statement

**Pre-approved to merge** on green gates + exact SQL (Omar, 2026-07-25). After prod deploy verifies, PR-B (`feat/98-suggest-with-ai`) branches from updated main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018pJJgDHCnnNeEqEAApxFcQ
