### PR TITLE
fix(marketing): stop browsers painting year-stale HTML after deploys

### DIFF
--- a/apps/marketing/next.config.ts
+++ b/apps/marketing/next.config.ts
@@ -4,6 +4,21 @@ import { withContentCollections } from "@content-collections/next";
 const config: NextConfig = {
 	reactStrictMode: true,
 	transpilePackages: ["@llmchat/shared"],
+	// Every page renders SiteHeader, whose GitHubStars fetch (revalidate: 600)
+	// makes the whole page ISR. Next then stamps HTML with `s-maxage=600,
+	// stale-while-revalidate=<expireTime - 600>`, and expireTime defaults to a
+	// YEAR. On Ploy (unlike Vercel) that header reaches the visitor's browser,
+	// which is licensed to paint a year-stale cached copy while revalidating in
+	// the background — and Ploy drops the previous deployment's hashed
+	// /_next/static assets, so the stale HTML's CSS href 404s and the first
+	// load after any deploy renders unstyled (refresh = revalidated HTML =
+	// fixed). Pinning expireTime at the revalidate interval makes
+	// `revalidate >= expireTime`, which drops the stale-while-revalidate
+	// directive entirely (see Next's formatRevalidate): browsers ignore
+	// s-maxage, so HTML is always revalidated before paint. Keep this ≤ the
+	// smallest fetch/page revalidate used in the app, or the SWR window comes
+	// back for that page.
+	expireTime: 600,
 	async redirects() {
 		return [
 			// The old marketing /docs page moved to the dedicated docs app.

--- a/apps/marketing/src/lib/next-config.test.ts
+++ b/apps/marketing/src/lib/next-config.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it, vi } from "vitest";
+
+// Stub the content-collections wrapper so importing next.config.ts doesn't
+// boot a content build — we only assert on the plain config object.
+vi.mock("@content-collections/next", () => ({
+	withContentCollections: (config: unknown) => config,
+}));
+
+describe("next.config caching", () => {
+	it("pins expireTime at the ISR revalidate interval so HTML is never served stale", async () => {
+		// The mobile "first load is unstyled" bug: GitHubStars' fetch
+		// (revalidate: 600) makes every page ISR, and Next's default
+		// expireTime (1 year) emits `stale-while-revalidate=31535400` on the
+		// HTML. Browsers then paint a stale copy whose hashed CSS href 404s
+		// after the next deploy. expireTime <= revalidate drops the SWR
+		// directive (formatRevalidate returns just `s-maxage=600, `), so the
+		// HTML is revalidated before paint.
+		const config = (await import("../../next.config")).default;
+		expect(config.expireTime).toBeDefined();
+		expect(config.expireTime).toBeLessThanOrEqual(600);
+	});
+});


### PR DESCRIPTION
- GitHubStars' fetch (revalidate: 600) makes every page ISR, and Next's
  default expireTime (1 year) stamped HTML with
  s-maxage=600, stale-while-revalidate=31535400
- on Ploy that header reaches the browser, which paints a stale cached
  copy whose hashed CSS href 404s after the next deploy — the reported
  unstyled-first-load-on-mobile bug (refresh = revalidated HTML = fixed)
- pin expireTime at the revalidate interval so Next drops the SWR
  directive entirely; browsers ignore s-maxage and revalidate before paint
- contract test asserts expireTime stays <= the smallest revalidate used

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019HUbd5UQmd3Z1PWueMFw8a