### PR TITLE
test: weekly coverage for merges 2026-08-10 – 2026-08-17

### DIFF
--- a/apps/api/src/routes/account.delete.e2e.test.ts
+++ b/apps/api/src/routes/account.delete.e2e.test.ts
@@ -222,6 +222,77 @@ describe("DELETE /account — positive end-to-end (credential user, populated wo
 	});
 });
 
+describe("DELETE /account — assignment attribution scrub in a SURVIVING workspace (#96)", () => {
+	it("removes the deleted user as ASSIGNEE (row gone) but only NULLs assigned_by where they were the ASSIGNER (row kept)", async () => {
+		const sqlite = new DatabaseSync(":memory:");
+		applyMigrations(sqlite);
+
+		const hash = await hashPassword("correct horse");
+		// u1 is being deleted; u2 owns the surviving workspace ws2.
+		sqlite.exec(
+			`INSERT INTO user (id,name,email) VALUES ('u1','U1','u1@x.io'),('u2','U2','u2@x.io')`,
+		);
+		sqlite.exec(
+			`INSERT INTO account (id,user_id,account_id,provider_id,password) VALUES ('acc1','u1','u1','credential','${hash}')`,
+		);
+		// ws1: solely owned by u1 → deleted wholesale (its own assignments would be
+		// swept by the workspace cascade, so it can't exercise the user scrub).
+		seedWorkspace(sqlite, "ws1", "u1", "a");
+		// ws2: owned by u2 → SURVIVES. u1 is a non-owner member here, so the user
+		// scrub — not the workspace cascade — is the only thing touching ws2's
+		// assignment rows. This is the branch the positive test can't reach.
+		seedWorkspace(sqlite, "ws2", "u2", "b");
+		sqlite.exec(
+			`INSERT INTO member (id,workspace_id,user_id,role) VALUES ('mb_u1_ws2','ws2','u1','agent')`,
+		);
+		// seedWorkspace put conversation 'bc' in project 'bp'; add a second one.
+		sqlite.exec(
+			`INSERT INTO conversation (id,project_id,client_id) VALUES ('bc2','bp','cl2')`,
+		);
+		// A: bc assigned BY u1 (the deleted user) TO u2 (survives). assigned_by must
+		// be scrubbed to NULL, but the row — and u2's assignment — must remain (S6:
+		// only the who-assigned attribution is removed, never a live assignment).
+		sqlite.exec(
+			`INSERT INTO conversation_assignment (conversation_id,workspace_id,assignee_user_id,assigned_by) VALUES ('bc','ws2','u2','u1')`,
+		);
+		// B: bc2 assigned BY u2 TO u1 (the deleted user is the ASSIGNEE). The whole
+		// row must go — assignee_user_id references user.id with no ON DELETE, so a
+		// surviving row would dangle against a deleted user.
+		sqlite.exec(
+			`INSERT INTO conversation_assignment (conversation_id,workspace_id,assignee_user_id,assigned_by) VALUES ('bc2','ws2','u1','u2')`,
+		);
+
+		vi.mocked(db).mockReturnValue(makeProxy(sqlite) as never);
+
+		const res = await del({
+			confirmEmail: "u1@x.io",
+			password: "correct horse",
+		});
+		expect(res.status).toBe(200);
+
+		// ws2 (and u2) survive — u1 was only a member.
+		expect(n(sqlite, "id='ws2'", "workspace")).toBe(1);
+		expect(n(sqlite, "id='u2'", "user")).toBe(1);
+		// A survives with u2 still assigned; the who-assigned attribution is NULL.
+		const a = sqlite
+			.prepare(
+				`SELECT assignee_user_id AS assignee, assigned_by AS by FROM conversation_assignment WHERE conversation_id='bc'`,
+			)
+			.get() as { assignee: string; by: string | null };
+		expect(a).toEqual({ assignee: "u2", by: null });
+		// B is gone — the deleted user is no longer an assignee anywhere.
+		expect(n(sqlite, "assignee_user_id='u1'", "conversation_assignment")).toBe(
+			0,
+		);
+		expect(n(sqlite, "conversation_id='bc2'", "conversation_assignment")).toBe(
+			0,
+		);
+		// u1 and their ws2 membership are gone.
+		expect(n(sqlite, "id='u1'", "user")).toBe(0);
+		expect(n(sqlite, "workspace_id='ws2' AND user_id='u1'", "member")).toBe(0);
+	});
+});
+
 describe("DELETE /account — abort atomicity (2 owned workspaces, one with an active sub)", () => {
 	it("returns 409 and deletes NOTHING — both workspaces and the user survive intact", async () => {
 		const sqlite = new DatabaseSync(":memory:");

--- a/apps/dashboard/src/app/inbox/_components/format.test.ts
+++ b/apps/dashboard/src/app/inbox/_components/format.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+	firstName,
 	formatFullDate,
 	initials,
 	parseDevice,
@@ -99,5 +100,22 @@ describe("initials", () => {
 	it("falls back to '?' with no name", () => {
 		expect(initials(null)).toBe("?");
 		expect(initials("   ")).toBe("?");
+	});
+});
+
+describe("firstName", () => {
+	it("returns the first whitespace token", () => {
+		expect(firstName("Ada Lovelace")).toBe("Ada");
+		expect(firstName("madonna")).toBe("madonna");
+		expect(firstName("  jean   claude  van damme ")).toBe("jean");
+	});
+
+	// The #96 assignee chip renders firstName for a deleted-account assignee
+	// (user row gone ⇒ name null). A blank chip or a crash here is the visible
+	// regression; the neutral fallback keeps the chip legible.
+	it("falls back to 'Teammate' when the name is missing or blank", () => {
+		expect(firstName(null)).toBe("Teammate");
+		expect(firstName(undefined)).toBe("Teammate");
+		expect(firstName("   ")).toBe("Teammate");
 	});
 });


### PR DESCRIPTION
## Summary

Automated weekly test-coverage pass over merges landing on `main` in the last 7 days (2026-08-10 → 2026-08-17). The week's merges were reviewed against business risk, not file count:

- **#216 / #219 / #215 — conversation assignment (#96):** the big new surface. It shipped with strong coverage already — `conversations.assignment.e2e.test.ts` (492 lines) pins the assignee PUT (upsert, unassign idempotency, `not_a_member` 400, cross-tenant 404s), the first-reply claim, the assignee list/stats filters, member-removal unassign, and conversation-DELETE cleanup. Two smaller additions from the same feature slipped through without a test — closed here.
- **#221 — session-signout-hardening:** high blast radius (Better Auth / `requireSession` / rate-limit scoping / `/admin/*`), but it shipped its own comprehensive suite — `session.refresh.e2e.test.ts` already pins the cookie re-stamp chain, the `no-store` on `/api/auth/*`, admin-middleware cookie forwarding, and the transient-vs-definitive gate (`isTransientSessionError` across dashboard-shell/root/onboarding). No gap.
- **#225 (dashboard skeleton on root route), #222 / meetploy / ploy-env / better-auth bumps, #223 (widget `dir=auto`), #224 (blog content):** dep bumps, config, cosmetic, or marketing content — out of scope, or already covered by tests that shipped with the change.

The two genuine gaps both come from the **#96 assignment** feature adding code to files whose PR didn't extend their tests.

## Tests added

| Test file | Behavior covered | Regression it prevents |
| --- | --- | --- |
| `apps/api/src/routes/account.delete.e2e.test.ts` | Account deletion scrubs assignment attribution in a **surviving** workspace: the deleted user is removed as **assignee** (row deleted), but where they were the **assigner** only `assigned_by` is NULLed (row + the live assignment kept). Drives the real route + real `workspace-deletion` service against real migrations. | A deleted user dangling as `assignee_user_id` against a now-missing `user` row (the column has no `ON DELETE`), or the attribution scrub being coarsened into a delete that would drop a still-live assignment to a surviving teammate. The existing positive test only deletes a solely-owned workspace, so the user-global scrub's keep-vs-delete branch was never exercised. |
| `apps/dashboard/src/app/inbox/_components/format.test.ts` | `firstName` — first whitespace token, and the neutral `"Teammate"` fallback for a deleted-account assignee (name `null`/`undefined`/blank). | The #96 assignee chip rendering a blank label or throwing when the assignee's account was deleted (name null). |

## Intentionally skipped

- `conversations.ts` assignment PUT/list/stats — already covered end-to-end by `conversations.assignment.e2e.test.ts` (incl. cross-tenant 404s and stats isolation).
- `members.ts` removal + assignment cleanup — covered by `invites.e2e.test.ts` (last-owner/last-workspace/self-vs-other/invite-revoke) and `conversations.assignment.e2e.test.ts` (member-removal unassign).
- `workspace-deletion.ts` workspace-cascade assignment delete — covered by `workspaces.delete.e2e.test.ts`.
- `817f9d3` (`no-store` on `/api/auth/*`) and `1ffcc59` (`/admin/*` cookie forward) — fully covered by the `session.refresh.e2e.test.ts` shipped in #221.
- Dashboard auth-gate fixes (`isTransientSessionError`, onboarding-redirect hold) — both branches (401 redirect vs 429/5xx hold) already covered by `dashboard-shell.test.tsx` / `page.test.tsx` / `onboarding/page.test.tsx` / `use-onboarding-redirect.test.tsx`.
- `status.ts` `ASSIGNEE_FILTERS` — a static config array; no logic to regress.
- Widget `dir=auto` (#223), dashboard skeleton (#225), dep/config bumps, blog content — cosmetic / config / content, per scope.

## Validation

- `pnpm --filter @llmchat/api test` → **72 files, 893 tests passed** (incl. the new `account.delete.e2e.test.ts`, now 3 tests).
- `pnpm --filter @llmchat/dashboard test` → **80 files, 553 tests passed** (incl. `format.test.ts`, now 15 tests).
- `pnpm exec prettier --check` on both files → clean (tabs).
- `pnpm exec oxlint` on both files → exit 0 (the one `no-array-sort` warning is pre-existing in the untouched `applyMigrations` helper, not in this diff).

No production behavior was changed — tests only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LBQCZPNFKX9mAfL7BWN5P9)_