### PR TITLE
fix(voice): gate mic frames against speaker echo of the agent's own v…

### DIFF
--- a/packages/widget/src/voice-call.test.ts
+++ b/packages/widget/src/voice-call.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
 	floatToPcm16Base64,
+	frameRms,
 	pcm16Base64ToFloat,
 	resampleLinear,
 	REALTIME_SAMPLE_RATE,
@@ -63,5 +64,27 @@ describe("resampleLinear", () => {
 	it("handles the empty buffer without dividing by zero", () => {
 		const out = resampleLinear(new Float32Array(0), 48_000, 24_000);
 		expect(out.length).toBe(0);
+	});
+});
+
+describe("frameRms", () => {
+	it("is 0 for silence and empty frames", () => {
+		expect(frameRms(new Float32Array(0))).toBe(0);
+		expect(frameRms(new Float32Array(512))).toBe(0);
+	});
+
+	it("measures a constant signal's level exactly", () => {
+		expect(frameRms(new Float32Array(256).fill(0.5))).toBeCloseTo(0.5, 6);
+		expect(frameRms(new Float32Array(256).fill(-0.5))).toBeCloseTo(0.5, 6);
+	});
+
+	it("separates deliberate speech from quiet echo around the gate level", () => {
+		// A full-scale sine (deliberate, close speech) sits at ~0.707 RMS —
+		// far above the 0.07 gate; a -32 dBFS-ish murmur sits below it.
+		const loud = Float32Array.from({ length: 480 }, (_, i) =>
+			Math.sin((i / 480) * 2 * Math.PI * 10),
+		);
+		expect(frameRms(loud)).toBeGreaterThan(0.07);
+		expect(frameRms(new Float32Array(480).fill(0.02))).toBeLessThan(0.07);
 	});
 });

--- a/packages/widget/src/voice-call.ts
+++ b/packages/widget/src/voice-call.ts
@@ -17,6 +17,29 @@ export const REALTIME_SAMPLE_RATE = 24_000;
 // keep the event loop light, small enough for conversational latency.
 const CAPTURE_BUFFER_SIZE = 4096;
 
+// Half-duplex echo gate. The agent's voice plays through WebAudio, which
+// Chrome's echo canceller does NOT cancel (it only covers WebRTC/media-element
+// output) — so on speakers the mic hears the agent back, server VAD reads the
+// echo as visitor speech, barges in on the answer, and the model ends up
+// responding to a garbled recording of itself. While agent audio is playing,
+// only frames at least this loud (RMS) pass — a deliberate, close-to-the-mic
+// interruption clears it; speaker echo and room noise don't. Off-air (agent
+// silent) every frame passes, so normal turns lose nothing.
+const BARGE_IN_RMS = 0.07;
+
+/** Root-mean-square level of a capture frame — the loudness measure behind the
+ * barge-in gate. 0 for an empty frame. Exported for tests. */
+export function frameRms(samples: Float32Array): number {
+	if (samples.length === 0) {
+		return 0;
+	}
+	let sum = 0;
+	for (let i = 0; i < samples.length; i++) {
+		sum += samples[i] * samples[i];
+	}
+	return Math.sqrt(sum / samples.length);
+}
+
 export interface VoiceSessionInfo {
 	url: string;
 	clientSecret: string;
@@ -217,9 +240,7 @@ export class VoiceCallClient {
 										type: "audio/pcm",
 										rate: REALTIME_SAMPLE_RATE,
 									},
-									...(this.session.voice
-										? { voice: this.session.voice }
-										: {}),
+									...(this.session.voice ? { voice: this.session.voice } : {}),
 								},
 							},
 						},
@@ -302,6 +323,14 @@ export class VoiceCallClient {
 				return;
 			}
 			const captured = e.inputBuffer.getChannelData(0);
+			// Echo gate (see BARGE_IN_RMS): while the agent is audibly speaking,
+			// drop frames that aren't loud enough to be a deliberate barge-in —
+			// otherwise the speaker echo of the agent's own voice re-enters the
+			// pipeline as "visitor speech" and derails the conversation.
+			const agentSpeaking = (this.ctx?.currentTime ?? 0) < this.nextPlayTime;
+			if (agentSpeaking && frameRms(captured) < BARGE_IN_RMS) {
+				return;
+			}
 			const resampled = resampleLinear(
 				captured,
 				this.ctx?.sampleRate ?? REALTIME_SAMPLE_RATE,
@@ -357,8 +386,7 @@ export class VoiceCallClient {
 				// additionally surface via onclose.
 				console.warn(
 					"clanker voice: realtime error event",
-					(event as { error?: { message?: string } }).error?.message ??
-						e.data,
+					(event as { error?: { message?: string } }).error?.message ?? e.data,
 				);
 				break;
 			}


### PR DESCRIPTION
…oice

- Chrome's echo canceller doesn't cover WebAudio output, so on speakers the mic feeds the agent's voice back in: server VAD reads the echo as speech, barges in, and the model answers a garbled recording of itself (off-domain hallucinated replies)
- half-duplex gate: while agent audio is playing, only frames above a barge-in RMS threshold pass; off-air capture is unchanged
- frameRms helper + tests