### PR TITLE
fix(voice): ground every call — voice-sized instruction budget + fail-closed client setup

### DIFF
--- a/apps/api/src/lib/llm.ts
+++ b/apps/api/src/lib/llm.ts
@@ -51,7 +51,9 @@ export interface LlmCallInput {
 
 // Cap aggregate source content to keep system prompts bounded. ~80k chars
 // ≈ 20k tokens — well below typical 128k context windows but leaves room
-// for knowledge base + conversation history.
+// for knowledge base + conversation history. Text-path default; the voice
+// mint passes its own far smaller budget (realtime instructions are hard-
+// capped upstream at 16,384 tokens — see routes/voice.ts).
 const MAX_SOURCES_CHARS = 80_000;
 
 /**
@@ -249,6 +251,10 @@ export function buildSystem(
 	// exact same knowledge/sources/identity assembly below — one assembler, two
 	// audiences, never two diverging copies of the KB rendering.
 	basePrompt: string = SUPPORT_AGENT_BASE_PROMPT,
+	// Aggregate source budget. The voice mint passes a much smaller number
+	// (its instructions must clear the realtime API's 16,384-token cap) while
+	// reusing this exact even-split — one budgeting discipline, two sizes.
+	maxSourcesChars: number = MAX_SOURCES_CHARS,
 ) {
 	// Base guardrail FIRST, operator prompt second: the scaffold defines the job
 	// (support only), the operator prompt customizes persona/business within it.
@@ -263,7 +269,7 @@ export function buildSystem(
 	if (usable.length > 0) {
 		// Distribute the budget across sources so a single huge page can't
 		// crowd out the rest.
-		const perSource = Math.floor(MAX_SOURCES_CHARS / usable.length);
+		const perSource = Math.floor(maxSourcesChars / usable.length);
 		const rendered = usable
 			.map((s, i) => {
 				const body =

--- a/apps/api/src/routes/voice.test.ts
+++ b/apps/api/src/routes/voice.test.ts
@@ -8,7 +8,13 @@ import { captureEvent } from "@/lib/posthog";
 
 import { planEntitlements } from "@llmchat/shared";
 
-import { voice } from "./voice";
+import {
+	boundVoiceInstructions,
+	estimateRealtimeTokens,
+	voice,
+	VOICE_CALL_STYLE_PROMPT,
+	VOICE_TOKEN_CEILING,
+} from "./voice";
 
 vi.mock("@/lib/db", () => ({ db: vi.fn() }));
 vi.mock("@/lib/kv", () => ({
@@ -42,13 +48,18 @@ const project = {
 function mockDb({
 	hasProject = true,
 	conv = null as Record<string, unknown> | null,
+	sources = [] as Record<string, unknown>[],
+	projectOverrides = {} as Record<string, unknown>,
 } = {}) {
 	const inserted: unknown[] = [];
 	vi.mocked(db).mockReturnValue({
 		query: {
-			project: { findFirst: async () => (hasProject ? project : undefined) },
+			project: {
+				findFirst: async () =>
+					hasProject ? { ...project, ...projectOverrides } : undefined,
+			},
 			systemPrompt: { findFirst: async () => undefined },
-			source: { findMany: async () => [] },
+			source: { findMany: async () => sources },
 			conversation: { findFirst: async () => conv ?? undefined },
 		},
 		insert: () => ({
@@ -274,5 +285,124 @@ describe("POST /voice/session — Scale-only realtime voice", () => {
 		const { ctx } = makeCtx();
 		const res = await send(ctx);
 		expect(res.status).toBe(429);
+	});
+});
+
+describe("voice instruction budget — the realtime 16,384-token cap (item 0)", () => {
+	async function mintInstructions(opts: Parameters<typeof mockDb>[0]) {
+		// Earlier describes leave ok:false implementations on the gate mocks
+		// (clearAllMocks clears calls, not implementations) — re-prime them.
+		vi.mocked(rateLimit).mockResolvedValue({ ok: true, remaining: 1 });
+		vi.mocked(publicLookupRateLimit).mockResolvedValue({
+			ok: true,
+			remaining: 1,
+		});
+		mockMint();
+		mockDb(opts);
+		setPlan("scale");
+		const { ctx } = makeCtx();
+		const res = await send(ctx);
+		expect(res.status).toBe(200);
+		return ((await res.json()) as { instructions: string }).instructions;
+	}
+
+	it("keeps 80k of source content under the token ceiling via the voice even-split", async () => {
+		// The text path's worst case: 8 sources × 10k chars = 80k, which the old
+		// assembly shipped whole (~20k tokens — upstream rejects >16,384 and the
+		// call ran ungrounded). The voice budget must split floor(16000/8) =
+		// 2000 chars per source.
+		const sources = Array.from({ length: 8 }, (_, i) => ({
+			title: `Doc ${i}`,
+			url: `https://acme.test/${i}`,
+			content: `S${i}-${"x".repeat(9_980)}-TAIL${i}`,
+			active: true,
+		}));
+		const instructions = await mintInstructions({ sources });
+		expect(estimateRealtimeTokens(instructions)).toBeLessThanOrEqual(
+			VOICE_TOKEN_CEILING,
+		);
+		// Every source keeps its head (even split — no source crowds out another)…
+		expect(instructions).toContain("S0-");
+		expect(instructions).toContain("S7-");
+		// …and none ships past its floor(16000/8)=2000-char share.
+		for (let i = 0; i < 8; i++) {
+			expect(instructions).not.toContain(`TAIL${i}`);
+		}
+		// The spoken-delivery addendum always survives.
+		expect(instructions).toContain("# Voice call");
+	});
+
+	it("hard-slices knowledgeText for voice (uncapped on the text path)", async () => {
+		const instructions = await mintInstructions({
+			projectOverrides: {
+				knowledgeText: `${"k".repeat(8_000)}KNOWLEDGE-OVERFLOW`,
+			},
+		});
+		expect(instructions).not.toContain("KNOWLEDGE-OVERFLOW");
+		expect(estimateRealtimeTokens(instructions)).toBeLessThanOrEqual(
+			VOICE_TOKEN_CEILING,
+		);
+	});
+
+	it("backstop: truncates over-ceiling instructions at mint and logs a content-free counter", async () => {
+		// A giant operator prompt has no layer-1 budget of its own — the token
+		// backstop is what guarantees the mint NEVER ships instructions it
+		// expects the session to reject.
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const instructions = await mintInstructions({
+			projectOverrides: { systemPrompt: "y".repeat(60_000) },
+		});
+		expect(estimateRealtimeTokens(instructions)).toBeLessThanOrEqual(
+			VOICE_TOKEN_CEILING,
+		);
+		// Deterministic truncation preserves the spoken-delivery addendum whole.
+		expect(instructions.endsWith(VOICE_CALL_STYLE_PROMPT)).toBe(true);
+		// The counter fires exactly once and never carries prompt content.
+		const truncationWarns = warn.mock.calls.filter(
+			(c) => typeof c[0] === "string" && c[0].includes("over token ceiling"),
+		);
+		expect(truncationWarns).toHaveLength(1);
+		expect(String(truncationWarns[0][0])).not.toContain("yyy");
+		warn.mockRestore();
+	});
+});
+
+describe("estimateRealtimeTokens / boundVoiceInstructions (pure)", () => {
+	it("estimates ASCII at ~4 chars/token and non-ASCII at a full token each", () => {
+		expect(estimateRealtimeTokens("")).toBe(0);
+		expect(estimateRealtimeTokens("abcd")).toBe(1);
+		expect(estimateRealtimeTokens("abcde")).toBe(2);
+		expect(estimateRealtimeTokens("支支支")).toBe(3);
+		expect(estimateRealtimeTokens("ab支")).toBe(2);
+	});
+
+	it("passes under-ceiling instructions through untouched", () => {
+		const r = boundVoiceInstructions("base prompt", "# Voice call");
+		expect(r).toEqual({
+			instructions: "base prompt\n\n# Voice call",
+			truncated: false,
+			estimatedTokens: estimateRealtimeTokens("base prompt\n\n# Voice call"),
+		});
+	});
+
+	it("truncates deterministically to the ceiling, keeping the addendum whole", () => {
+		const base = "z".repeat(60_000); // est 15k tokens — over the 12,288 ceiling
+		const addendum = "# Voice call\nSpeak naturally.";
+		const a = boundVoiceInstructions(base, addendum);
+		const b = boundVoiceInstructions(base, addendum);
+		expect(a).toEqual(b); // same input, same output — deterministic
+		expect(a.truncated).toBe(true);
+		expect(a.estimatedTokens).toBeLessThanOrEqual(VOICE_TOKEN_CEILING);
+		// The walk fills the budget rather than wildly undershooting it…
+		expect(a.estimatedTokens).toBeGreaterThanOrEqual(VOICE_TOKEN_CEILING - 2);
+		// …and the addendum survives whole at the tail.
+		expect(a.instructions.endsWith(`\n\n${addendum}`)).toBe(true);
+	});
+
+	it("handles token-dense (non-ASCII) bases with the same guarantee", () => {
+		const a = boundVoiceInstructions("支".repeat(20_000), "# Voice call");
+		expect(a.truncated).toBe(true);
+		expect(a.estimatedTokens).toBeLessThanOrEqual(VOICE_TOKEN_CEILING);
+		expect(a.instructions.endsWith("# Voice call")).toBe(true);
 	});
 });

--- a/apps/api/src/routes/voice.test.ts
+++ b/apps/api/src/routes/voice.test.ts
@@ -368,10 +368,11 @@ describe("voice instruction budget — the realtime 16,384-token cap (item 0)", 
 });
 
 describe("estimateRealtimeTokens / boundVoiceInstructions (pure)", () => {
-	it("estimates ASCII at ~4 chars/token and non-ASCII at a full token each", () => {
+	it("estimates ASCII at 3 chars/token (dense-ASCII bias) and non-ASCII at a full token each", () => {
 		expect(estimateRealtimeTokens("")).toBe(0);
-		expect(estimateRealtimeTokens("abcd")).toBe(1);
-		expect(estimateRealtimeTokens("abcde")).toBe(2);
+		expect(estimateRealtimeTokens("abc")).toBe(1);
+		expect(estimateRealtimeTokens("abcd")).toBe(2);
+		expect(estimateRealtimeTokens("abcdef")).toBe(2);
 		expect(estimateRealtimeTokens("支支支")).toBe(3);
 		expect(estimateRealtimeTokens("ab支")).toBe(2);
 	});
@@ -404,5 +405,19 @@ describe("estimateRealtimeTokens / boundVoiceInstructions (pure)", () => {
 		expect(a.truncated).toBe(true);
 		expect(a.estimatedTokens).toBeLessThanOrEqual(VOICE_TOKEN_CEILING);
 		expect(a.instructions.endsWith("# Voice call")).toBe(true);
+	});
+
+	it("never cuts between the halves of a surrogate pair", () => {
+		// An all-emoji base makes every code unit cost 1 est token; with an
+		// odd remaining budget the walk lands exactly mid-pair, so without the
+		// guard the kept prefix ends in a lone high surrogate — ill-formed
+		// Unicode that strict upstream JSON parsers reject wholesale.
+		const addendum = "# Voice call";
+		const a = boundVoiceInstructions("😀".repeat(10_000), addendum);
+		expect(a.truncated).toBe(true);
+		const cut = a.instructions.slice(0, -(addendum.length + 2));
+		const last = cut.charCodeAt(cut.length - 1);
+		expect(last >= 0xd800 && last <= 0xdbff).toBe(false);
+		expect(a.estimatedTokens).toBeLessThanOrEqual(VOICE_TOKEN_CEILING);
 	});
 });

--- a/apps/api/src/routes/voice.ts
+++ b/apps/api/src/routes/voice.ts
@@ -83,11 +83,16 @@ const VOICE_MAX_KNOWLEDGE_CHARS = 8_000;
 export const VOICE_TOKEN_CEILING = 12_288;
 
 /**
- * Worst-case-biased token estimate for realtime instructions: ASCII at the
- * usual ~4 chars/token, every non-ASCII code unit counted as a FULL token —
- * CJK and other token-dense scripts really do approach 1 token/char, and the
- * cost of overestimating is a shorter KB, while underestimating means the
- * upstream rejects the session and the call runs ungrounded. Pure.
+ * Worst-case-biased token estimate for realtime instructions: ASCII at 3
+ * chars/token — NOT the usual prose average of ~4, because operator content
+ * is often token-dense ASCII (hex ids, base64 blobs, code, numeric tables)
+ * that real BPE tokenizers price at ~2-3 chars/token — and every non-ASCII
+ * code unit counted as a FULL token (CJK really does approach 1 token/char).
+ * Overestimating costs a shorter KB; underestimating ships an update the
+ * upstream rejects. Content denser than 2.25 chars/token (36,864 chars at
+ * the 12,288 ceiling vs the real 16,384 cap) can still slip past — and then
+ * fails CLOSED in the widget (terminal "unavailable"), never ungrounded.
+ * Pure.
  */
 export function estimateRealtimeTokens(text: string): number {
 	let ascii = 0;
@@ -96,7 +101,7 @@ export function estimateRealtimeTokens(text: string): number {
 		if (text.charCodeAt(i) <= 0x7f) ascii++;
 		else wide++;
 	}
-	return Math.ceil(ascii / 4) + wide;
+	return Math.ceil(ascii / 3) + wide;
 }
 
 /**
@@ -119,17 +124,27 @@ export function boundVoiceInstructions(
 	}
 	const reserved = estimateRealtimeTokens(`\n\n${addendum}`);
 	const budget = VOICE_TOKEN_CEILING - reserved;
-	// Walk the base accumulating the estimator's per-char cost until the
-	// remaining budget is spent. Fractional ASCII cost is accumulated exactly
-	// (¼ token per char) so the walk agrees with estimateRealtimeTokens' ceil.
-	let spent = 0;
+	// Walk the base one code unit at a time, recomputing the estimator's own
+	// integer arithmetic (ceil(ascii/3) + wide) on running counts — exact
+	// agreement with estimateRealtimeTokens by construction, no accumulated
+	// float drift.
+	let ascii = 0;
+	let wide = 0;
 	let end = 0;
 	while (end < base.length) {
-		const cost = base.charCodeAt(end) <= 0x7f ? 0.25 : 1;
-		if (Math.ceil(spent + cost) > budget) break;
-		spent += cost;
+		const isAscii = base.charCodeAt(end) <= 0x7f;
+		const next =
+			Math.ceil((ascii + (isAscii ? 1 : 0)) / 3) + wide + (isAscii ? 0 : 1);
+		if (next > budget) break;
+		if (isAscii) ascii++;
+		else wide++;
 		end++;
 	}
+	// Never cut between the halves of a surrogate pair — a trailing lone high
+	// surrogate is ill-formed Unicode, and strict JSON parsers upstream reject
+	// the whole session.update that carries it.
+	const lastKept = end > 0 ? base.charCodeAt(end - 1) : 0;
+	if (lastKept >= 0xd800 && lastKept <= 0xdbff) end--;
 	const instructions = `${base.slice(0, end)}\n\n${addendum}`;
 	return {
 		instructions,

--- a/apps/api/src/routes/voice.ts
+++ b/apps/api/src/routes/voice.ts
@@ -61,6 +61,83 @@ const CALL_RATE_WINDOW = 60 * 60;
 const CALL_DAILY_MAX = 20;
 const CALL_DAILY_WINDOW = 24 * 60 * 60;
 
+// --- Voice instruction budget -----------------------------------------------
+//
+// The realtime API hard-caps session instructions (+ tools) at 16,384 tokens;
+// an oversized session.update is REJECTED upstream and the call would run
+// ungrounded. The text path's budgets (80k source chars, uncapped knowledge)
+// were sized for 128k-context chat models and blow straight through that cap,
+// which is exactly the bug this bounds out: the mint must NEVER ship
+// instructions it expects the session to reject.
+//
+// Layer 1 — voice-sized budgets. Sources reuse buildSystem's even-split
+// discipline with a smaller constant; knowledgeText (uncapped on the text
+// path) gets a hard slice here.
+const VOICE_MAX_SOURCES_CHARS = 16_000;
+const VOICE_MAX_KNOWLEDGE_CHARS = 8_000;
+// Layer 2 — the by-construction guarantee. Estimated instruction tokens must
+// clear this ceiling or the assembled prompt is truncated server-side before
+// it ships: 12,288 = 75% of the upstream 16,384 cap, a 4,096-token margin for
+// estimator error. The estimator is worst-case-biased (see below), so typical
+// Latin-script prompts sit far beneath the real cap.
+export const VOICE_TOKEN_CEILING = 12_288;
+
+/**
+ * Worst-case-biased token estimate for realtime instructions: ASCII at the
+ * usual ~4 chars/token, every non-ASCII code unit counted as a FULL token —
+ * CJK and other token-dense scripts really do approach 1 token/char, and the
+ * cost of overestimating is a shorter KB, while underestimating means the
+ * upstream rejects the session and the call runs ungrounded. Pure.
+ */
+export function estimateRealtimeTokens(text: string): number {
+	let ascii = 0;
+	let wide = 0;
+	for (let i = 0; i < text.length; i++) {
+		if (text.charCodeAt(i) <= 0x7f) ascii++;
+		else wide++;
+	}
+	return Math.ceil(ascii / 4) + wide;
+}
+
+/**
+ * Bound assembled voice instructions to VOICE_TOKEN_CEILING. The spoken-style
+ * addendum ALWAYS survives whole (it's what makes the call sound like a call);
+ * when the estimate is over the ceiling, the base prompt (scaffold + operator
+ * prompt + KB) is cut at the exact prefix whose estimated tokens fit the
+ * remainder — a single deterministic left-to-right walk, so the same input
+ * always yields the same output. Pure; the caller logs the (content-free)
+ * truncation counter.
+ */
+export function boundVoiceInstructions(
+	base: string,
+	addendum: string,
+): { instructions: string; truncated: boolean; estimatedTokens: number } {
+	const joined = `${base}\n\n${addendum}`;
+	const total = estimateRealtimeTokens(joined);
+	if (total <= VOICE_TOKEN_CEILING) {
+		return { instructions: joined, truncated: false, estimatedTokens: total };
+	}
+	const reserved = estimateRealtimeTokens(`\n\n${addendum}`);
+	const budget = VOICE_TOKEN_CEILING - reserved;
+	// Walk the base accumulating the estimator's per-char cost until the
+	// remaining budget is spent. Fractional ASCII cost is accumulated exactly
+	// (¼ token per char) so the walk agrees with estimateRealtimeTokens' ceil.
+	let spent = 0;
+	let end = 0;
+	while (end < base.length) {
+		const cost = base.charCodeAt(end) <= 0x7f ? 0.25 : 1;
+		if (Math.ceil(spent + cost) > budget) break;
+		spent += cost;
+		end++;
+	}
+	const instructions = `${base.slice(0, end)}\n\n${addendum}`;
+	return {
+		instructions,
+		truncated: true,
+		estimatedTokens: estimateRealtimeTokens(instructions),
+	};
+}
+
 /**
  * Spoken-channel addendum appended after the assembled support prompt. The
  * base scaffold + operator prompt + knowledge assembly is byte-identical to
@@ -158,19 +235,36 @@ export const voice = new Hono<AppContext>().post(
 				a(e(ct.projectId, project.id), e(ct.clientId, clientId)),
 		});
 
-		const instructions = [
-			buildSystem(
-				activePromptContent,
-				project.knowledgeText,
-				activeSources.map((s) => ({
-					title: s.title || s.url || "",
-					url: s.url ?? "",
-					content: s.content,
-				})),
-				conv ? { name: conv.name, email: conv.email } : undefined,
-			),
-			VOICE_CALL_STYLE_PROMPT,
-		].join("\n\n");
+		// Same assembler as text chat, but with the VOICE budgets (see the
+		// constants above): a smaller even-split source budget, a hard knowledge
+		// slice, and a token-ceiling backstop — the upstream realtime API rejects
+		// instructions over 16,384 tokens, and a rejected update means an
+		// ungrounded call.
+		const assembled = buildSystem(
+			activePromptContent,
+			project.knowledgeText.slice(0, VOICE_MAX_KNOWLEDGE_CHARS),
+			activeSources.map((s) => ({
+				title: s.title || s.url || "",
+				url: s.url ?? "",
+				content: s.content,
+			})),
+			conv ? { name: conv.name, email: conv.email } : undefined,
+			undefined,
+			undefined,
+			VOICE_MAX_SOURCES_CHARS,
+		);
+		const bounded = boundVoiceInstructions(assembled, VOICE_CALL_STYLE_PROMPT);
+		if (bounded.truncated) {
+			// Content-free counter: sizes only, never prompt text. Firing at all
+			// means a project's prompt+KB outgrew even the voice budgets (token-
+			// dense scripts can) — worth noticing, not worth failing the call.
+			console.warn(
+				`voice: instructions over token ceiling at mint (est ${estimateRealtimeTokens(
+					`${assembled}\n\n${VOICE_CALL_STYLE_PROMPT}`,
+				)} > ${VOICE_TOKEN_CEILING}); truncated to est ${bounded.estimatedTokens}`,
+			);
+		}
+		const instructions = bounded.instructions;
 
 		// Mint the ephemeral client secret server-to-server. The base URL
 		// already carries /v1 (see .env.example), same as the chat provider.

--- a/packages/widget/src/components/VoiceCall.tsx
+++ b/packages/widget/src/components/VoiceCall.tsx
@@ -88,12 +88,13 @@ export function VoiceCall({
 			} catch (err) {
 				// Mint refused, mic denied, or the socket failed — one terminal
 				// state, but the hint names the actual cause (a mint failure must
-				// never read as a microphone problem).
+				// never read as a microphone problem). stop() FIRST: it emits
+				// "ended", which must not clobber the "error" set here.
+				client?.stop();
 				if (!cancelled) {
 					setHint(failureHint(err));
 					setStatus("error");
 				}
-				client?.stop();
 			}
 		})();
 		return () => {

--- a/packages/widget/src/components/VoiceCall.tsx
+++ b/packages/widget/src/components/VoiceCall.tsx
@@ -13,6 +13,7 @@ const STATUS_LABEL: Record<VoiceCallStatus, string> = {
 	listening: "Listening…",
 	speaking: "Speaking…",
 	ended: "Call ended",
+	unavailable: "Voice is unavailable",
 	error: "Call failed",
 };
 
@@ -134,6 +135,11 @@ export function VoiceCall({
 			{status === "error" && (
 				<p className="llmchat-voice-hint">
 					{hint ?? "We couldn't start the call. Please try again."}
+				</p>
+			)}
+			{status === "unavailable" && (
+				<p className="llmchat-voice-hint">
+					Voice is unavailable right now — please keep chatting below.
 				</p>
 			)}
 			<div className="llmchat-voice-controls">

--- a/packages/widget/src/voice-call.test.ts
+++ b/packages/widget/src/voice-call.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
 	floatToPcm16Base64,
@@ -6,6 +6,9 @@ import {
 	pcm16Base64ToFloat,
 	resampleLinear,
 	REALTIME_SAMPLE_RATE,
+	SETUP_ACK_TIMEOUT_MS,
+	VoiceCallClient,
+	type VoiceCallStatus,
 } from "./voice-call";
 
 describe("PCM16 base64 codec", () => {
@@ -86,5 +89,190 @@ describe("frameRms", () => {
 		);
 		expect(frameRms(loud)).toBeGreaterThan(0.07);
 		expect(frameRms(new Float32Array(480).fill(0.02))).toBeLessThan(0.07);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Setup-ack hardening (item 0 client half): the model must never take a turn
+// before session.updated confirms the operator's instructions were applied,
+// and a rejected/unacked configuring update must end as "unavailable" — never
+// as a live, ungrounded call.
+// ---------------------------------------------------------------------------
+
+class FakeWebSocket {
+	static OPEN = 1;
+	static instances: FakeWebSocket[] = [];
+	readyState = FakeWebSocket.OPEN;
+	sent: string[] = [];
+	closed = false;
+	private listeners = new Map<string, ((e: unknown) => void)[]>();
+
+	constructor(
+		public url: string,
+		public protocols: string[],
+	) {
+		FakeWebSocket.instances.push(this);
+	}
+
+	addEventListener(type: string, fn: (e: unknown) => void) {
+		this.listeners.set(type, [...(this.listeners.get(type) ?? []), fn]);
+	}
+
+	send(data: string) {
+		this.sent.push(data);
+	}
+
+	close() {
+		this.closed = true;
+		this.readyState = 3;
+		this.emit("close", {});
+	}
+
+	emit(type: string, e: unknown) {
+		for (const fn of this.listeners.get(type) ?? []) {
+			fn(e);
+		}
+	}
+
+	sentTypes(): string[] {
+		return this.sent.map((s) => (JSON.parse(s) as { type: string }).type);
+	}
+}
+
+class FakeProcessor {
+	onaudioprocess: ((e: unknown) => void) | null = null;
+	connect() {}
+	disconnect() {}
+}
+
+class FakeAudioContext {
+	static lastProcessor: FakeProcessor | null = null;
+	sampleRate = REALTIME_SAMPLE_RATE;
+	currentTime = 0;
+	destination = {};
+
+	createMediaStreamSource() {
+		return { connect() {}, disconnect() {} };
+	}
+
+	createScriptProcessor() {
+		const p = new FakeProcessor();
+		FakeAudioContext.lastProcessor = p;
+		return p;
+	}
+
+	async close() {}
+}
+
+function loudFrame() {
+	return {
+		inputBuffer: { getChannelData: () => new Float32Array(4096).fill(0.5) },
+	};
+}
+
+describe("VoiceCallClient setup-ack hardening", () => {
+	beforeEach(() => {
+		FakeWebSocket.instances = [];
+		FakeAudioContext.lastProcessor = null;
+		vi.stubGlobal("WebSocket", FakeWebSocket);
+		vi.stubGlobal("AudioContext", FakeAudioContext);
+		vi.stubGlobal("navigator", {
+			mediaDevices: {
+				getUserMedia: async () => ({ getTracks: () => [] }),
+			},
+		});
+		vi.spyOn(console, "warn").mockImplementation(() => {});
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+		vi.restoreAllMocks();
+		vi.useRealTimers();
+	});
+
+	async function startClient() {
+		const statuses: VoiceCallStatus[] = [];
+		const client = new VoiceCallClient(
+			{
+				url: "wss://gw.test/v1/realtime?model=gpt-realtime",
+				clientSecret: "ek_test",
+				model: "gpt-realtime",
+				instructions: "GROUNDED-INSTRUCTIONS",
+				voice: "marin",
+			},
+			{ onStatus: (s) => statuses.push(s) },
+		);
+		const started = client.start();
+		// start() awaits getUserMedia before opening the socket — drain the
+		// microtask chain until the fake socket exists.
+		for (let i = 0; i < 10 && FakeWebSocket.instances.length === 0; i++) {
+			await Promise.resolve();
+		}
+		const ws = FakeWebSocket.instances[FakeWebSocket.instances.length - 1];
+		ws.emit("open", {});
+		await started;
+		return { client, ws, statuses };
+	}
+
+	it("greets ONLY after session.updated, and mic frames wait for the ack", async () => {
+		const { ws, client } = await startClient();
+		// The configuring update is the first and only frame so far…
+		expect(ws.sentTypes()).toEqual(["session.update"]);
+		const update = JSON.parse(ws.sent[0]) as {
+			session: { instructions?: string };
+		};
+		expect(update.session.instructions).toBe("GROUNDED-INSTRUCTIONS");
+		// …a loud mic frame BEFORE the ack is dropped (no ungrounded turn)…
+		FakeAudioContext.lastProcessor?.onaudioprocess?.(loudFrame());
+		expect(ws.sentTypes()).toEqual(["session.update"]);
+		// …and no greeting has been requested yet.
+		ws.emit("message", { data: JSON.stringify({ type: "session.updated" }) });
+		expect(ws.sentTypes()).toEqual(["session.update", "response.create"]);
+		// After the ack, mic frames flow.
+		FakeAudioContext.lastProcessor?.onaudioprocess?.(loudFrame());
+		expect(ws.sentTypes()).toEqual([
+			"session.update",
+			"response.create",
+			"input_audio_buffer.append",
+		]);
+		client.stop();
+	});
+
+	it("rejected instructions → unavailable + closed, zero ungrounded turns", async () => {
+		const { ws, statuses } = await startClient();
+		// The upstream rejects the configuring update (e.g. instructions over
+		// its 16,384-token cap): an error event arrives and NO ack ever will.
+		ws.emit("message", {
+			data: JSON.stringify({
+				type: "error",
+				error: { message: "instructions too long" },
+			}),
+		});
+		expect(statuses[statuses.length - 1]).toBe("unavailable");
+		expect(ws.closed).toBe(true);
+		// The killed path: warn-and-continue used to leave this call live and
+		// ungrounded. No greeting, no audio — ever.
+		expect(ws.sentTypes()).toEqual(["session.update"]);
+		expect(statuses).not.toContain("ended"); // terminal state is unavailable
+	});
+
+	it("no ack within the setup timeout → unavailable, no greeting", async () => {
+		vi.useFakeTimers();
+		const { ws, statuses } = await startClient();
+		vi.advanceTimersByTime(SETUP_ACK_TIMEOUT_MS + 1);
+		expect(statuses[statuses.length - 1]).toBe("unavailable");
+		expect(ws.closed).toBe(true);
+		expect(ws.sentTypes()).toEqual(["session.update"]);
+	});
+
+	it("post-ack errors stay non-fatal — the session is already grounded", async () => {
+		const { ws, statuses, client } = await startClient();
+		ws.emit("message", { data: JSON.stringify({ type: "session.updated" }) });
+		ws.emit("message", {
+			data: JSON.stringify({ type: "error", error: { message: "transient" } }),
+		});
+		expect(ws.closed).toBe(false);
+		expect(statuses).not.toContain("unavailable");
+		client.stop();
 	});
 });

--- a/packages/widget/src/voice-call.test.ts
+++ b/packages/widget/src/voice-call.test.ts
@@ -215,7 +215,10 @@ describe("VoiceCallClient setup-ack hardening", () => {
 	}
 
 	it("greets ONLY after session.updated, and mic frames wait for the ack", async () => {
-		const { ws, client } = await startClient();
+		const { ws, client, statuses } = await startClient();
+		// Status honesty: "Listening…" is a lie while the gate drops frames —
+		// the client stays "connecting" until the ack.
+		expect(statuses).toEqual(["connecting"]);
 		// The configuring update is the first and only frame so far…
 		expect(ws.sentTypes()).toEqual(["session.update"]);
 		const update = JSON.parse(ws.sent[0]) as {
@@ -228,6 +231,7 @@ describe("VoiceCallClient setup-ack hardening", () => {
 		// …and no greeting has been requested yet.
 		ws.emit("message", { data: JSON.stringify({ type: "session.updated" }) });
 		expect(ws.sentTypes()).toEqual(["session.update", "response.create"]);
+		expect(statuses).toContain("listening");
 		// After the ack, mic frames flow.
 		FakeAudioContext.lastProcessor?.onaudioprocess?.(loudFrame());
 		expect(ws.sentTypes()).toEqual([
@@ -274,5 +278,65 @@ describe("VoiceCallClient setup-ack hardening", () => {
 		expect(ws.closed).toBe(false);
 		expect(statuses).not.toContain("unavailable");
 		client.stop();
+	});
+
+	it("refuses to start a call with empty instructions — unavailable, no mic, no socket", async () => {
+		const statuses: VoiceCallStatus[] = [];
+		const client = new VoiceCallClient(
+			{
+				url: "wss://gw.test/v1/realtime",
+				clientSecret: "ek_test",
+				model: "gpt-realtime",
+				instructions: "",
+				voice: "marin",
+			},
+			{ onStatus: (s) => statuses.push(s) },
+		);
+		await client.start();
+		expect(statuses).toEqual(["unavailable"]);
+		expect(FakeWebSocket.instances).toHaveLength(0);
+	});
+
+	it("stop() during the mic-permission prompt never leaves a hot mic or a socket", async () => {
+		const track = { stop: vi.fn() };
+		let grant: (s: unknown) => void = () => {};
+		vi.stubGlobal("navigator", {
+			mediaDevices: {
+				getUserMedia: () =>
+					new Promise((resolve) => {
+						grant = resolve;
+					}),
+			},
+		});
+		const client = new VoiceCallClient(
+			{
+				url: "wss://gw.test/v1/realtime",
+				clientSecret: "ek_test",
+				model: "gpt-realtime",
+				instructions: "GROUNDED",
+				voice: "marin",
+			},
+			{ onStatus: () => {} },
+		);
+		const started = client.start();
+		client.stop(); // visitor closed the panel while the permission prompt was up
+		grant({ getTracks: () => [track] }); // then granted the permission
+		await started;
+		expect(track.stop).toHaveBeenCalled(); // the just-granted mic is released…
+		expect(FakeWebSocket.instances).toHaveLength(0); // …and no socket ever opens
+	});
+
+	it("server close BEFORE the ack is a failed setup (unavailable), after it a normal end", async () => {
+		const early = await startClient();
+		early.ws.emit("close", {});
+		expect(early.statuses[early.statuses.length - 1]).toBe("unavailable");
+
+		FakeWebSocket.instances = [];
+		const late = await startClient();
+		late.ws.emit("message", {
+			data: JSON.stringify({ type: "session.updated" }),
+		});
+		late.ws.emit("close", {});
+		expect(late.statuses[late.statuses.length - 1]).toBe("ended");
 	});
 });

--- a/packages/widget/src/voice-call.ts
+++ b/packages/widget/src/voice-call.ts
@@ -156,11 +156,22 @@ export function resampleLinear(
 	return out;
 }
 
+// How long the client waits for the session.updated ack of its configuring
+// session.update before declaring the call unusable. Generous against slow
+// networks; the alternative to giving up is a live call with NO operator
+// instructions, which is never acceptable.
+export const SETUP_ACK_TIMEOUT_MS = 5_000;
+
 export type VoiceCallStatus =
 	| "connecting"
 	| "listening"
 	| "speaking"
 	| "ended"
+	// Terminal: the session refused (or never acknowledged) the configuring
+	// session.update that carries the operator's instructions. The call is
+	// closed rather than run ungrounded — an absent feature is honest, a
+	// hallucinating one is not.
+	| "unavailable"
 	| "error";
 
 interface VoiceCallHandlers {
@@ -183,7 +194,11 @@ export class VoiceCallClient {
 	private playing: AudioBufferSourceNode[] = [];
 	private nextPlayTime = 0;
 	private speakingUntil: ReturnType<typeof setTimeout> | null = null;
-	private greetFallback: ReturnType<typeof setTimeout> | null = null;
+	private setupTimeout: ReturnType<typeof setTimeout> | null = null;
+	/** True once session.updated confirmed the instructions were applied. Until
+	 * then no greeting is requested and no mic audio is appended — the model
+	 * must never take a turn before it is grounded. */
+	private configured = false;
 	private greeted = false;
 	private stopped = false;
 	private micMuted = false;
@@ -246,12 +261,18 @@ export class VoiceCallClient {
 						},
 					}),
 				);
-				// The greeting response is NOT requested here: response.create in
-				// the same breath can race the session.update above, and a model
-				// with no instructions yet greets ungrounded (arbitrary language).
-				// It fires on the session.updated ack (handleEvent) — with a timer
-				// fallback in case the ack never comes.
-				this.greetFallback = setTimeout(() => this.greet(), 2_000);
+				// NOTHING else happens until the session.updated ack confirms the
+				// instructions above were applied (handleEvent): the greeting is
+				// requested there, and the capture callback drops frames until then.
+				// If the ack never comes — the upstream REJECTS oversized/invalid
+				// instructions with an error event and no ack — the call is torn
+				// down as "unavailable" instead of running ungrounded. There is
+				// deliberately no greet-anyway fallback: it produced live calls
+				// that knew nothing about the business.
+				this.setupTimeout = setTimeout(
+					() => this.failSetup(),
+					SETUP_ACK_TIMEOUT_MS,
+				);
 				this.startCapture();
 				this.handlers.onStatus("listening");
 				resolve();
@@ -293,10 +314,27 @@ export class VoiceCallClient {
 		this.handlers.onStatus("ended");
 	}
 
+	/** Terminal setup failure: the configuring session.update was rejected or
+	 * never acknowledged. Close everything and surface "unavailable" — the one
+	 * state this client refuses to be in is a live, ungrounded call. */
+	private failSetup() {
+		if (this.stopped) {
+			return;
+		}
+		this.stopped = true;
+		try {
+			this.ws?.close();
+		} catch {
+			// Already closed/failed — releasing the audio below is what matters.
+		}
+		this.releaseAudio();
+		this.handlers.onStatus("unavailable");
+	}
+
 	private releaseAudio() {
-		if (this.greetFallback) {
-			clearTimeout(this.greetFallback);
-			this.greetFallback = null;
+		if (this.setupTimeout) {
+			clearTimeout(this.setupTimeout);
+			this.setupTimeout = null;
 		}
 		this.cancelPlayback();
 		this.processor?.disconnect();
@@ -320,6 +358,13 @@ export class VoiceCallClient {
 		this.processor = this.ctx.createScriptProcessor(CAPTURE_BUFFER_SIZE, 1, 1);
 		this.processor.onaudioprocess = (e) => {
 			if (this.micMuted || this.ws?.readyState !== WebSocket.OPEN) {
+				return;
+			}
+			// No audio before the session.updated ack: an unconfigured session
+			// answering committed speech is an ungrounded turn (same reference
+			// behavior as the gateway's own playground client, which drops mic
+			// frames until the session is live).
+			if (!this.configured) {
 				return;
 			}
 			const captured = e.inputBuffer.getChannelData(0);
@@ -361,8 +406,14 @@ export class VoiceCallClient {
 		}
 		switch (event.type) {
 			case "session.updated": {
-				// Instructions/voice are confirmed applied — NOW the greeting is
-				// grounded in the support prompt instead of an empty context.
+				// Instructions/voice are confirmed applied — the call is grounded.
+				// Only now do mic frames flow (see startCapture) and the greeting
+				// get requested.
+				this.configured = true;
+				if (this.setupTimeout) {
+					clearTimeout(this.setupTimeout);
+					this.setupTimeout = null;
+				}
 				this.greet();
 				break;
 			}
@@ -380,14 +431,19 @@ export class VoiceCallClient {
 				break;
 			}
 			case "error": {
-				// Surfaced (not swallowed): a rejected session.update leaves the
-				// agent running WITHOUT the operator's instructions — the one
-				// warn keeps that diagnosable on any embed. Session-fatal errors
-				// additionally surface via onclose.
 				console.warn(
 					"clanker voice: realtime error event",
 					(event as { error?: { message?: string } }).error?.message ?? e.data,
 				);
+				// Before the session.updated ack, an error event is the upstream
+				// rejecting our configuring update (oversized/invalid instructions
+				// — no ack will ever come): tear the call down instead of letting
+				// it run without the operator's instructions. After the ack the
+				// session is grounded, so later errors stay non-fatal (fatal ones
+				// surface via onclose).
+				if (!this.configured) {
+					this.failSetup();
+				}
 				break;
 			}
 			default:
@@ -395,13 +451,10 @@ export class VoiceCallClient {
 		}
 	}
 
-	/** Request the agent's opening greeting exactly once — on the
-	 * session.updated ack, or the connect-time fallback timer. */
+	/** Request the agent's opening greeting exactly once — ONLY on the
+	 * session.updated ack. There is no unacked path here by design: a greeting
+	 * before the instructions apply is an ungrounded turn. */
 	private greet() {
-		if (this.greetFallback) {
-			clearTimeout(this.greetFallback);
-			this.greetFallback = null;
-		}
 		if (this.greeted || this.stopped) {
 			return;
 		}

--- a/packages/widget/src/voice-call.ts
+++ b/packages/widget/src/voice-call.ts
@@ -209,12 +209,29 @@ export class VoiceCallClient {
 	) {}
 
 	async start(): Promise<void> {
+		// A call with no instructions IS an ungrounded call — refuse before any
+		// mic prompt or socket exists (the mint always assembles at least the
+		// base scaffold, so an empty string means a malformed response).
+		if (!this.session.instructions) {
+			this.stopped = true;
+			this.handlers.onStatus("unavailable");
+			return;
+		}
 		this.handlers.onStatus("connecting");
 		// Mic first: a permission denial should fail the call before any socket
 		// or gateway spend exists.
 		this.stream = await navigator.mediaDevices.getUserMedia({
 			audio: { echoCancellation: true, noiseSuppression: true },
 		});
+		// stop() may have run while the permission prompt was open — with no
+		// stream to release yet, it couldn't stop these tracks. Without this
+		// re-check the call would come up headless: live hot mic, open socket,
+		// no UI owning either.
+		if (this.stopped) {
+			this.stream.getTracks().forEach((t) => t.stop());
+			this.stream = null;
+			return;
+		}
 		// Ask for the realtime rate; fall back to the device default and
 		// resample in the capture callback (see resampleLinear).
 		try {
@@ -230,6 +247,12 @@ export class VoiceCallClient {
 			]);
 			this.ws = ws;
 			ws.addEventListener("open", () => {
+				// stop() during the connect handshake: close and bow out.
+				if (this.stopped) {
+					ws.close();
+					resolve();
+					return;
+				}
 				// The model is locked at mint time; everything else is configured
 				// here per the gateway's docs — the server-assembled instructions
 				// and voice (its mint endpoint accepts neither), the audio wire
@@ -274,7 +297,9 @@ export class VoiceCallClient {
 					SETUP_ACK_TIMEOUT_MS,
 				);
 				this.startCapture();
-				this.handlers.onStatus("listening");
+				// Status stays "connecting" until the ack — the capture gate is
+				// dropping every frame, and claiming "Listening…" here would be
+				// a lie the visitor can see.
 				resolve();
 			});
 			ws.addEventListener("message", (e) => this.handleEvent(e));
@@ -288,7 +313,10 @@ export class VoiceCallClient {
 				if (!this.stopped) {
 					this.stopped = true;
 					this.releaseAudio();
-					this.handlers.onStatus("ended");
+					// A server-side close BEFORE the session was configured is a
+					// failed setup, not a finished call — "Call ended" would tell
+					// the visitor a call happened.
+					this.handlers.onStatus(this.configured ? "ended" : "unavailable");
 				}
 			});
 		});
@@ -414,6 +442,7 @@ export class VoiceCallClient {
 					clearTimeout(this.setupTimeout);
 					this.setupTimeout = null;
 				}
+				this.handlers.onStatus("listening");
 				this.greet();
 				break;
 			}


### PR DESCRIPTION
## The defect

The voice mint assembled the **text path's** prompt: an 80,000-char source budget plus **uncapped** `knowledgeText` — routinely 20k+ tokens. The upstream realtime API rejects `session.update` instructions above **16,384 tokens** (instructions + tools), and the widget's response to that rejection was a `console.warn` and carry on: the call stayed live, sounded normal, and knew **nothing about the business** — no retry, no visible failure, for the whole call. For any KB-heavy project (exactly the customers voice targets) this was deterministic, and the marketing-site demo was likely running ungrounded.

## The fix — two halves, one invariant

**Invariant: no path may leave a live ungrounded session.**

### Server — the mint never ships instructions it expects to be rejected (`apps/api/src/routes/voice.ts`)

- **Layer 1, voice budgets:** `VOICE_MAX_SOURCES_CHARS = 16_000` through `buildSystem`'s existing even-split (`floor(budget/N)` — the same discipline, now parameterized; text path default unchanged), plus a hard `VOICE_MAX_KNOWLEDGE_CHARS = 8_000` slice on `knowledgeText` (uncapped even for text — fatal only for realtime).
- **Layer 2, by-construction guarantee:** `estimateRealtimeTokens` (ASCII at **3** chars/token — not the prose-average 4, because operator content is often token-dense hex/base64/code — and every non-ASCII code unit a **full** token) asserted against `VOICE_TOKEN_CEILING = 12_288` at mint. Over the ceiling → deterministic truncation of the base prompt (integer re-computation of the estimator's own arithmetic, no float drift; never cuts a surrogate pair; always preserves the spoken-style addendum whole) plus a **content-free** counter log (sizes only, never prompt text).

### Client — rejection is call-fatal, never warn-and-continue (`packages/widget/src/voice-call.ts`)

- Greeting fires **only** on the `session.updated` ack. The 2-second greet-anyway fallback is gone — it was the mechanism that turned a rejected update into a live ungrounded call.
- An `error` event before the ack, no ack within `SETUP_ACK_TIMEOUT_MS` (5s), a server-side close before the ack, or **empty minted instructions** all tear the call down into a terminal **"unavailable"** state ("Voice is unavailable right now — please keep chatting below"). An absent feature is honest; a hallucinating one is the thing this product exists to remove.
- Mic frames are dropped until the ack (parity with the gateway's own reference client), and status stays "Connecting…" until then — no audio turn can precede grounding, and the UI never claims "Listening…" while the gate drops frames.
- `stop()` during the mic-permission prompt now releases the just-granted track and never opens the socket (was: hidden hot mic + headless call). Post-ack errors stay non-fatal: the session is already grounded.

## Budget math

**(a) Under the 16,384-token cap.** Ceiling 12,288 est tokens = 75% of the cap. The estimator is worst-case-biased: ASCII at 3 chars/token (dense-ASCII content — hex ids, base64, code, numeric tables — really tokenizes at ~2-3; the prose average is ~4), non-ASCII at 1 token/char (CJK approaches 1:1). Composition at the budgets: sources 16,000 chars ≈ 5,334 est + knowledge 8,000 ≈ 2,667 est + scaffold + spoken addendum ≈ 717 est + a typical 2k-char operator prompt ≈ 667 est + identity ≤ 85 est → **≈ 9.5k est tokens** (77% of our ceiling), which for normal prose is **≈ 7.1k real tokens = 43% of the upstream cap**. Truncation retains at most 36,864 ASCII chars, so the shipped string stays under the real cap for any content at ≥ 2.25 chars/token; anything denser (adversarial, not natural) now **fails closed** in the widget — a clean "unavailable", never an ungrounded call. Sources at 16k (mid of the 12–24k prior): voice answers are capped at one-two sentences by the style prompt, so grounding recall beats breadth; `floor(16000/N)` still gives 8 sources ~2,000 chars each, 20 sources ~800 each.

**(b) Per-turn cost under the $10 session cap.** Instructions bill as text-input tokens on every response (~$4/1M uncached, ~$0.40/1M cached at gpt-realtime list). Old worst case ~20k+ real tokens ≈ **$0.08/turn** uncached; new typical ~7k real ≈ **$0.03/turn**, and the ceiling bounds it at ≤ ~$0.065/turn — even a 100-turn, hour-long call spends ≤ ~$5 on instructions uncached, so instructions can no longer meaningfully consume the per-session cap; audio dominates, as it should. The budget is a cost fix as well as a correctness fix.

## Why not fix it at mint time?

The gateway's mint endpoint accepts only `{ session: { type, model } }` (strict schema — verified in gateway source, `apps/gateway/src/realtime/client-secrets-route.ts`; unknown fields 400). Server-side instruction binding at mint is an upstream llmgateway feature request (**to be filed** — it would also stop shipping the prompt to the browser at all). Until then, instructions must ride `session.update`, so the client must treat its rejection as fatal.

## Adversarial pre-PR review

An 11-agent review/verify pass (3 lenses, every finding independently re-derived) confirmed 6 defects in the first two commits; all are fixed in the third:

1. ASCII/4 estimator admitted dense-ASCII strings past the real cap → divisor 3 (break-even 2.25 chars/token, denser fails closed).
2. Truncation could cut a surrogate pair → guard + pin (a lone high surrogate is ill-formed and strict upstream JSON parsers reject the whole update).
3. `stop()` during `getUserMedia` left a hot mic + headless call → stopped re-checks after every await.
4. `stop()`'s "ended" clobbered the component's "error" hint → stop-before-setState in `VoiceCall.tsx`.
5. Pre-ack server close read as "Call ended" → now "unavailable".
6. "Listening…" shown while the pre-ack gate dropped every frame → status stays "connecting" until the ack.

## Disclosure note (audit finding 6)

This budget also shrinks the prompt-disclosure surface: the mint response now ships ≤ ~28k chars to the browser instead of up to 80k+ of operator prompt/KB/sources. The boundary itself (prompt text reaches the visitor's browser) still stands and remains Omar's call — cross-reference the upstream mint-time-binding request above once filed.

## Tests + mutation table

Suites: api 735/735, widget 251/251 (17 voice route + 17 voice-call client). Regression pair: 402-below-Scale and fail-closed 429 tests untouched and green.

| Mutant | Expected kill | Result |
|---|---|---|
| M1 · voice source budget → 80k | even-split-under-ceiling test | ✅ exactly that test |
| M2 · backstop disabled | backstop route test + 3 pure truncation pins | ✅ exactly those 4 |
| M3 · knowledge slice removed | knowledge-slice test | ✅ exactly that test |
| M4 · error → warn-and-continue restored | rejection → unavailable test | ✅ exactly that test |
| M5 · 2s ungrounded greet fallback restored | timeout → unavailable test | ✅ exactly that test |
| M6 · pre-ack mic gate removed | ack-gated greet/mic test | ✅ exactly that test |
| M7 · surrogate guard removed | surrogate-cut pin | ✅ exactly that test |
| M8 · stopped re-check removed | hot-mic release test | ✅ exactly that test |

Sequencing: lands **before** `fix/voice-fastfollow` (both touch `voice.ts`; fastfollow rebases on this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018pJJgDHCnnNeEqEAApxFcQ
