### PR TITLE
test: weekly coverage for merges 2026-07-29 – 2026-08-02

### DIFF
--- a/packages/widget/src/components/VoiceCall.test.tsx
+++ b/packages/widget/src/components/VoiceCall.test.tsx
@@ -1,0 +1,104 @@
+import { render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// The whole point of the call-error screen is to name the REAL cause: a plan
+// gate, a call-budget hit, a gateway outage, or an actual microphone problem —
+// and to blame the mic ONLY when the mic actually failed. We drive VoiceCall
+// through each failure and assert the visitor-facing hint, keeping the real
+// VoiceSessionError class so its `instanceof` branch is exercised.
+
+const requestVoiceSession = vi.fn();
+const startMock = vi.fn();
+const stopMock = vi.fn();
+
+vi.mock("../voice-call", async () => {
+	const actual =
+		await vi.importActual<typeof import("../voice-call")>("../voice-call");
+	return {
+		...actual,
+		requestVoiceSession: (...args: unknown[]) => requestVoiceSession(...args),
+		postVoiceTranscript: vi.fn(async () => {}),
+		VoiceCallClient: class {
+			start = startMock;
+			stop = stopMock;
+			setMuted = vi.fn();
+		},
+	};
+});
+
+import { VoiceSessionError } from "../voice-call";
+import { VoiceCall } from "./VoiceCall";
+
+afterEach(() => {
+	vi.clearAllMocks();
+});
+
+function okSession() {
+	return {
+		url: "wss://gw/rt",
+		clientSecret: "ek",
+		model: "gpt-realtime",
+		instructions: "hi",
+		voice: "alloy",
+	};
+}
+
+function mount() {
+	render(
+		<VoiceCall
+			apiUrl="https://api.example"
+			projectKey="pk"
+			clientId="c"
+			onClose={() => {}}
+		/>,
+	);
+}
+
+describe("VoiceCall error hints", () => {
+	it("blames the plan, not the mic, on a 402 mint failure", async () => {
+		requestVoiceSession.mockRejectedValue(new VoiceSessionError(402));
+		mount();
+		expect(
+			await screen.findByText(/aren't available on this plan/i),
+		).toBeTruthy();
+		expect(screen.queryByText(/microphone/i)).toBeNull();
+		expect(startMock).not.toHaveBeenCalled();
+	});
+
+	it("names the call limit on a 429 mint failure", async () => {
+		requestVoiceSession.mockRejectedValue(new VoiceSessionError(429));
+		mount();
+		expect(
+			await screen.findByText(/call limit has been reached/i),
+		).toBeTruthy();
+		expect(screen.queryByText(/microphone/i)).toBeNull();
+	});
+
+	it("names the voice service on a gateway (502) mint failure", async () => {
+		requestVoiceSession.mockRejectedValue(new VoiceSessionError(502));
+		mount();
+		expect(
+			await screen.findByText(/voice service is unavailable/i),
+		).toBeTruthy();
+		expect(screen.queryByText(/microphone/i)).toBeNull();
+	});
+
+	it("blames the mic ONLY when getUserMedia is denied", async () => {
+		requestVoiceSession.mockResolvedValue(okSession());
+		// The session mints fine; the failure is the mic prompt during start().
+		startMock.mockRejectedValue(new DOMException("denied", "NotAllowedError"));
+		mount();
+		expect(
+			await screen.findByText(/couldn't access your microphone/i),
+		).toBeTruthy();
+	});
+
+	it("falls back to a connection hint for an unclassified failure", async () => {
+		requestVoiceSession.mockResolvedValue(okSession());
+		// Socket blew up after a clean mint + mic grant — not a plan/mic fault.
+		startMock.mockRejectedValue(new Error("socket closed"));
+		mount();
+		expect(await screen.findByText(/couldn't connect/i)).toBeTruthy();
+		expect(screen.queryByText(/microphone/i)).toBeNull();
+	});
+});

--- a/packages/widget/src/voice-call.session.test.ts
+++ b/packages/widget/src/voice-call.session.test.ts
@@ -1,0 +1,130 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { requestVoiceSession, VoiceSessionError } from "./voice-call";
+
+// The widget mints an ephemeral voice session via the api before opening its
+// own socket to the gateway. requestVoiceSession is the whole client side of
+// that handshake: it must carry the HTTP status out on failure (so the UI can
+// name a plan gate / budget hit / gateway fault instead of blaming the mic)
+// and reject a malformed OK body rather than handing junk to VoiceCallClient.
+
+function jsonResponse(status: number, body: unknown) {
+	return {
+		ok: status >= 200 && status < 300,
+		status,
+		json: async () => body,
+	} as unknown as Response;
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("requestVoiceSession", () => {
+	it("posts JSON to /v1/voice/session and returns the parsed session", async () => {
+		const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			jsonResponse(200, {
+				url: "wss://gw.example/rt",
+				clientSecret: "ek_secret",
+				model: "gpt-realtime",
+				instructions: "Be helpful.",
+				voice: "alloy",
+			}),
+		);
+
+		const session = await requestVoiceSession("https://api.example", {
+			projectKey: "pk_1",
+			clientId: "c_1",
+		});
+
+		expect(session).toEqual({
+			url: "wss://gw.example/rt",
+			clientSecret: "ek_secret",
+			model: "gpt-realtime",
+			instructions: "Be helpful.",
+			voice: "alloy",
+		});
+
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		const [calledUrl, init] = fetchMock.mock.calls[0];
+		expect(calledUrl).toBe("https://api.example/v1/voice/session");
+		const requestInit = init as RequestInit;
+		expect(requestInit.method).toBe("POST");
+		expect(
+			(requestInit.headers as Record<string, string>)["content-type"],
+		).toBe("application/json");
+		expect(JSON.parse(requestInit.body as string)).toEqual({
+			projectKey: "pk_1",
+			clientId: "c_1",
+		});
+	});
+
+	it("defaults the optional fields to empty strings when the body omits them", async () => {
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			jsonResponse(200, { url: "wss://gw/rt", clientSecret: "ek" }),
+		);
+
+		const session = await requestVoiceSession("https://api.example", {
+			projectKey: "pk",
+			clientId: "c",
+		});
+
+		expect(session.url).toBe("wss://gw/rt");
+		expect(session.clientSecret).toBe("ek");
+		// A gateway that returns these as null/absent must not surface `undefined`
+		// or a stringified null into the session.update payload.
+		expect(session.model).toBe("");
+		expect(session.instructions).toBe("");
+		expect(session.voice).toBe("");
+	});
+
+	it.each([402, 429, 502])(
+		"throws a VoiceSessionError carrying status %i on a non-OK response",
+		async (status) => {
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				jsonResponse(status, { error: "nope" }),
+			);
+
+			const err = await requestVoiceSession("https://api.example", {
+				projectKey: "pk",
+				clientId: "c",
+			}).catch((e) => e);
+
+			// The status is the load-bearing detail: the error screen reads it to
+			// distinguish a 402 plan gate / 429 budget hit from a mic fault. If the
+			// type or status is lost, a paywalled call reads as "check your mic".
+			expect(err).toBeInstanceOf(VoiceSessionError);
+			expect((err as VoiceSessionError).status).toBe(status);
+		},
+	);
+
+	it("rejects a malformed OK body with a plain (non-session) error", async () => {
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			// 200 but no clientSecret — handing this to VoiceCallClient would open a
+			// socket with an undefined subprotocol secret.
+			jsonResponse(200, { url: "wss://gw/rt" }),
+		);
+
+		const err = await requestVoiceSession("https://api.example", {
+			projectKey: "pk",
+			clientId: "c",
+		}).catch((e) => e);
+
+		expect(err).toBeInstanceOf(Error);
+		expect(err).not.toBeInstanceOf(VoiceSessionError);
+		expect((err as Error).message).toMatch(/malformed/i);
+	});
+
+	it("rejects when url is present but not a string", async () => {
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			jsonResponse(200, { url: 123, clientSecret: "ek" }),
+		);
+
+		await expect(
+			requestVoiceSession("https://api.example", {
+				projectKey: "pk",
+				clientId: "c",
+			}),
+		).rejects.toThrow(/malformed/i);
+	});
+});


### PR DESCRIPTION
## Summary

Automated weekly coverage pass. No PRs merged to `main` in the strict last-7-days window (latest merge is #185 on 2026-08-02, 8 days ago), and no previous `automation/weekly-tests-*` PR has ever run — so this pass reviews the most recent cluster of merges (2026-07-29 → 2026-08-02), dominated by the **Scale-only live voice-call** feature (#177) and its hardening fast-follows (#178–#185).

That cluster landed remarkably well-tested already: `apps/api/src/routes/voice.test.ts` (~800 lines), `packages/widget/src/voice-call.test.ts` (codec, resampling, echo-gate, transcript recorder, setup-ack/greet-ordering hardening), plus updates to `traffic-report.test.ts`, `billing-tiers.test.ts`, `widget-config.test.ts`, and `models.test.ts`. Most fixes shipped their own tests in the same PR.

The one clear gap: the **widget's voice-session mint path and its error screen**. PR #37e5fb4 ("name the real failure cause in the call-error hint") changed production code — `requestVoiceSession` now throws a typed `VoiceSessionError` carrying the HTTP status, and `VoiceCall` maps that status to a cause-specific hint — **without a test**. This is the load-bearing logic behind the paid voice feature's promise that a plan/budget/gateway failure never reads as "check your microphone." Both gaps are closed here with transport-only mocking (no network, no real timers, no new deps).

## Tests added

| Test file | Behavior covered | Regression it prevents |
| --- | --- | --- |
| `packages/widget/src/voice-call.session.test.ts` | `requestVoiceSession` posts JSON to `/v1/voice/session` and parses the session; non-OK (402/429/502) throws `VoiceSessionError` with the status preserved; malformed OK body (missing/non-string `url`/`clientSecret`) throws a plain error; optional fields default to `""` | Mint call silently losing the HTTP status (so a paywalled/over-budget call is misclassified) or handing a malformed body to `VoiceCallClient` (opening a socket with an undefined secret) |
| `packages/widget/src/components/VoiceCall.test.tsx` | Error screen renders the cause-specific hint: 402 → "not available on this plan", 429 → "call limit reached", 502 → "voice service unavailable", `getUserMedia` `NotAllowedError` → mic hint, generic failure → connection hint | The mic being blamed for a server/plan/connection fault (the exact bug #37e5fb4 fixed) regressing back |

## Intentionally skipped

- **`apps/api` voice route (`voice.ts`)** — per-workspace/per-project budget buckets, mint-instruction sizing, gateway-base fallback, client_secrets schema: already covered by the ~800-line `voice.test.ts`; each fix (#177, #181, #183, #184) added its own cases.
- **`voice-call.ts` client** (codec, resample, RMS echo-gate, `TranscriptRecorder`, setup-ack/greet-after-`session.updated` ordering) — thoroughly covered by the existing `voice-call.test.ts`.
- **`traffic-report.ts` realtime-spend line, `billing-tiers.ts` voice entitlement, `models.ts` proxy, `conversation-summary.ts`** — tests added in their own PRs.
- **`lib/llm.ts` `DEFAULT_GATEWAY_BASE` hoist (#4db775b)** — behavior-preserving refactor already exercised via `models`/`voice` suites.
- **Copy/theme changes** (dashboard Warm Press theme, favicons, voice positioning strings, widget launcher offset) — cosmetic, out of scope.

## Validation

- `pnpm --filter @llmchat/widget test` → **37 files, 303 tests pass** (was 291; +12 new: 7 in `voice-call.session.test.ts`, 5 in `VoiceCall.test.tsx`).
- `pnpm lint` → exit 0 (no new errors/warnings from the added files).
- `pnpm format` → applied (repo uses tabs).

No production code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fzd26LkdsD32cMxZg6dbGE)_