### PR TITLE
fix(voice): default the gateway base URL when the env var is unset

### DIFF
--- a/apps/api/src/routes/voice.test.ts
+++ b/apps/api/src/routes/voice.test.ts
@@ -176,6 +176,36 @@ describe("POST /voice/session — Scale-only realtime voice", () => {
 		);
 	});
 
+	it("falls back to the default gateway base when LLMGATEWAY_BASE_URL is unset", async () => {
+		// Prod regression: the env var was missing and the undefined dereference
+		// 500'd the route while chat kept working on the provider's own default.
+		const fetchMock = mockMint();
+		mockDb();
+		setPlan("scale");
+		const { ctx } = makeCtx();
+		const envWithoutBase = {
+			vars: { LLMGATEWAY_API_KEY: "llmgw_test" },
+			DB: {},
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		} as any;
+		const res = await voice.request(
+			"/voice/session",
+			{
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify({ projectKey: "pk_live", clientId: "c1" }),
+			},
+			envWithoutBase,
+			ctx as unknown as CtxArg,
+		);
+		expect(res.status).toBe(200);
+		const [url] = fetchMock.mock.calls[0] as unknown as [string];
+		expect(url).toBe("https://api.llmgateway.io/v1/realtime/client_secrets");
+		expect(((await res.json()) as { url: string }).url).toBe(
+			"wss://api.llmgateway.io/v1/realtime?model=gpt-realtime",
+		);
+	});
+
 	it("accepts the nested { client_secret: { value } } mint response shape", async () => {
 		mockMint({ client_secret: { value: "ek_nested", expires_at: 42 } });
 		mockDb();

--- a/apps/api/src/routes/voice.ts
+++ b/apps/api/src/routes/voice.ts
@@ -45,6 +45,13 @@ const REALTIME_MODEL = "gpt-realtime";
 // Default output voice (gateway/OpenAI catalog).
 const REALTIME_VOICE = "marin";
 
+// Fallback when LLMGATEWAY_BASE_URL is unset in the runtime env — the same
+// default the AI SDK provider applies for chat, so voice and chat can never
+// disagree about where the gateway lives. (Prod initially shipped without the
+// var; chat kept working on the provider default while this route 500'd on
+// the undefined dereference.)
+const DEFAULT_GATEWAY_BASE = "https://api.llmgateway.io/v1";
+
 // Voice sessions cost realtime-audio money on the shared operator key (the
 // gateway's default per-session spend cap alone is $10), so the budgets are far
 // tighter than chat's 20/hr — and FAIL CLOSED, like the integration-action
@@ -167,7 +174,9 @@ export const voice = new Hono<AppContext>().post(
 
 		// Mint the ephemeral client secret server-to-server. The base URL
 		// already carries /v1 (see .env.example), same as the chat provider.
-		const base = c.env.vars.LLMGATEWAY_BASE_URL.replace(/\/$/, "");
+		const base = (
+			c.env.vars.LLMGATEWAY_BASE_URL || DEFAULT_GATEWAY_BASE
+		).replace(/\/$/, "");
 		let minted: {
 			value?: unknown;
 			expires_at?: unknown;


### PR DESCRIPTION
- prod shipped without LLMGATEWAY_BASE_URL; chat kept working on the AI SDK provider's built-in default while /v1/voice/session 500'd dereferencing undefined
- fall back to https://api.llmgateway.io/v1 (the provider's default) for the mint URL and the derived wss URL
- regression test pins the fallback