### PR TITLE
fix(api): voice budget relief for named projects — never for the internal workspace class

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -135,6 +135,15 @@ POSTHOG_QUERY_HOST=https://eu.posthog.com
 # Unset = probe skipped (self-hosters / local dev need nothing here).
 SHOWCASE_WIDGET_KEY=
 
+# Voice budget relief for dogfooding: comma-separated PROJECT IDS whose voice
+# buckets are raised (60/hr per project+IP, 500/day per project — still
+# enforced, still fail-closed). Deliberately project-scoped, never
+# workspace-scoped: internal project keys are published in public page source
+# (marketing self-dogfood), so a workspace-class exemption would hand anonymous
+# visitors thousands of dollars/day of realtime minting. Only list projects
+# whose keys are NOT published anywhere. Unset/empty = zero exemptions.
+VOICE_RAISED_LIMIT_PROJECTS=
+
 # Internal/founder accounts that get full product access without paying (paywall
 # + quota + metering bypassed). Comma-separated emails; matched server-side
 # against the WORKSPACE OWNER's email (never client input). Leave blank in prod

--- a/apps/api/env.d.ts
+++ b/apps/api/env.d.ts
@@ -54,6 +54,11 @@ declare module "@meetploy/nextjs" {
 			// probe skipped (self-hosters / local dev).
 			SHOWCASE_WIDGET_KEY?: string;
 			API_PUBLIC_ORIGIN?: string;
+			// Comma-separated project ids whose voice buckets are RAISED (not
+			// removed) — dogfood relief scoped to named projects, never to the
+			// internal workspace class (internal keys are published; audit
+			// finding 5). Unset/empty ⇒ zero exemptions anywhere.
+			VOICE_RAISED_LIMIT_PROJECTS?: string;
 			GOOGLE_CLIENT_ID?: string;
 			GOOGLE_CLIENT_SECRET?: string;
 			GITHUB_CLIENT_ID?: string;
@@ -123,6 +128,11 @@ declare global {
 			// probe skipped (self-hosters / local dev).
 			SHOWCASE_WIDGET_KEY?: string;
 			API_PUBLIC_ORIGIN?: string;
+			// Comma-separated project ids whose voice buckets are RAISED (not
+			// removed) — dogfood relief scoped to named projects, never to the
+			// internal workspace class (internal keys are published; audit
+			// finding 5). Unset/empty ⇒ zero exemptions anywhere.
+			VOICE_RAISED_LIMIT_PROJECTS?: string;
 			GOOGLE_CLIENT_ID?: string;
 			GOOGLE_CLIENT_SECRET?: string;
 			GITHUB_CLIENT_ID?: string;

--- a/apps/api/ploy.yaml
+++ b/apps/api/ploy.yaml
@@ -49,6 +49,7 @@ env:
   POSTHOG_PROJECT_ID: $POSTHOG_PROJECT_ID
   POSTHOG_QUERY_HOST: $POSTHOG_QUERY_HOST
   SHOWCASE_WIDGET_KEY: $SHOWCASE_WIDGET_KEY
+  VOICE_RAISED_LIMIT_PROJECTS: $VOICE_RAISED_LIMIT_PROJECTS
   # TRUSTED integration upstream overrides (tests/self-host/demo mock). Leave
   # unset in prod: Shopify pins to the shop domain, Cal.com to api.cal.com.
   SHOPIFY_API_BASE: $SHOPIFY_API_BASE

--- a/apps/api/src/routes/voice.test.ts
+++ b/apps/api/src/routes/voice.test.ts
@@ -11,6 +11,7 @@ import { planEntitlements } from "@llmchat/shared";
 import {
 	boundVoiceInstructions,
 	estimateRealtimeTokens,
+	resolveVoiceBudgets,
 	voice,
 	VOICE_CALL_STYLE_PROMPT,
 	VOICE_TOKEN_CEILING,
@@ -285,6 +286,110 @@ describe("POST /voice/session — Scale-only realtime voice", () => {
 		const { ctx } = makeCtx();
 		const res = await send(ctx);
 		expect(res.status).toBe(429);
+	});
+});
+
+describe("voice budget relief — named projects ONLY (audit finding 5 guard)", () => {
+	function primeGates() {
+		vi.mocked(rateLimit).mockResolvedValue({ ok: true, remaining: 1 });
+		vi.mocked(publicLookupRateLimit).mockResolvedValue({
+			ok: true,
+			remaining: 1,
+		});
+	}
+
+	async function mintWith(raisedList: string | undefined, exempt = false) {
+		primeGates();
+		mockMint();
+		mockDb();
+		setPlan("scale", exempt);
+		const env = {
+			vars: {
+				LLMGATEWAY_API_KEY: "llmgw_test",
+				LLMGATEWAY_BASE_URL: "https://api.llmgateway.io/v1",
+				...(raisedList !== undefined
+					? { VOICE_RAISED_LIMIT_PROJECTS: raisedList }
+					: {}),
+			},
+			DB: {},
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		} as any;
+		const { ctx } = makeCtx();
+		const res = await voice.request(
+			"/voice/session",
+			{
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify({ projectKey: "pk_live", clientId: "c1" }),
+			},
+			env,
+			ctx as unknown as CtxArg,
+		);
+		expect(res.status).toBe(200);
+		return env;
+	}
+
+	function expectBuckets(env: unknown, hourly: number, daily: number) {
+		expect(rateLimit).toHaveBeenNthCalledWith(
+			1,
+			env,
+			"voice:p1:1.2.3.4",
+			hourly,
+			60 * 60,
+			{ failClosed: true },
+		);
+		expect(rateLimit).toHaveBeenNthCalledWith(
+			2,
+			env,
+			"voice-daily:p1",
+			daily,
+			24 * 60 * 60,
+			{ failClosed: true },
+		);
+	}
+
+	it("a LISTED project gets the raised — still enforced, still fail-closed — buckets", async () => {
+		const env = await mintWith(" p-other , p1 ");
+		expectBuckets(env, 60, 500);
+	});
+
+	it("an UNLISTED project on an EXEMPT internal workspace keeps the standard caps", async () => {
+		// THE finding-5 guard: internal project keys are published in public
+		// page source (marketing self-dogfood), so relief must never key off
+		// the workspace's internal/exempt status — only off an explicit
+		// project-id listing. 661cd84's workspace-scoped exemption fails here.
+		const env = await mintWith("p-some-other-project", true);
+		expectBuckets(env, 4, 20);
+	});
+
+	it("unset or empty env means zero exemptions anywhere", async () => {
+		const unset = await mintWith(undefined);
+		expectBuckets(unset, 4, 20);
+		vi.clearAllMocks();
+		const empty = await mintWith("");
+		expectBuckets(empty, 4, 20);
+	});
+
+	it("resolveVoiceBudgets (pure): exact-id match, whitespace-tolerant, empty ⇒ standard", () => {
+		expect(resolveVoiceBudgets("p1", undefined)).toEqual({
+			raised: false,
+			hourlyMax: 4,
+			dailyMax: 20,
+		});
+		expect(resolveVoiceBudgets("p1", "")).toEqual({
+			raised: false,
+			hourlyMax: 4,
+			dailyMax: 20,
+		});
+		expect(resolveVoiceBudgets("p1", " p1 , p2 ")).toEqual({
+			raised: true,
+			hourlyMax: 60,
+			dailyMax: 500,
+		});
+		// Exact-id match only — "p1" in the list must not cover "p10".
+		expect(resolveVoiceBudgets("p10", "p1").raised).toBe(false);
+		// A stray comma never becomes an empty-string wildcard.
+		expect(resolveVoiceBudgets("", "p1,,p2").raised).toBe(false);
 	});
 });
 

--- a/apps/api/src/routes/voice.ts
+++ b/apps/api/src/routes/voice.ts
@@ -61,6 +61,43 @@ const CALL_RATE_WINDOW = 60 * 60;
 const CALL_DAILY_MAX = 20;
 const CALL_DAILY_WINDOW = 24 * 60 * 60;
 
+// --- Named-project budget relief (supersedes 661cd84's workspace-scoped
+// exemption) ------------------------------------------------------------------
+//
+// Dogfooding needs more headroom than 4/hr + 20/day, but relief must NEVER key
+// off the workspace's internal status: internal project keys are deliberately
+// published (the marketing site self-dogfoods its embed key in public page
+// source), so any workspace-scoped raise converts dogfood relief into
+// anonymous public minting on the operator key — thousands of dollars/day at
+// the gateway's per-session caps. Relief is therefore granted only to project
+// ids explicitly listed in VOICE_RAISED_LIMIT_PROJECTS (Ploy-set; unset or
+// empty ⇒ zero exemptions anywhere), and listed projects keep ENFORCED,
+// fail-closed buckets — the constants change, the structure doesn't.
+const VOICE_RAISED_HOURLY = 60;
+const VOICE_RAISED_DAILY = 500;
+
+/** Resolve the two voice-bucket ceilings for a project: raised for ids listed
+ * in VOICE_RAISED_LIMIT_PROJECTS (comma-separated, whitespace-tolerant,
+ * exact-id match only), standard for everyone else — including internal
+ * workspaces and the published dogfood keys. Pure. */
+export function resolveVoiceBudgets(
+	projectId: string,
+	raisedList: string | undefined,
+): { raised: boolean; hourlyMax: number; dailyMax: number } {
+	const listed = (raisedList ?? "")
+		.split(",")
+		.map((s) => s.trim())
+		.filter(Boolean)
+		.includes(projectId);
+	return listed
+		? {
+				raised: true,
+				hourlyMax: VOICE_RAISED_HOURLY,
+				dailyMax: VOICE_RAISED_DAILY,
+			}
+		: { raised: false, hourlyMax: CALL_RATE_MAX, dailyMax: CALL_DAILY_MAX };
+}
+
 // --- Voice instruction budget -----------------------------------------------
 //
 // The realtime API hard-caps session instructions (+ tools) at 16,384 tokens;
@@ -203,12 +240,18 @@ export const voice = new Hono<AppContext>().post(
 			return c.json({ error: "voice_not_available" }, 402);
 		}
 
-		// Tight, fail-closed budgets (see constants above): per-(project,IP)
-		// hourly AND a per-project daily aggregate against IP rotation.
+		// Tight, fail-closed budgets (standard, or raised for explicitly listed
+		// project ids — never for a workspace class; see resolveVoiceBudgets):
+		// per-(project,IP) hourly AND a per-project daily aggregate against IP
+		// rotation.
+		const budgets = resolveVoiceBudgets(
+			project.id,
+			c.env.vars.VOICE_RAISED_LIMIT_PROJECTS,
+		);
 		const perIp = await rateLimit(
 			c.env,
 			`voice:${project.id}:${ip}`,
-			CALL_RATE_MAX,
+			budgets.hourlyMax,
 			CALL_RATE_WINDOW,
 			{ failClosed: true },
 		);
@@ -218,7 +261,7 @@ export const voice = new Hono<AppContext>().post(
 		const perProjectDaily = await rateLimit(
 			c.env,
 			`voice-daily:${project.id}`,
-			CALL_DAILY_MAX,
+			budgets.dailyMax,
 			CALL_DAILY_WINDOW,
 			{ failClosed: true },
 		);


### PR DESCRIPTION
## Context — supersedes 661cd84, scope changed

This reshapes `fix/voice-exempt-internal-budgets` (661cd84, co-authored here — thanks @Bidbogs-prog; the dogfooding pain it solved is real). As written it removed **both** fail-closed voice budgets for internal workspaces. The voice audit's finding 5 is why that scope can't ship: **internal project keys are deliberately published** — the marketing site self-dogfoods its embed key in public page source — so any workspace-scoped raise (or removal) converts dogfood relief into anonymous public minting on the operator's gateway key. The math: at the raised constants a workspace-scoped raise hands the published key 500 sessions/day × $10 gateway session cap = **$5k/day**; full removal is unbounded. Relief therefore keys off **explicitly named project ids**, never a workspace class. (661cd84's branch stays — deleting it is Haytham's call.)

## The design

- **`VOICE_RAISED_LIMIT_PROJECTS`** — comma-separated project ids, Ploy-set (Luca). **Unset/empty = zero exemptions anywhere**, so the deploy defaults safe and self-hosters need nothing.
- Listed projects get **raised, still-enforced, still-fail-closed** buckets: `VOICE_RAISED_HOURLY = 60` per (project, IP), `VOICE_RAISED_DAILY = 500` per project. Constants swap; structure, keys, and `failClosed: true` don't.
- **Everything else keeps the standard 4/hr + 20/day — including internal workspaces and the published marketing key.** Internal status grants voice *entitlement* (unchanged), never budget relief.
- Resolution is one exported pure function, `resolveVoiceBudgets` (exact-id match, whitespace-tolerant, a stray comma never becomes an empty-string wildcard).

## Dogfood path

Team voice-testing happens on a **dedicated internal project whose public key is not published anywhere** — not the marketing embed, not the showcase, not docs. Omar creates one (60 seconds in the dashboard) or reuses an existing unpublished internal project, and that project id goes into `VOICE_RAISED_LIMIT_PROJECTS` in the prod Ploy env. If a listed key ever leaks into page source, exposure is still bounded by the raised fail-closed buckets (≤ $5k/day per listed project, vs unbounded under a class exemption) and one env edit revokes it.

## Not in scope

`emailVerified` on the internal exemption in `resolveAccess` (rides with #80) · echo-gate calibration (ticketed) · any change to the standard public-key caps.

## Tests + mutation table

Suite: api 739/739 (21 voice route). Existing entitlement/402 gate and fail-closed 429 tests untouched and green (regression pair).

| Mutant | Expected kill | Result |
|---|---|---|
| N1 · workspace-scoped exemption restored (the 661cd84 shape) | unlisted-project-on-EXEMPT-internal-workspace keeps 4/20 — **the finding-5 guard** | ✅ exactly that test |
| N2 · empty list treated as raise-all | unset/empty ⇒ zero exemptions + pure pins | ✅ exactly those 2 |
| N3 · relief never applies | listed-project raised buckets + pure pins | ✅ exactly those 2 |
| N4 · `failClosed` dropped from the per-IP bucket | all three bucket-assertion tests | ✅ exactly those 3 |

Sequencing: branched from post-#181 main (same file); `fix/voice-fastfollow` rebases on both and lands last.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018pJJgDHCnnNeEqEAApxFcQ
